### PR TITLE
feat(void-odyssey): merge backstory into Step 2 with Oracle generator

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -1983,6 +1983,134 @@ Generate the next narrative beat, state mutations, available actions, AND a roll
 });
 
 /**
+ * voidOdysseyGenerateBackstory — generates a captain backstory tuned to the
+ * selected journey and traits. Used by the creation wizard's Step 2 "Generate
+ * Backstory" button so the player can seed the textarea with an AI-written
+ * draft and then edit it before continuing.
+ *
+ * Caller must be authenticated and have the 'void-odyssey' app claim.
+ *
+ * Data:
+ *   journey: string            — journey / tone ID (same set as voidOdysseyNewGame)
+ *   captainName: string        — optional; used for flavor if provided
+ *   captainTraits: string[]    — 2-3 trait IDs
+ *
+ * Returns:
+ *   backstory: string          — 2-4 sentence backstory (<= 400 chars)
+ */
+exports.voidOdysseyGenerateBackstory = onCall(async (request) => {
+  // ── Auth + claim check ─────────────────────────────────────
+  if (!request.auth) {
+    throw new HttpsError('unauthenticated', 'You must be signed in to play Void Odyssey.');
+  }
+  const tokenApps = request.auth.token.apps;
+  if (!Array.isArray(tokenApps) || !tokenApps.includes('void-odyssey')) {
+    throw new HttpsError('permission-denied', "You don't have access to Void Odyssey.");
+  }
+
+  // ── Input validation ───────────────────────────────────────
+  const { journey, captainName, captainTraits } = request.data || {};
+
+  const validJourneys = [
+    'frontier_explorer',
+    'smugglers_run',
+    'warpath',
+    'deep_salvage',
+    'first_contact',
+    'the_long_haul',
+    'ships_company',
+    'custom',
+  ];
+  const validTraitIds = [
+    'resourceful',
+    'cautious',
+    'silver_tongued',
+    'reckless',
+    'honorable',
+    'ruthless',
+    'curious',
+    'paranoid',
+    'compassionate',
+    'calculating',
+    'charismatic',
+    'stoic',
+  ];
+
+  if (!journey || !validJourneys.includes(journey)) {
+    throw new HttpsError('invalid-argument', 'Invalid journey selection.');
+  }
+  if (!Array.isArray(captainTraits) || captainTraits.length < 2 || captainTraits.length > 3) {
+    throw new HttpsError('invalid-argument', 'Select 2–3 captain traits.');
+  }
+  if (!captainTraits.every((t) => validTraitIds.includes(t))) {
+    throw new HttpsError('invalid-argument', 'Invalid captain trait selection.');
+  }
+
+  const journeyToneLabels = {
+    frontier_explorer: 'Frontier Explorer — discovery-focused, wonder, first contact',
+    smugglers_run: "Smuggler's Run — gritty trade, intrigue, moral grey areas",
+    warpath: 'Warpath — military campaigns, tactical combat, high stakes',
+    deep_salvage: 'Deep Salvage — atmospheric horror, derelict wrecks, resource scarcity',
+    first_contact: 'First Contact — cerebral, diplomatic, xenolinguistic stakes',
+    the_long_haul: 'The Long Haul — intimate character-driven voyage, isolation, crew bonds',
+    ships_company:
+      "Ship's Company — capital warship crew role, chain of command, institutional drama",
+    custom: 'Custom — flexible tone, adapt to whatever story emerges',
+  };
+
+  const nameLine =
+    typeof captainName === 'string' && captainName.trim()
+      ? `Captain's name: ${captainName.trim().slice(0, 60)}`
+      : "Captain's name: (unnamed — you may reference them as 'the captain')";
+
+  const systemPrompt = `You write short character backstories for Void Odyssey, an AI-driven space exploration game set in a hard-ish sci-fi universe (Firefly meets Mass Effect — grounded crews, alien encounters, political tensions, moments of wonder).
+
+You MUST respond with ONLY a valid JSON object. No prose outside the JSON. The schema is:
+{
+  "backstory": string (2-4 sentences, second person, 280 characters or fewer, tuned to the journey tone and chosen traits; should imply a reason this captain is heading into the void now)
+}
+
+Constraints:
+- Write in second person ("You grew up…").
+- Keep it grounded: a specific place, a specific incident, a hint of what's driving them.
+- Reference the traits implicitly through behavior or history, not as a list.
+- Do NOT name the ship, the crew, or the destination — those come later in creation.
+- Stay within 280 characters total. Do not exceed 400 under any circumstances.`;
+
+  const userMessage = `Generate a captain backstory for a new Void Odyssey campaign.
+
+Journey / Tone: ${journeyToneLabels[journey]}
+${nameLine}
+Traits: ${captainTraits.join(', ')}`;
+
+  let aiResponse;
+  try {
+    aiResponse = await callGemini({
+      modelName: VOID_ODYSSEY_MODEL,
+      systemInstruction: systemPrompt,
+      userMessage,
+      maxOutputTokens: 512,
+    });
+  } catch (err) {
+    if (err instanceof HttpsError) throw err;
+    console.error('voidOdysseyGenerateBackstory Gemini error:', err);
+    throw new HttpsError('internal', 'Failed to generate backstory. Please try again.');
+  }
+
+  let backstory = typeof aiResponse?.backstory === 'string' ? aiResponse.backstory.trim() : '';
+  if (!backstory) {
+    throw new HttpsError('internal', 'AI did not return a backstory.');
+  }
+  // Hard cap to match voidOdysseyNewGame's 400-char limit so the generated
+  // text can be sent straight back without rejection.
+  if (backstory.length > 400) {
+    backstory = backstory.slice(0, 400).trimEnd();
+  }
+
+  return { backstory };
+});
+
+/**
  * voidOdysseyNewGame — creates a new Void Odyssey campaign.
  *
  * Caller must be authenticated and have the 'void-odyssey' app claim.

--- a/functions/index.js
+++ b/functions/index.js
@@ -366,6 +366,35 @@ exports.inviteUser = onCall(async (request) => {
 const VOID_ODYSSEY_MODEL = 'gemini-2.5-flash';
 const VOID_ODYSSEY_COST_PER_TURN = 0.01; // USD per AI turn
 
+// Shared allowlists used by multiple Void Odyssey callables (voidOdysseyNewGame,
+// voidOdysseyGenerateBackstory, …). Keep these in one place so a new journey or
+// trait added here is automatically honored across every entry point.
+const VOID_ODYSSEY_JOURNEY_IDS = [
+  'frontier_explorer',
+  'smugglers_run',
+  'warpath',
+  'deep_salvage',
+  'first_contact',
+  'the_long_haul',
+  'ships_company',
+  'custom',
+];
+
+const VOID_ODYSSEY_TRAIT_IDS = [
+  'resourceful',
+  'cautious',
+  'silver_tongued',
+  'reckless',
+  'honorable',
+  'ruthless',
+  'curious',
+  'paranoid',
+  'compassionate',
+  'calculating',
+  'charismatic',
+  'stoic',
+];
+
 const VOID_ODYSSEY_TURN_SYSTEM_PROMPT = `You are the narrator for Void Odyssey, an AI-driven space exploration game. You write in second person ("You step onto the bridge..."). The genre is hard-ish sci-fi — think Firefly meets Mass Effect: grounded crews, alien encounters, political tensions, moments of wonder.
 
 You MUST respond with ONLY a valid JSON object. No prose outside the JSON. The schema is:
@@ -2011,38 +2040,13 @@ exports.voidOdysseyGenerateBackstory = onCall(async (request) => {
   // ── Input validation ───────────────────────────────────────
   const { journey, captainName, captainTraits } = request.data || {};
 
-  const validJourneys = [
-    'frontier_explorer',
-    'smugglers_run',
-    'warpath',
-    'deep_salvage',
-    'first_contact',
-    'the_long_haul',
-    'ships_company',
-    'custom',
-  ];
-  const validTraitIds = [
-    'resourceful',
-    'cautious',
-    'silver_tongued',
-    'reckless',
-    'honorable',
-    'ruthless',
-    'curious',
-    'paranoid',
-    'compassionate',
-    'calculating',
-    'charismatic',
-    'stoic',
-  ];
-
-  if (!journey || !validJourneys.includes(journey)) {
+  if (!journey || !VOID_ODYSSEY_JOURNEY_IDS.includes(journey)) {
     throw new HttpsError('invalid-argument', 'Invalid journey selection.');
   }
   if (!Array.isArray(captainTraits) || captainTraits.length < 2 || captainTraits.length > 3) {
     throw new HttpsError('invalid-argument', 'Select 2–3 captain traits.');
   }
-  if (!captainTraits.every((t) => validTraitIds.includes(t))) {
+  if (!captainTraits.every((t) => VOID_ODYSSEY_TRAIT_IDS.includes(t))) {
     throw new HttpsError('invalid-argument', 'Invalid captain trait selection.');
   }
 
@@ -2067,7 +2071,7 @@ exports.voidOdysseyGenerateBackstory = onCall(async (request) => {
 
 You MUST respond with ONLY a valid JSON object. No prose outside the JSON. The schema is:
 {
-  "backstory": string (2-4 sentences, second person, 280 characters or fewer, tuned to the journey tone and chosen traits; should imply a reason this captain is heading into the void now)
+  "backstory": string (2-4 sentences, second person, 400 characters or fewer, tuned to the journey tone and chosen traits; should imply a reason this captain is heading into the void now)
 }
 
 Constraints:
@@ -2075,7 +2079,7 @@ Constraints:
 - Keep it grounded: a specific place, a specific incident, a hint of what's driving them.
 - Reference the traits implicitly through behavior or history, not as a list.
 - Do NOT name the ship, the crew, or the destination — those come later in creation.
-- Stay within 280 characters total. Do not exceed 400 under any circumstances.`;
+- Stay within 400 characters total. Do not exceed this limit.`;
 
   const userMessage = `Generate a captain backstory for a new Void Odyssey campaign.
 
@@ -2153,16 +2157,6 @@ exports.voidOdysseyNewGame = onCall(async (request) => {
     shipName,
   } = request.data || {};
 
-  const validDifficulties = [
-    'frontier_explorer',
-    'smugglers_run',
-    'warpath',
-    'deep_salvage',
-    'first_contact',
-    'the_long_haul',
-    'ships_company',
-    'custom',
-  ];
   const validShipClasses = [
     'light_freighter',
     'scout_corvette',
@@ -2179,23 +2173,9 @@ exports.voidOdysseyNewGame = onCall(async (request) => {
     'heavy_cruiser',
   ];
 
-  if (!difficulty || !validDifficulties.includes(difficulty)) {
+  if (!difficulty || !VOID_ODYSSEY_JOURNEY_IDS.includes(difficulty)) {
     throw new HttpsError('invalid-argument', 'Invalid difficulty selection.');
   }
-  const validTraitIds = [
-    'resourceful',
-    'cautious',
-    'silver_tongued',
-    'reckless',
-    'honorable',
-    'ruthless',
-    'curious',
-    'paranoid',
-    'compassionate',
-    'calculating',
-    'charismatic',
-    'stoic',
-  ];
 
   if (typeof captainName !== 'string' || captainName.trim().length === 0) {
     throw new HttpsError('invalid-argument', "Captain's name is required.");
@@ -2206,7 +2186,7 @@ exports.voidOdysseyNewGame = onCall(async (request) => {
   if (!Array.isArray(captainTraits) || captainTraits.length < 2 || captainTraits.length > 3) {
     throw new HttpsError('invalid-argument', 'Select 2–3 captain traits.');
   }
-  if (!captainTraits.every((t) => validTraitIds.includes(t))) {
+  if (!captainTraits.every((t) => VOID_ODYSSEY_TRAIT_IDS.includes(t))) {
     throw new HttpsError('invalid-argument', 'Invalid captain trait selection.');
   }
   if (!shipClass || !validShipClasses.includes(shipClass)) {

--- a/public/apps/void-odyssey/game-create.js
+++ b/public/apps/void-odyssey/game-create.js
@@ -141,6 +141,7 @@
   // Step 2: Name your captain, pick traits, write or generate a backstory
   function _renderStep2(container) {
     var d = VO.state.wizardData;
+    var busy = VO.state._backstoryGenerating === true;
 
     var html =
       '<h2 class="wizard-step-title">Name Your Captain</h2>' +
@@ -169,13 +170,19 @@
         '</button>';
     });
 
+    var generateLabelHtml = busy
+      ? '<span class="backstory-spinner" aria-hidden="true"></span>Generating…'
+      : '✨ Generate Backstory';
+
     html +=
       '</div></div>' +
       '<div class="form-group">' +
       '<div class="backstory-label-row">' +
       '<label class="form-label" for="captain-backstory">Backstory <span class="form-optional">(optional)</span></label>' +
       '<button type="button" class="btn btn-ghost btn-sm backstory-generate-btn" id="backstory-generate" disabled>' +
-      '<span class="backstory-generate-label">✨ Generate Backstory</span>' +
+      '<span class="backstory-generate-label">' +
+      generateLabelHtml +
+      '</span>' +
       '</button>' +
       '</div>' +
       '<textarea id="captain-backstory" class="form-textarea" placeholder="A few sentences about your past — or select 2–3 traits and let the Oracle write one for you." maxlength="400">' +
@@ -194,8 +201,13 @@
     var backstoryInput = document.getElementById('captain-backstory');
     var nextBtn = document.getElementById('step2-next');
     var generateBtn = document.getElementById('backstory-generate');
-    var generateLabel = generateBtn.querySelector('.backstory-generate-label');
     var hint = document.getElementById('backstory-hint');
+
+    // If a previous generation finished with an error, surface it once and clear.
+    if (VO.state._backstoryError) {
+      _showError('wizard-body', VO.state._backstoryError);
+      VO.state._backstoryError = null;
+    }
 
     function updateNextEnabled() {
       var nameOk = nameInput.value.trim().length > 0;
@@ -205,9 +217,9 @@
 
     function updateGenerateEnabled() {
       var traitsOk = d.captainTraits.length >= 2 && d.captainTraits.length <= 3;
-      var busy = VO.state._backstoryGenerating === true;
-      generateBtn.disabled = !traitsOk || busy;
-      if (busy) {
+      var isBusy = VO.state._backstoryGenerating === true;
+      generateBtn.disabled = !traitsOk || isBusy;
+      if (isBusy) {
         hint.textContent = 'The Oracle is dreaming up your past…';
       } else if (traitsOk) {
         hint.textContent = 'Let the Oracle draft one — you can edit it after.';
@@ -254,11 +266,17 @@
       // Clear any previous inline error
       var existing = container.querySelector('.wizard-inline-error');
       if (existing) existing.remove();
+      VO.state._backstoryError = null;
 
       VO.state._backstoryGenerating = true;
-      generateLabel.innerHTML =
-        '<span class="backstory-spinner" aria-hidden="true"></span>Generating…';
       updateGenerateEnabled();
+      // Swap the button label to a spinner for immediate feedback; if a
+      // re-render happens later it will reconstruct the same state from
+      // VO.state._backstoryGenerating.
+      var labelEl = generateBtn.querySelector('.backstory-generate-label');
+      if (labelEl) {
+        labelEl.innerHTML = '<span class="backstory-spinner" aria-hidden="true"></span>Generating…';
+      }
 
       var fn = VO.state.functions.httpsCallable('voidOdysseyGenerateBackstory');
       fn({
@@ -269,18 +287,24 @@
         .then(function (result) {
           var text = (result && result.data && result.data.backstory) || '';
           if (text) {
-            backstoryInput.value = text;
+            // Write through state so a re-render (or revisit) picks it up.
             d.captainBackstory = text;
           }
         })
         .catch(function (err) {
           console.error('voidOdysseyGenerateBackstory error:', err);
-          _showError('wizard-body', err.message || 'Failed to generate backstory. Try again.');
+          VO.state._backstoryError = err.message || 'Failed to generate backstory. Try again.';
         })
         .then(function () {
           VO.state._backstoryGenerating = false;
-          generateLabel.textContent = '✨ Generate Backstory';
-          updateGenerateEnabled();
+          // If the user is still on Step 2, re-render so the textarea shows
+          // the generated text (or the error is surfaced) and the button
+          // returns to its resting state. If they navigated away mid-request,
+          // state is already updated and the fresh render on revisit picks
+          // it up — do not force navigation back.
+          if (VO.state.wizardStep === 2) {
+            VO.renderWizardStep(2);
+          }
         });
     });
 

--- a/public/apps/void-odyssey/game-create.js
+++ b/public/apps/void-odyssey/game-create.js
@@ -37,9 +37,6 @@
       case 6:
         _renderStep6(container);
         break;
-      case 7:
-        _renderStep7(container);
-        break;
     }
   };
 
@@ -141,7 +138,7 @@
     }
   }
 
-  // Step 2: Name your captain and choose traits
+  // Step 2: Name your captain, pick traits, write or generate a backstory
   function _renderStep2(container) {
     var d = VO.state.wizardData;
 
@@ -174,17 +171,60 @@
 
     html +=
       '</div></div>' +
+      '<div class="form-group">' +
+      '<div class="backstory-label-row">' +
+      '<label class="form-label" for="captain-backstory">Backstory <span class="form-optional">(optional)</span></label>' +
+      '<button type="button" class="btn btn-ghost btn-sm backstory-generate-btn" id="backstory-generate" disabled>' +
+      '<span class="backstory-generate-label">✨ Generate Backstory</span>' +
+      '</button>' +
+      '</div>' +
+      '<textarea id="captain-backstory" class="form-textarea" placeholder="A few sentences about your past — or select 2–3 traits and let the Oracle write one for you." maxlength="400">' +
+      _esc(d.captainBackstory) +
+      '</textarea>' +
+      '<p class="backstory-hint" id="backstory-hint">Pick 2–3 traits to unlock the Oracle.</p>' +
+      '</div>' +
       '<div class="wizard-nav">' +
       '<button type="button" class="btn btn-secondary wizard-back" id="step2-back">← Back</button>' +
-      '<button type="button" class="btn btn-primary wizard-next" id="step2-next">Next →</button>' +
+      '<button type="button" class="btn btn-primary wizard-next" id="step2-next" disabled>Next →</button>' +
       '</div>';
 
     container.innerHTML = html;
 
-    // Sync name input
     var nameInput = document.getElementById('captain-name');
+    var backstoryInput = document.getElementById('captain-backstory');
+    var nextBtn = document.getElementById('step2-next');
+    var generateBtn = document.getElementById('backstory-generate');
+    var generateLabel = generateBtn.querySelector('.backstory-generate-label');
+    var hint = document.getElementById('backstory-hint');
+
+    function updateNextEnabled() {
+      var nameOk = nameInput.value.trim().length > 0;
+      var traitsOk = d.captainTraits.length >= 2 && d.captainTraits.length <= 3;
+      nextBtn.disabled = !(nameOk && traitsOk);
+    }
+
+    function updateGenerateEnabled() {
+      var traitsOk = d.captainTraits.length >= 2 && d.captainTraits.length <= 3;
+      var busy = VO.state._backstoryGenerating === true;
+      generateBtn.disabled = !traitsOk || busy;
+      if (busy) {
+        hint.textContent = 'The Oracle is dreaming up your past…';
+      } else if (traitsOk) {
+        hint.textContent = 'Let the Oracle draft one — you can edit it after.';
+      } else {
+        hint.textContent = 'Pick 2–3 traits to unlock the Oracle.';
+      }
+    }
+
+    // Sync name input
     nameInput.addEventListener('input', function () {
       d.captainName = nameInput.value;
+      updateNextEnabled();
+    });
+
+    // Sync backstory textarea
+    backstoryInput.addEventListener('input', function () {
+      d.captainBackstory = backstoryInput.value;
     });
 
     // Trait buttons — enforce 2-3 limit
@@ -204,26 +244,68 @@
           btn.classList.add('selected');
           btn.setAttribute('aria-pressed', 'true');
         }
+        updateNextEnabled();
+        updateGenerateEnabled();
       });
+    });
+
+    generateBtn.addEventListener('click', function () {
+      if (generateBtn.disabled) return;
+      // Clear any previous inline error
+      var existing = container.querySelector('.wizard-inline-error');
+      if (existing) existing.remove();
+
+      VO.state._backstoryGenerating = true;
+      generateLabel.innerHTML =
+        '<span class="backstory-spinner" aria-hidden="true"></span>Generating…';
+      updateGenerateEnabled();
+
+      var fn = VO.state.functions.httpsCallable('voidOdysseyGenerateBackstory');
+      fn({
+        journey: d.tone,
+        captainName: nameInput.value.trim(),
+        captainTraits: d.captainTraits.slice(),
+      })
+        .then(function (result) {
+          var text = (result && result.data && result.data.backstory) || '';
+          if (text) {
+            backstoryInput.value = text;
+            d.captainBackstory = text;
+          }
+        })
+        .catch(function (err) {
+          console.error('voidOdysseyGenerateBackstory error:', err);
+          _showError('wizard-body', err.message || 'Failed to generate backstory. Try again.');
+        })
+        .then(function () {
+          VO.state._backstoryGenerating = false;
+          generateLabel.textContent = '✨ Generate Backstory';
+          updateGenerateEnabled();
+        });
     });
 
     document.getElementById('step2-back').addEventListener('click', function () {
       VO.renderWizardStep(1);
     });
 
-    document.getElementById('step2-next').addEventListener('click', function () {
-      var name = document.getElementById('captain-name').value.trim();
+    nextBtn.addEventListener('click', function () {
+      if (nextBtn.disabled) return;
+      var name = nameInput.value.trim();
       if (!name) {
         _showFieldError('captain-name', "Please enter your captain's name.");
         return;
       }
-      if (d.captainTraits.length < 2) {
-        _showError('wizard-body', 'Please select at least 2 traits.');
+      if (d.captainTraits.length < 2 || d.captainTraits.length > 3) {
+        _showError('wizard-body', 'Please select 2 or 3 traits.');
         return;
       }
       d.captainName = name;
+      d.captainBackstory = backstoryInput.value;
       VO.renderWizardStep(3);
     });
+
+    updateNextEnabled();
+    updateGenerateEnabled();
   }
 
   // Step 3: Allocate skills
@@ -369,42 +451,8 @@
     });
   }
 
-  // Step 4: Backstory
+  // Step 4: Choose your ship
   function _renderStep4(container) {
-    var d = VO.state.wizardData;
-
-    var html =
-      '<h2 class="wizard-step-title">Your Backstory</h2>' +
-      '<p class="wizard-step-desc">A few words about your past — or let the Oracle invent one.</p>' +
-      '<div class="form-group">' +
-      '<label class="form-label" for="captain-backstory">Backstory <span class="form-optional">(optional — or let Claude invent one)</span></label>' +
-      '<textarea id="captain-backstory" class="form-textarea" placeholder="A few sentences about your past..." maxlength="400">' +
-      _esc(d.captainBackstory) +
-      '</textarea>' +
-      '</div>' +
-      '<div class="wizard-nav">' +
-      '<button type="button" class="btn btn-secondary" id="step4-back">← Back</button>' +
-      '<button type="button" class="btn btn-primary" id="step4-next">Next →</button>' +
-      '</div>';
-
-    container.innerHTML = html;
-
-    var backstoryInput = document.getElementById('captain-backstory');
-    backstoryInput.addEventListener('input', function () {
-      d.captainBackstory = backstoryInput.value;
-    });
-
-    document.getElementById('step4-back').addEventListener('click', function () {
-      VO.renderWizardStep(3);
-    });
-
-    document.getElementById('step4-next').addEventListener('click', function () {
-      VO.renderWizardStep(5);
-    });
-  }
-
-  // Step 5: Choose your ship
-  function _renderStep5(container) {
     var d = VO.state.wizardData;
 
     var html =
@@ -454,8 +502,8 @@
       '">' +
       '</div>' +
       '<div class="wizard-nav">' +
-      '<button type="button" class="btn btn-secondary" id="step5-back">← Back</button>' +
-      '<button type="button" class="btn btn-primary" id="step5-next"' +
+      '<button type="button" class="btn btn-secondary" id="step4-back">← Back</button>' +
+      '<button type="button" class="btn btn-primary" id="step4-next"' +
       (d.shipClass ? '' : ' disabled') +
       '>Next →</button>' +
       '</div>';
@@ -469,7 +517,7 @@
           c.classList.toggle('selected', c.dataset.id === d.shipClass);
         });
         document.getElementById('ship-name-group').style.display = '';
-        document.getElementById('step5-next').disabled = false;
+        document.getElementById('step4-next').disabled = false;
       });
     });
 
@@ -480,11 +528,11 @@
       });
     }
 
-    document.getElementById('step5-back').addEventListener('click', function () {
-      VO.renderWizardStep(4);
+    document.getElementById('step4-back').addEventListener('click', function () {
+      VO.renderWizardStep(3);
     });
 
-    document.getElementById('step5-next').addEventListener('click', function () {
+    document.getElementById('step4-next').addEventListener('click', function () {
       if (!d.shipClass) return;
       var name =
         document.getElementById('ship-name') && document.getElementById('ship-name').value.trim();
@@ -493,12 +541,12 @@
         return;
       }
       d.shipName = name;
-      VO.renderWizardStep(6);
+      VO.renderWizardStep(5);
     });
   }
 
-  // Step 6: Generate and review starting crew (Cloud Function call + Firestore write)
-  function _renderStep6(container) {
+  // Step 5: Generate and review starting crew (Cloud Function call + Firestore write)
+  function _renderStep5(container) {
     var d = VO.state.wizardData;
 
     // Show spinner while we call the Cloud Function
@@ -534,10 +582,10 @@
           _esc(err.message || 'Failed to generate game. Please try again.') +
           '</p>' +
           '<div class="wizard-nav">' +
-          '<button type="button" class="btn btn-secondary" id="step6-retry">← Try Again</button>' +
+          '<button type="button" class="btn btn-secondary" id="step5-retry">← Try Again</button>' +
           '</div>';
-        document.getElementById('step6-retry').addEventListener('click', function () {
-          VO.renderWizardStep(6);
+        document.getElementById('step5-retry').addEventListener('click', function () {
+          VO.renderWizardStep(5);
         });
       });
   }
@@ -568,27 +616,27 @@
     html +=
       '</div>' +
       '<div class="wizard-nav">' +
-      '<button type="button" class="btn btn-secondary" id="step6-back">← Reroll</button>' +
-      '<button type="button" class="btn btn-primary" id="step6-next">Launch Campaign →</button>' +
+      '<button type="button" class="btn btn-secondary" id="step5-back">← Reroll</button>' +
+      '<button type="button" class="btn btn-primary" id="step5-next">Launch Campaign →</button>' +
       '</div>';
 
     container.innerHTML = html;
 
-    document.getElementById('step6-back').addEventListener('click', function () {
+    document.getElementById('step5-back').addEventListener('click', function () {
       VO.state.generatedGame = null;
-      VO.renderWizardStep(6);
+      VO.renderWizardStep(5);
     });
 
-    document.getElementById('step6-next').addEventListener('click', function () {
-      VO.renderWizardStep(7);
+    document.getElementById('step5-next').addEventListener('click', function () {
+      VO.renderWizardStep(6);
     });
   }
 
-  // Step 7: Display opening scene
-  function _renderStep7(container) {
+  // Step 6: Display opening scene
+  function _renderStep6(container) {
     var game = VO.state.generatedGame;
     if (!game) {
-      VO.renderWizardStep(6);
+      VO.renderWizardStep(5);
       return;
     }
 
@@ -620,10 +668,10 @@
       '<p class="action-panel-note">(Full turn actions available in Phase 2)</p>' +
       '</div>' +
       '<div class="wizard-nav wizard-nav--center">' +
-      '<button type="button" class="btn btn-primary" id="step7-enter">Enter the Void →</button>' +
+      '<button type="button" class="btn btn-primary" id="step6-enter">Enter the Void →</button>' +
       '</div>';
 
-    document.getElementById('step7-enter').addEventListener('click', function () {
+    document.getElementById('step6-enter').addEventListener('click', function () {
       VO.showView('game-active');
     });
   }

--- a/public/apps/void-odyssey/index.html
+++ b/public/apps/void-odyssey/index.html
@@ -49,7 +49,6 @@
             <div class="wizard-step-dot" title="Journey"></div>
             <div class="wizard-step-dot" title="Captain"></div>
             <div class="wizard-step-dot" title="Skills"></div>
-            <div class="wizard-step-dot" title="Backstory"></div>
             <div class="wizard-step-dot" title="Ship"></div>
             <div class="wizard-step-dot" title="Crew"></div>
             <div class="wizard-step-dot" title="Opening Scene"></div>

--- a/public/apps/void-odyssey/styles.css
+++ b/public/apps/void-odyssey/styles.css
@@ -447,6 +447,59 @@
   color: #ffd54f;
 }
 
+/* ── Backstory generator (Step 2) ────────────────────────── */
+
+.backstory-label-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.45rem;
+}
+
+.backstory-label-row .form-label {
+  margin-bottom: 0;
+}
+
+.btn-ghost {
+  background: rgba(255, 183, 77, 0.08);
+  color: #ffd54f;
+  border: 1px solid rgba(255, 183, 77, 0.35);
+}
+
+.btn-ghost:hover:not(:disabled) {
+  background: rgba(255, 183, 77, 0.16);
+  border-color: rgba(255, 183, 77, 0.55);
+}
+
+.backstory-generate-btn {
+  white-space: nowrap;
+}
+
+.backstory-spinner {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 213, 79, 0.3);
+  border-top-color: #ffd54f;
+  animation: backstory-spin 0.8s linear infinite;
+  margin-right: 0.45rem;
+  vertical-align: -2px;
+}
+
+@keyframes backstory-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.backstory-hint {
+  margin: 0.45rem 0 0;
+  font-size: 0.78rem;
+  color: #78909c;
+}
+
 /* ── Ship cards ──────────────────────────────────────────── */
 
 .ship-grid {

--- a/tests/void-odyssey-generate-backstory.test.js
+++ b/tests/void-odyssey-generate-backstory.test.js
@@ -1,0 +1,229 @@
+'use strict';
+
+/**
+ * Unit tests for voidOdysseyGenerateBackstory.
+ *
+ * Mocks functions/gemini so no Vertex AI credentials are needed and the test
+ * does not require the Firestore emulator — this callable does not read or
+ * write Firestore.
+ *
+ * Run: cd tests && npx jest void-odyssey-generate-backstory --verbose
+ */
+
+// Set project env var BEFORE any require so firebase-admin can initialize
+// without real credentials.
+process.env.GCLOUD_PROJECT = 'demo-void-odyssey-test';
+
+// Mock callGemini BEFORE requiring the functions module so the export picks
+// up the mock.
+jest.mock('../functions/gemini', () => ({
+  callGemini: jest.fn(),
+}));
+
+const { callGemini } = require('../functions/gemini');
+const { voidOdysseyGenerateBackstory } = require('../functions/index');
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+/**
+ * Invokes the callable directly via .run() — firebase-functions-test misdetects
+ * v2 onCall arity, so the existing turn tests use the same workaround.
+ */
+function callGenerate(data = {}, { authOverride } = {}) {
+  return voidOdysseyGenerateBackstory.run({
+    data,
+    auth:
+      authOverride !== undefined
+        ? authOverride
+        : {
+            uid: 'test-user',
+            token: { apps: ['void-odyssey'], admin: false },
+          },
+  });
+}
+
+function validData(overrides = {}) {
+  return {
+    journey: 'frontier_explorer',
+    captainName: 'Mara Solano',
+    captainTraits: ['resourceful', 'curious'],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  callGemini.mockReset();
+});
+
+// ── Auth / claim enforcement ───────────────────────────────────────────────
+
+describe('voidOdysseyGenerateBackstory — auth', () => {
+  test('rejects unauthenticated callers', async () => {
+    await expect(callGenerate(validData(), { authOverride: null })).rejects.toMatchObject({
+      code: 'unauthenticated',
+    });
+    expect(callGemini).not.toHaveBeenCalled();
+  });
+
+  test('rejects callers without the void-odyssey app claim', async () => {
+    await expect(
+      callGenerate(validData(), {
+        authOverride: { uid: 'test-user', token: { apps: ['symposium'] } },
+      })
+    ).rejects.toMatchObject({ code: 'permission-denied' });
+    expect(callGemini).not.toHaveBeenCalled();
+  });
+
+  test('rejects callers with no apps array', async () => {
+    await expect(
+      callGenerate(validData(), {
+        authOverride: { uid: 'test-user', token: {} },
+      })
+    ).rejects.toMatchObject({ code: 'permission-denied' });
+    expect(callGemini).not.toHaveBeenCalled();
+  });
+});
+
+// ── Input validation ───────────────────────────────────────────────────────
+
+describe('voidOdysseyGenerateBackstory — input validation', () => {
+  test('rejects missing journey', async () => {
+    await expect(callGenerate(validData({ journey: undefined }))).rejects.toMatchObject({
+      code: 'invalid-argument',
+    });
+    expect(callGemini).not.toHaveBeenCalled();
+  });
+
+  test('rejects unknown journey', async () => {
+    await expect(callGenerate(validData({ journey: 'not_a_real_journey' }))).rejects.toMatchObject({
+      code: 'invalid-argument',
+    });
+    expect(callGemini).not.toHaveBeenCalled();
+  });
+
+  test('accepts every allowlisted journey', async () => {
+    const journeys = [
+      'frontier_explorer',
+      'smugglers_run',
+      'warpath',
+      'deep_salvage',
+      'first_contact',
+      'the_long_haul',
+      'ships_company',
+      'custom',
+    ];
+    for (const journey of journeys) {
+      callGemini.mockResolvedValueOnce({ backstory: 'ok.' });
+      const result = await callGenerate(validData({ journey }));
+      expect(result).toEqual({ backstory: 'ok.' });
+    }
+    expect(callGemini).toHaveBeenCalledTimes(journeys.length);
+  });
+
+  test('rejects fewer than 2 traits', async () => {
+    await expect(callGenerate(validData({ captainTraits: ['resourceful'] }))).rejects.toMatchObject(
+      { code: 'invalid-argument' }
+    );
+    expect(callGemini).not.toHaveBeenCalled();
+  });
+
+  test('rejects more than 3 traits', async () => {
+    await expect(
+      callGenerate(validData({ captainTraits: ['resourceful', 'curious', 'stoic', 'reckless'] }))
+    ).rejects.toMatchObject({ code: 'invalid-argument' });
+    expect(callGemini).not.toHaveBeenCalled();
+  });
+
+  test('accepts exactly 2 traits', async () => {
+    callGemini.mockResolvedValueOnce({ backstory: 'A short past.' });
+    const result = await callGenerate(validData({ captainTraits: ['resourceful', 'curious'] }));
+    expect(result.backstory).toBe('A short past.');
+  });
+
+  test('accepts exactly 3 traits', async () => {
+    callGemini.mockResolvedValueOnce({ backstory: 'A short past.' });
+    const result = await callGenerate(
+      validData({ captainTraits: ['resourceful', 'curious', 'stoic'] })
+    );
+    expect(result.backstory).toBe('A short past.');
+  });
+
+  test('rejects trait not on the allowlist', async () => {
+    await expect(
+      callGenerate(validData({ captainTraits: ['resourceful', 'destroyer_of_worlds'] }))
+    ).rejects.toMatchObject({ code: 'invalid-argument' });
+    expect(callGemini).not.toHaveBeenCalled();
+  });
+
+  test('rejects non-array captainTraits', async () => {
+    await expect(
+      callGenerate(validData({ captainTraits: 'resourceful,curious' }))
+    ).rejects.toMatchObject({ code: 'invalid-argument' });
+    expect(callGemini).not.toHaveBeenCalled();
+  });
+});
+
+// ── Output shape / capping ─────────────────────────────────────────────────
+
+describe('voidOdysseyGenerateBackstory — output handling', () => {
+  test('returns trimmed backstory from the AI', async () => {
+    callGemini.mockResolvedValueOnce({
+      backstory: '   You grew up on a mining moon and never looked back.   ',
+    });
+    const result = await callGenerate(validData());
+    expect(result.backstory).toBe('You grew up on a mining moon and never looked back.');
+  });
+
+  test('caps oversize AI output at 400 characters', async () => {
+    const oversize = 'a'.repeat(600);
+    callGemini.mockResolvedValueOnce({ backstory: oversize });
+    const result = await callGenerate(validData());
+    expect(result.backstory.length).toBeLessThanOrEqual(400);
+    expect(result.backstory.length).toBe(400);
+  });
+
+  test('throws internal error when AI returns empty backstory', async () => {
+    callGemini.mockResolvedValueOnce({ backstory: '   ' });
+    await expect(callGenerate(validData())).rejects.toMatchObject({ code: 'internal' });
+  });
+
+  test('throws internal error when AI response has no backstory field', async () => {
+    callGemini.mockResolvedValueOnce({ somethingElse: 'nope' });
+    await expect(callGenerate(validData())).rejects.toMatchObject({ code: 'internal' });
+  });
+
+  test('wraps unknown callGemini errors as internal HttpsError', async () => {
+    callGemini.mockRejectedValueOnce(new Error('network down'));
+    await expect(callGenerate(validData())).rejects.toMatchObject({ code: 'internal' });
+  });
+});
+
+// ── Prompt construction ────────────────────────────────────────────────────
+
+describe('voidOdysseyGenerateBackstory — prompt content', () => {
+  test('passes captain name and traits into the user message', async () => {
+    callGemini.mockResolvedValueOnce({ backstory: 'ok.' });
+    await callGenerate(
+      validData({
+        journey: 'smugglers_run',
+        captainName: 'Mara Solano',
+        captainTraits: ['silver_tongued', 'ruthless'],
+      })
+    );
+
+    expect(callGemini).toHaveBeenCalledTimes(1);
+    const callArgs = callGemini.mock.calls[0][0];
+    expect(callArgs.userMessage).toContain('Mara Solano');
+    expect(callArgs.userMessage).toContain('silver_tongued');
+    expect(callArgs.userMessage).toContain('ruthless');
+    expect(callArgs.userMessage).toContain("Smuggler's Run");
+  });
+
+  test('falls back to an anonymous captain label when name is absent', async () => {
+    callGemini.mockResolvedValueOnce({ backstory: 'ok.' });
+    await callGenerate(validData({ captainName: '' }));
+
+    const callArgs = callGemini.mock.calls[0][0];
+    expect(callArgs.userMessage).toContain('unnamed');
+  });
+});


### PR DESCRIPTION
Closes #145.

## Summary

- Merges the captain backstory into Step 2 of the creation wizard alongside name + traits, matching the issue spec and the creation amendment
- Adds a `voidOdysseyGenerateBackstory` Cloud Function (Gemini Flash via Vertex AI) that produces a 2–4 sentence backstory tuned to the selected journey and traits
- Wires a "Generate Backstory" button + spinner into Step 2 that calls the function and seeds the textarea with an editable draft
- Reactively enables the Step 2 Continue button only when name is filled and 2–3 traits are selected (per acceptance criteria)
- Removes the now-redundant standalone Step 4 backstory page and collapses the wizard from 7 step dots to 6 (Journey → Captain → Skills → Ship → Crew → Opening Scene)

## Notes on the implementation

- The Generate button is gated on having 2–3 traits selected, otherwise the Oracle has no tone context to write from. A small hint label tells the player what's needed.
- The Cloud Function validates the journey + trait IDs against the same allowlists used by `voidOdysseyNewGame`, hard-caps the returned text at 400 characters (matching `voidOdysseyNewGame`'s server-side limit), and uses `maxOutputTokens: 512` for a tight, cheap call.
- The button label flips to a spinner during the call. Errors surface in the existing wizard inline-error slot.
- The issue text says "Generate with Claude" but the Void Odyssey stack moved to Gemini Flash via Vertex AI in #151, so the user-facing copy reads "Generate Backstory" / "the Oracle" to match the rest of the app's voice.

## Test plan

- [ ] Open the new game wizard, advance to Step 2, confirm 6 step dots are visible
- [ ] Confirm Continue stays disabled until name is filled AND 2–3 traits are selected
- [ ] Select 2 traits → Generate Backstory button becomes enabled; click it → spinner shows, textarea fills with AI text after the call
- [ ] Edit the generated backstory, advance to Step 3 (Skills), then back to Step 2, confirm name/traits/backstory are preserved
- [ ] Walk all the way through the wizard to launch a campaign and confirm the captain's backstory shows up on the new game document
- [ ] Re-run with 0/1/4 traits and confirm Generate stays disabled
- [ ] Re-run lint + format locally (`npm run lint && npm run format:check`)

https://claude.ai/code/session_01LoK2d65uPniMANLjNfmbQd