### PR TITLE
feat: add search, category browse grid, sort, and stock filter for ingredients (#25)

### DIFF
--- a/public/apps/symposium/index.html
+++ b/public/apps/symposium/index.html
@@ -1278,16 +1278,27 @@
           if (result.length === 0) {
             emptyEl.classList.remove('hidden');
             countEl.classList.add('hidden');
-            if (searchQuery) {
-              emptyEl.querySelector('.empty-state-text').textContent =
-                'The Oracle finds nothing by that name.';
+            var emptyMsg;
+            if (searchQuery && activeFilter !== 'all') {
+              emptyMsg = 'The Oracle finds nothing matching that name in this category.';
+            } else if (searchQuery) {
+              emptyMsg = 'The Oracle finds nothing by that name.';
+            } else if (stockFilter === 'in-stock') {
+              emptyMsg =
+                activeFilter !== 'all'
+                  ? 'No in-stock ingredients in this category.'
+                  : 'No in-stock ingredients found.';
+            } else if (stockFilter === 'out-of-stock') {
+              emptyMsg =
+                activeFilter !== 'all'
+                  ? 'No out-of-stock ingredients in this category.'
+                  : 'No out-of-stock ingredients found.';
             } else if (activeFilter !== 'all' && allIngredients.length > 0) {
-              emptyEl.querySelector('.empty-state-text').textContent =
-                'No ingredients in this category yet.';
+              emptyMsg = 'No ingredients in this category yet.';
             } else {
-              emptyEl.querySelector('.empty-state-text').textContent =
-                'The Cellar awaits its first offering.';
+              emptyMsg = 'The Cellar awaits its first offering.';
             }
+            emptyEl.querySelector('.empty-state-text').textContent = emptyMsg;
             return;
           }
 


### PR DESCRIPTION
Implements Story 1.4 — Search & Browse Ingredients ("Consult the Oracle"):

- Oracle search bar: client-side filtering by name, category, and tags
  (case-insensitive partial match); shows ✕ clear button when active
- Category browse grid: replaces horizontal filter chips with a responsive
  grid of cards showing ingredient count per category; cards update live
  as ingredients change
- Sort options: Category (default, Firestore order), Alphabetical (A–Z),
  Stock Status (in-stock first then A–Z)
- Stock filter toggle: 3-way segmented control — All / In Stock / Out of Stock
- Empty state message: "The Oracle finds nothing by that name." when search
  returns no results
- All three controls compose: search + sort + stock filter apply together
- Responsive: controls stack vertically on narrow screens

https://claude.ai/code/session_01RBgYrxh9RsZ67zMrXQTUoA