### PR TITLE
fix: move setpolicy after functions deploy so AR repo exists

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -61,7 +61,7 @@ jobs:
             --project olympus-dfa00
       - name: Install functions dependencies
         run: npm ci --prefix functions
-      - name: Set up Artifact Registry cleanup policy
-        run: firebase functions:artifacts:setpolicy --force --project olympus-dfa00
       - name: Deploy Cloud Functions
         run: firebase deploy --only functions --project olympus-dfa00
+      - name: Set up Artifact Registry cleanup policy
+        run: firebase functions:artifacts:setpolicy --force --project olympus-dfa00


### PR DESCRIPTION
## Summary
- `firebase functions:artifacts:setpolicy` was failing with "Failed to set up artifact registry cleanup policy"
- Root cause: the Artifact Registry repository is created during the first `firebase deploy --only functions` run — running `setpolicy` *before* deploy fails because the repo doesn't exist yet
- Fix: moved the `setpolicy` step to after the deploy step

## Test plan
- [ ] "Deploy Cloud Functions" step succeeds and creates the AR repo
- [ ] "Set up Artifact Registry cleanup policy" step succeeds after the repo exists

https://claude.ai/code/session_01DwdR6M4ujfnch4EELoqMQ5