### PR TITLE
fix: pass ActionCodeSettings to generatePasswordResetLink

### DIFF
--- a/scripts/invite-user.js
+++ b/scripts/invite-user.js
@@ -60,7 +60,13 @@ try {
   });
   console.log(`Created user: ${userRecord.uid} (${userRecord.email})`);
 
-  const resetLink = await auth.generatePasswordResetLink(email);
+  const actionCodeSettings = {
+    url: process.env.APP_URL || "https://olympus-dfa00.web.app",
+  };
+  const resetLink = await auth.generatePasswordResetLink(
+    email,
+    actionCodeSettings,
+  );
   console.log("Invitation link generated successfully.");
 
   if (process.env.GITHUB_OUTPUT) {


### PR DESCRIPTION
## Summary
- Fixes `auth/configuration-not-found` error when generating password reset links
- Passes `ActionCodeSettings` with the app's redirect URL (`https://olympus-dfa00.web.app`) to `generatePasswordResetLink`
- URL is overridable via `APP_URL` env var for flexibility

## Test plan
- [ ] Run the **Invite User to Firebase** workflow with a test email
- [ ] Verify the workflow completes without `auth/configuration-not-found` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)