### PR TITLE
fix: use --force on functions deploy to handle cleanup policy automatically

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -62,6 +62,4 @@ jobs:
       - name: Install functions dependencies
         run: npm ci --prefix functions
       - name: Deploy Cloud Functions
-        run: firebase deploy --only functions --project olympus-dfa00
-      - name: Set up Artifact Registry cleanup policy
-        run: firebase functions:artifacts:setpolicy --force --project olympus-dfa00
+        run: firebase deploy --only functions --force --project olympus-dfa00


### PR DESCRIPTION
## Summary
- The deploy was failing with: *"Functions successfully deployed but could not set up cleanup policy... Pass the --force option to automatically set up a cleanup policy"*
- The Firebase CLI exits with code 1 when no AR cleanup policy exists, even though functions deploy succeeded
- `--force` on the deploy command tells Firebase to set up the cleanup policy automatically, so no separate `setpolicy` step is needed

## Test plan
- [ ] `deploy_functions` job passes on merge to main

https://claude.ai/code/session_01DwdR6M4ujfnch4EELoqMQ5