### PR TITLE
fix(void-odyssey): fix crew manifest generation by correcting model ID

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -365,7 +365,7 @@ exports.inviteUser = onCall(async (request) => {
 // ── Void Odyssey ──────────────────────────────────────────────────────────────
 
 const ANTHROPIC_API_URL = 'https://api.anthropic.com/v1/messages';
-const VOID_ODYSSEY_MODEL = 'claude-sonnet-4-20250514';
+const VOID_ODYSSEY_MODEL = 'claude-sonnet-4-6';
 
 const SHIP_CLASS_DEFAULTS = {
   light_freighter: {


### PR DESCRIPTION
## Summary
- The `voidOdysseyNewGame` Cloud Function was using the invalid model ID `claude-sonnet-4-20250514`, causing Anthropic API calls to fail during game creation
- Updated `VOID_ODYSSEY_MODEL` to the valid `claude-sonnet-4-6` model ID
- This fixes the crew manifest generation step (Step 4) in the new game wizard

## Test plan
- [ ] Start a new Void Odyssey game and complete Steps 1–3
- [ ] Confirm Step 4 successfully generates and displays the crew manifest
- [ ] Confirm the "Reroll" button re-generates the crew without errors
- [ ] Confirm Step 5 displays the opening narrative and available actions

https://claude.ai/code/session_01GMZcW6AsXtBkk5YbrNKnw3