### PR TITLE
fix: show 500 starting credits in HUD on new game creation

### DIFF
--- a/public/apps/void-odyssey/app.js
+++ b/public/apps/void-odyssey/app.js
@@ -224,7 +224,11 @@
       // Populate HUD — build a game-shaped object for renderHud
       VO.renderHud({
         ship: Object.assign(
-          { name: game.ship.name, class: game.ship.class, credits: 500 },
+          {
+            name: game.ship.name,
+            class: game.ship.class,
+            credits: game.ship && typeof game.ship.credits === 'number' ? game.ship.credits : 500,
+          },
           VO.SHIP_CLASSES.find(function (s) {
             return s.id === game.ship.class;
           }).stats


### PR DESCRIPTION
## Summary

- Fix HUD showing 0 credits after creating a new game. The 500 starting credits were correctly saved to Firestore but the client-side ship object built for `renderHud()` in the game-create → game-active transition didn't include `credits`. Added `credits: 500` to the `Object.assign` call in `app.js`.

## Test plan

- [ ] Create a new game and verify the HUD displays 500 credits immediately after the opening scene
- [ ] Take a turn and confirm credits persist correctly from Firestore
- [ ] Load an existing game and verify credits display normally

https://claude.ai/code/session_01Dz65NUYGUiQ35sdojmREW5