### PR TITLE
fix: include credits and ship stats in new game response

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -2047,6 +2047,6 @@ Generate the opening scene, starting crew, location, quest hook, and first avail
     })),
     startingLocation: claudeResponse.startingLocationName || 'Unknown Location',
     mood: claudeResponse.mood || 'calm',
-    ship: { name: shipName.trim(), class: shipClass },
+    ship: { name: shipName.trim(), class: shipClass, credits: 500, ...shipStats },
   };
 });


### PR DESCRIPTION
## Summary
- The `voidOdysseyNewGame` cloud function was returning only `{ name, class }` for the ship object, missing `credits` and all stats (`hull`, `shields`, `fuel`, etc.)
- This caused the HUD to show defaults/zeros on initial game creation; credits and stats only appeared after a page reload when the full Firestore doc was fetched
- Updated the response to include `credits: 500` and the full `shipStats` so the client renders the HUD correctly on first load

## Test plan
- [ ] Create a new game and verify credits (500) and ship stats display immediately in the HUD
- [ ] Verify values match the selected ship class stats
- [ ] Reload the page and confirm the HUD still displays correctly

https://claude.ai/code/session_01Dz65NUYGUiQ35sdojmREW5