### PR TITLE
feat(void-odyssey): complete Step 3 skill allocation UI (#163)

### DIFF
--- a/public/apps/void-odyssey/game-create.js
+++ b/public/apps/void-odyssey/game-create.js
@@ -351,16 +351,45 @@
 
       VO.SKILLS.forEach(function (skill) {
         var level = d.captainSkills[skill.id] || 0;
-        var canIncrease = level < 3 && COSTS[level + 1] - COSTS[level] <= remaining;
+        var nextDelta = level < 3 ? COSTS[level + 1] - COSTS[level] : 0;
+        var canIncrease = level < 3 && nextDelta <= remaining;
         var canDecrease = level > 0;
 
+        var rowClass = 'skill-row';
+        if (level >= 3) {
+          rowClass += ' is-maxed';
+        } else if (!canIncrease) {
+          rowClass += ' is-unaffordable';
+        }
+
+        var nextLabel;
+        if (level >= 3) {
+          nextLabel = 'Maxed';
+        } else if (!canIncrease) {
+          nextLabel = "Can't afford (" + nextDelta + ' pts)';
+        } else {
+          nextLabel = 'Next: ' + nextDelta + (nextDelta === 1 ? ' pt' : ' pts');
+        }
+
+        var incTitle = level < 3 ? 'Next level: ' + nextDelta + ' points' : 'Level 3 is the cap';
+
         rows +=
-          '<div class="skill-row" data-skill="' +
+          '<div class="' +
+          rowClass +
+          '" data-skill="' +
           skill.id +
           '">' +
+          '<div class="skill-info">' +
           '<span class="skill-label">' +
           _esc(skill.label) +
           '</span>' +
+          '<span class="skill-desc">' +
+          _esc(skill.description || '') +
+          '</span>' +
+          '<span class="skill-next-cost">' +
+          _esc(nextLabel) +
+          '</span>' +
+          '</div>' +
           '<div class="skill-controls">' +
           '<button type="button" class="skill-btn skill-dec"' +
           (canDecrease ? '' : ' disabled') +
@@ -372,6 +401,9 @@
           '</span>' +
           '<button type="button" class="skill-btn skill-inc"' +
           (canIncrease ? '' : ' disabled') +
+          ' title="' +
+          _esc(incTitle) +
+          '"' +
           ' data-skill="' +
           skill.id +
           '">+</button>' +

--- a/public/apps/void-odyssey/game-create.js
+++ b/public/apps/void-odyssey/game-create.js
@@ -354,6 +354,7 @@
         var nextDelta = level < 3 ? COSTS[level + 1] - COSTS[level] : 0;
         var canIncrease = level < 3 && nextDelta <= remaining;
         var canDecrease = level > 0;
+        var nextPts = nextDelta === 1 ? ' pt' : ' pts';
 
         var rowClass = 'skill-row';
         if (level >= 3) {
@@ -366,12 +367,26 @@
         if (level >= 3) {
           nextLabel = 'Maxed';
         } else if (!canIncrease) {
-          nextLabel = "Can't afford (" + nextDelta + ' pts)';
+          nextLabel = "Can't afford (" + nextDelta + nextPts + ')';
         } else {
-          nextLabel = 'Next: ' + nextDelta + (nextDelta === 1 ? ' pt' : ' pts');
+          nextLabel = 'Next: ' + nextDelta + nextPts;
         }
 
-        var incTitle = level < 3 ? 'Next level: ' + nextDelta + ' points' : 'Level 3 is the cap';
+        var incTitle =
+          level < 3
+            ? 'Next level: ' + nextDelta + (nextDelta === 1 ? ' point' : ' points')
+            : 'Level 3 is the cap';
+
+        var incAriaLabel;
+        if (level >= 3) {
+          incAriaLabel = skill.label + ' is at level 3 (maximum)';
+        } else {
+          incAriaLabel = 'Increase ' + skill.label + ' to level ' + (level + 1);
+        }
+        var decAriaLabel =
+          level > 0
+            ? 'Decrease ' + skill.label + ' to level ' + (level - 1)
+            : skill.label + ' is at level 0';
 
         rows +=
           '<div class="' +
@@ -393,16 +408,22 @@
           '<div class="skill-controls">' +
           '<button type="button" class="skill-btn skill-dec"' +
           (canDecrease ? '' : ' disabled') +
+          ' aria-label="' +
+          _esc(decAriaLabel) +
+          '"' +
           ' data-skill="' +
           skill.id +
           '">−</button>' +
-          '<span class="skill-level">' +
+          '<span class="skill-level" aria-hidden="true">' +
           level +
           '</span>' +
           '<button type="button" class="skill-btn skill-inc"' +
           (canIncrease ? '' : ' disabled') +
           ' title="' +
           _esc(incTitle) +
+          '"' +
+          ' aria-label="' +
+          _esc(incAriaLabel) +
           '"' +
           ' data-skill="' +
           skill.id +

--- a/public/apps/void-odyssey/state.js
+++ b/public/apps/void-odyssey/state.js
@@ -52,21 +52,81 @@
   // ── Skill definitions (used in character creation Step 3) ──
   // Cost per level: 1→1pt, 2→3pt, 3→6pt. Total budget: 10 pts.
   VO.SKILLS = [
-    { id: 'piloting', label: 'Piloting' },
-    { id: 'gunnery', label: 'Gunnery' },
-    { id: 'engineering', label: 'Engineering' },
-    { id: 'medicine', label: 'Medicine' },
-    { id: 'diplomacy', label: 'Diplomacy' },
-    { id: 'intimidation', label: 'Intimidation' },
-    { id: 'deception', label: 'Deception' },
-    { id: 'investigation', label: 'Investigation' },
-    { id: 'survival', label: 'Survival' },
-    { id: 'hacking', label: 'Hacking' },
-    { id: 'stealth', label: 'Stealth' },
-    { id: 'leadership', label: 'Leadership' },
-    { id: 'xenology', label: 'Xenology' },
-    { id: 'commerce', label: 'Commerce' },
-    { id: 'perception', label: 'Perception' },
+    {
+      id: 'piloting',
+      label: 'Piloting',
+      description: 'Ship maneuvering, evasive action, precision flying',
+    },
+    {
+      id: 'gunnery',
+      label: 'Gunnery',
+      description: 'Weapon targeting, fire control, turret operation',
+    },
+    {
+      id: 'engineering',
+      label: 'Engineering',
+      description: 'Ship repair, system maintenance, jury-rigging',
+    },
+    {
+      id: 'medicine',
+      label: 'Medicine',
+      description: 'Treating injuries, surgery, disease identification',
+    },
+    {
+      id: 'diplomacy',
+      label: 'Diplomacy',
+      description: 'Negotiation, persuasion, de-escalation',
+    },
+    {
+      id: 'intimidation',
+      label: 'Intimidation',
+      description: 'Coercion, threatening, projecting authority',
+    },
+    {
+      id: 'deception',
+      label: 'Deception',
+      description: 'Lying, bluffing, disguise, misdirection',
+    },
+    {
+      id: 'investigation',
+      label: 'Investigation',
+      description: 'Searching, analyzing clues, forensic analysis',
+    },
+    {
+      id: 'survival',
+      label: 'Survival',
+      description: 'EVA operations, harsh environments, rationing',
+    },
+    {
+      id: 'hacking',
+      label: 'Hacking',
+      description: 'Cybersecurity, cracking systems, electronic warfare',
+    },
+    {
+      id: 'stealth',
+      label: 'Stealth',
+      description: 'Moving undetected, silent operations, ambush setup',
+    },
+    {
+      id: 'leadership',
+      label: 'Leadership',
+      description: 'Commanding under pressure, tactical coordination',
+    },
+    {
+      id: 'xenology',
+      label: 'Xenology',
+      description: 'Alien languages, customs, biology, first-contact protocols',
+    },
+    {
+      id: 'commerce',
+      label: 'Commerce',
+      description: 'Market knowledge, appraising goods, deal-making',
+    },
+    {
+      id: 'perception',
+      label: 'Perception',
+      description: 'Spotting threats, reading people, situational awareness',
+    },
   ];
   VO.SKILL_POINT_BUDGET = 10;
   // Index = level (0 = not taken)

--- a/public/apps/void-odyssey/styles.css
+++ b/public/apps/void-odyssey/styles.css
@@ -500,6 +500,146 @@
   color: #78909c;
 }
 
+/* ── Skill allocation (Step 3) ────────────────────────────── */
+
+.skill-budget {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 1.25rem;
+  padding: 0.85rem 1rem;
+  background: rgba(255, 183, 77, 0.06);
+  border: 1px solid rgba(255, 183, 77, 0.2);
+  border-radius: 8px;
+}
+
+.skill-budget-label {
+  color: #b0bec5;
+  font-size: 0.9rem;
+  font-weight: 500;
+}
+
+.skill-budget-count {
+  font-weight: 700;
+  font-size: 1.1rem;
+  color: #ffb74d;
+  min-width: 1.5rem;
+  text-align: right;
+}
+
+.skill-budget-count.skill-budget-done {
+  color: #81c784;
+}
+
+.skill-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.skill-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.75rem 1rem;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 10px;
+  transition:
+    border-color 0.15s,
+    background 0.15s,
+    opacity 0.15s;
+}
+
+.skill-row.is-maxed {
+  border-color: rgba(255, 183, 77, 0.45);
+  background: rgba(255, 183, 77, 0.08);
+}
+
+.skill-row.is-unaffordable {
+  opacity: 0.55;
+}
+
+.skill-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  min-width: 0;
+  flex: 1;
+}
+
+.skill-label {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #e0e0e0;
+}
+
+.skill-desc {
+  font-size: 0.8rem;
+  color: #90a4ae;
+  line-height: 1.3;
+}
+
+.skill-next-cost {
+  font-size: 0.72rem;
+  color: #78909c;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-top: 0.15rem;
+}
+
+.skill-row.is-maxed .skill-next-cost {
+  color: #ffd54f;
+}
+
+.skill-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  flex-shrink: 0;
+}
+
+.skill-btn {
+  width: 32px;
+  height: 32px;
+  border-radius: 6px;
+  border: 1px solid rgba(255, 183, 77, 0.4);
+  background: rgba(255, 183, 77, 0.08);
+  color: #ffb74d;
+  font-weight: 700;
+  font-size: 1.1rem;
+  line-height: 1;
+  cursor: pointer;
+  transition:
+    background 0.15s,
+    border-color 0.15s,
+    transform 0.1s;
+}
+
+.skill-btn:hover:not(:disabled) {
+  background: rgba(255, 183, 77, 0.18);
+  border-color: rgba(255, 183, 77, 0.7);
+}
+
+.skill-btn:active:not(:disabled) {
+  transform: scale(0.94);
+}
+
+.skill-btn:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+.skill-level {
+  min-width: 1.25rem;
+  text-align: center;
+  font-weight: 700;
+  color: #ffd54f;
+  font-size: 1rem;
+}
+
 /* ── Ship cards ──────────────────────────────────────────── */
 
 .ship-grid {


### PR DESCRIPTION
- Add descriptions to the 15 entries in VO.SKILLS
- Render description, "Next: N pts" cost preview, and maxed /
  unaffordable row states in wizard Step 3
- Add hover tooltip on upgrade button with next-level cost
- Add dark-theme CSS for .skill-row, .skill-btn, .skill-budget