### PR TITLE
feat: add Firebase Authentication login with Greek gods theme

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -685,12 +685,12 @@
     <script>
       // Generate twinkling stars
       (function () {
-        var container = document.getElementById('stars');
-        var count = 80;
-        for (var i = 0; i < count; i++) {
-          var star = document.createElement('div');
+        const container = document.getElementById('stars');
+        const count = 80;
+        for (let i = 0; i < count; i++) {
+          const star = document.createElement('div');
           star.classList.add('star');
-          var size = Math.random() * 2.5 + 0.5;
+          const size = Math.random() * 2.5 + 0.5;
           star.style.width = size + 'px';
           star.style.height = size + 'px';
           star.style.top = Math.random() * 100 + '%';
@@ -701,22 +701,39 @@
         }
       })();
 
-      document.addEventListener('DOMContentLoaded', function () {
-        var loadingScreen = document.getElementById('loading-screen');
-        var landing = document.getElementById('landing');
-        var loginModal = document.getElementById('login-modal');
-        var authView = document.getElementById('auth-view');
-        var loginForm = document.getElementById('login-form');
-        var emailInput = document.getElementById('email');
-        var passwordInput = document.getElementById('password');
-        var submitBtn = document.getElementById('submit-btn');
-        var submitText = document.getElementById('submit-text');
-        var errorMessage = document.getElementById('error-message');
-        var authEmail = document.getElementById('auth-email');
+      document.addEventListener('DOMContentLoaded', () => {
+        const loadingScreen = document.getElementById('loading-screen');
+        const landing = document.getElementById('landing');
+        const loginModal = document.getElementById('login-modal');
+        const authView = document.getElementById('auth-view');
+        const loginForm = document.getElementById('login-form');
+        const emailInput = document.getElementById('email');
+        const passwordInput = document.getElementById('password');
+        const submitBtn = document.getElementById('submit-btn');
+        const submitText = document.getElementById('submit-text');
+        const errorMessage = document.getElementById('error-message');
+        const authEmail = document.getElementById('auth-email');
+
+        // Map Firebase error codes to themed messages
+        const ERROR_MESSAGES = {
+          'auth/wrong-password': 'The gates remain sealed. Your credentials displease the gods.',
+          'auth/invalid-credential':
+            'The gates remain sealed. Your credentials displease the gods.',
+          'auth/user-not-found': 'The Fates have not woven your thread into Olympus.',
+          'auth/invalid-email': 'The oracle cannot decipher this inscription.',
+          'auth/user-disabled': 'Your passage has been revoked by decree of the gods.',
+          'auth/too-many-requests':
+            'You have angered the gods with too many attempts. Wait before trying again.',
+          'auth/network-request-failed':
+            'The winds of Hermes cannot carry your message. Check your connection.',
+        };
+
+        const getErrorMessage = (code) =>
+          ERROR_MESSAGES[code] || 'An unknown force blocks your path. Try again.';
 
         try {
-          var app = firebase.app();
-          var features = [
+          const app = firebase.app();
+          const features = [
             'auth',
             'database',
             'firestore',
@@ -726,63 +743,51 @@
             'analytics',
             'remoteConfig',
             'performance',
-          ].filter(function (feature) {
-            return typeof app[feature] === 'function';
-          });
-          console.log('Firebase SDK loaded with ' + features.join(', '));
+          ].filter((feature) => typeof app[feature] === 'function');
+          console.log(`Firebase SDK loaded with ${features.join(', ')}`);
         } catch (e) {
           console.error(e);
-        }
-
-        // Map Firebase error codes to themed messages
-        function getErrorMessage(code) {
-          var messages = {
-            'auth/wrong-password': 'The gates remain sealed. Your credentials displease the gods.',
-            'auth/invalid-credential':
-              'The gates remain sealed. Your credentials displease the gods.',
-            'auth/user-not-found': 'The Fates have not woven your thread into Olympus.',
-            'auth/invalid-email': 'The oracle cannot decipher this inscription.',
-            'auth/user-disabled': 'Your passage has been revoked by decree of the gods.',
-            'auth/too-many-requests':
-              'You have angered the gods with too many attempts. Wait before trying again.',
-            'auth/network-request-failed':
-              'The winds of Hermes cannot carry your message. Check your connection.',
-          };
-          return messages[code] || 'An unknown force blocks your path. Try again.';
+          loadingScreen.classList.add('hidden');
+          landing.classList.remove('hidden');
+          return;
         }
 
         // Show / hide helpers
-        function showLanding() {
+        const showLanding = () => {
           landing.classList.remove('hidden');
           authView.classList.add('hidden');
-        }
+        };
 
-        function showAuthView(user) {
+        const showAuthView = (user) => {
           landing.classList.add('hidden');
           authView.classList.remove('hidden');
           authEmail.textContent = user.email;
-        }
+        };
 
-        function openModal() {
+        const resetSubmitButton = () => {
+          submitBtn.disabled = false;
+          submitText.textContent = 'Enter';
+          const spinner = submitBtn.querySelector('.spinner');
+          if (spinner) {
+            spinner.remove();
+          }
+        };
+
+        const openModal = () => {
           loginForm.reset();
           errorMessage.classList.add('hidden');
           errorMessage.textContent = '';
           resetSubmitButton();
           loginModal.classList.add('active');
           emailInput.focus();
-        }
+        };
 
-        function closeModal() {
+        const closeModal = () => {
           loginModal.classList.remove('active');
-        }
-
-        function resetSubmitButton() {
-          submitBtn.disabled = false;
-          submitText.textContent = 'Enter';
-        }
+        };
 
         // Auth state observer
-        firebase.auth().onAuthStateChanged(function (user) {
+        firebase.auth().onAuthStateChanged((user) => {
           loadingScreen.classList.add('hidden');
           if (user) {
             closeModal();
@@ -799,24 +804,25 @@
         document.getElementById('close-login').addEventListener('click', closeModal);
 
         // Close modal on overlay click
-        loginModal.addEventListener('click', function (e) {
+        loginModal.addEventListener('click', (e) => {
           if (e.target === loginModal) {
             closeModal();
           }
         });
 
         // Close modal on Escape key
-        document.addEventListener('keydown', function (e) {
+        document.addEventListener('keydown', (e) => {
           if (e.key === 'Escape' && loginModal.classList.contains('active')) {
             closeModal();
           }
         });
 
         // Login form submission
-        loginForm.addEventListener('submit', function (e) {
+        loginForm.addEventListener('submit', (e) => {
           e.preventDefault();
-          var email = emailInput.value.trim();
-          var password = passwordInput.value;
+          const email = emailInput.value.trim();
+          // Password is not trimmed — leading/trailing spaces may be intentional
+          const password = passwordInput.value;
 
           if (!email || !password) {
             errorMessage.textContent = 'The gods require both name and secret word.';
@@ -829,10 +835,14 @@
           submitText.textContent = 'The gates are opening\u2026';
           errorMessage.classList.add('hidden');
 
+          const spinner = document.createElement('span');
+          spinner.className = 'spinner spinner--small';
+          submitBtn.appendChild(spinner);
+
           firebase
             .auth()
             .signInWithEmailAndPassword(email, password)
-            .catch(function (error) {
+            .catch((error) => {
               errorMessage.textContent = getErrorMessage(error.code);
               errorMessage.classList.remove('hidden');
               resetSubmitButton();
@@ -840,8 +850,13 @@
         });
 
         // Sign out
-        document.getElementById('signout-btn').addEventListener('click', function () {
-          firebase.auth().signOut();
+        document.getElementById('signout-btn').addEventListener('click', () => {
+          firebase
+            .auth()
+            .signOut()
+            .catch((error) => {
+              console.error('Sign-out failed:', error);
+            });
         });
       });
     </script>


### PR DESCRIPTION
## Summary
- Add "Enter Olympus" login button on the landing page with an email/password sign-in modal themed as "The Gates of Olympus"
- Implement Firebase Auth `signInWithEmailAndPassword` flow with `onAuthStateChanged` state management — no public sign-up (invite-only)
- Add authenticated welcome view with "Leave Olympus" sign-out that clears auth state and returns to the landing page
- Add loading spinner on initial page load and during login submission, with Greek mythology-themed error messages for all auth failure codes

## Test plan
- [x] Verify "Enter Olympus" button appears on the landing page
- [x] Click button and confirm login modal opens with themed title/subtitle
- [x] Submit invalid credentials and verify themed error message appears
- [x] Submit valid invited-user credentials and verify authenticated view shows
- [x] Click "Leave Olympus" and verify return to landing page
- [x] Refresh page while logged in and verify session persists
- [x] Test responsive layout at mobile viewport (< 600px)
- [x] Confirm no sign-up option is exposed anywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)