### PR TITLE
ci: add workflow to seed symposium categories

### DIFF
--- a/.github/workflows/seed-categories.yml
+++ b/.github/workflows/seed-categories.yml
@@ -1,0 +1,23 @@
+name: Seed Symposium Categories
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  seed:
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install script dependencies
+        run: npm ci --prefix scripts
+      - name: Seed categories
+        env:
+          FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_OLYMPUS_DFA00 }}
+        run: node scripts/seed-categories.js


### PR DESCRIPTION
## Summary
- Adds a manually-triggered (`workflow_dispatch`) GitHub Action that runs the existing `seed-categories.js` script
- Uses the production service account secret (`FIREBASE_SERVICE_ACCOUNT_OLYMPUS_DFA00`) already available in the repo
- No rules changes needed — the admin SDK bypasses Firestore security rules

## Why
The `symposium_categories` collection is empty in production, which blocks adding any ingredients (the `validIngredient()` rule requires `exists()` on the category document). This workflow lets you seed the 8 categories from the Actions tab without needing local credentials.

## Usage
After merging, go to **Actions → "Seed Symposium Categories" → Run workflow → Run workflow**.

## Test plan
- [x] Merge PR
- [ ] Trigger the workflow from the Actions tab
- [ ] Verify categories appear in the Symposium ingredient form dropdown

https://claude.ai/code/session_01UA3r3TrCZKGDXMfnFPazjW