### PR TITLE
fix: add --force to setpolicy to skip interactive confirmation

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -62,6 +62,6 @@ jobs:
       - name: Install functions dependencies
         run: npm ci --prefix functions
       - name: Set up Artifact Registry cleanup policy
-        run: firebase functions:artifacts:setpolicy --project olympus-dfa00
+        run: firebase functions:artifacts:setpolicy --force --project olympus-dfa00
       - name: Deploy Cloud Functions
         run: firebase deploy --only functions --project olympus-dfa00


### PR DESCRIPTION
## Summary
- The `firebase functions:artifacts:setpolicy` command prompts for confirmation in non-interactive CI environments, causing the step to fail
- Added `--force` flag to skip the interactive prompt
- This is safe — `setpolicy` only configures an Artifact Registry cleanup policy, it has no destructive side effects (unlike `firebase deploy --force`)

## Test plan
- [ ] Verify the "Set up Artifact Registry cleanup policy" step passes in CI
- [ ] Verify the "Deploy Cloud Functions" step still runs after it

https://claude.ai/code/session_01DwdR6M4ujfnch4EELoqMQ5