### PR TITLE
feat(void-odyssey): implement creation wizard Step 4 ship selection (#146)

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -396,7 +396,9 @@ const VOID_ODYSSEY_TRAIT_IDS = [
 ];
 
 // Roles selectable during game creation when difficulty === 'ships_company'.
-// Mirrors the roleOptions array in public/apps/void-odyssey/journeys.js.
+// Mirrors the roleOptions array in public/apps/void-odyssey/journeys.js. A
+// drift test in tests/void-odyssey-constants.test.js asserts the two stay
+// in sync.
 const VOID_ODYSSEY_SHIPS_COMPANY_ROLE_IDS = [
   'fighter_pilot',
   'weapons_officer',
@@ -406,6 +408,22 @@ const VOID_ODYSSEY_SHIPS_COMPANY_ROLE_IDS = [
   'intelligence_analyst',
   'marine_sergeant',
 ];
+
+// Per-journey ship allowlist. Mirrors VO.JOURNEYS[id].availableShips in
+// public/apps/void-odyssey/journeys.js. Used for server-side validation so
+// modified clients cannot pair a ship with a journey it does not belong to.
+// The same drift test above asserts this stays in sync with the frontend.
+// `custom` is intentionally omitted — the custom journey is not yet selectable
+// in the wizard (order 8, filtered out of Step 1), so no ship allowlist applies.
+const VOID_ODYSSEY_JOURNEY_SHIPS = {
+  frontier_explorer: ['survey_vessel', 'scout_corvette', 'light_freighter'],
+  smugglers_run: ['light_freighter', 'blockade_runner', 'salvage_rig'],
+  warpath: ['gunship', 'corvette_warfit', 'carrier_escort'],
+  deep_salvage: ['salvage_rig', 'light_freighter', 'scout_corvette'],
+  first_contact: ['survey_vessel', 'diplomatic_cruiser', 'scout_corvette'],
+  the_long_haul: ['long_range_cruiser', 'light_freighter', 'survey_vessel'],
+  ships_company: ['fleet_carrier', 'line_battleship', 'heavy_cruiser'],
+};
 
 const VOID_ODYSSEY_TURN_SYSTEM_PROMPT = `You are the narrator for Void Odyssey, an AI-driven space exploration game. You write in second person ("You step onto the bridge..."). The genre is hard-ish sci-fi — think Firefly meets Mass Effect: grounded crews, alien encounters, political tensions, moments of wonder.
 
@@ -2204,6 +2222,13 @@ exports.voidOdysseyNewGame = onCall(async (request) => {
   }
   if (!shipClass || !validShipClasses.includes(shipClass)) {
     throw new HttpsError('invalid-argument', 'Invalid ship class selection.');
+  }
+  // Enforce journey/ship pairing server-side so a modified client cannot pick
+  // any ship for any journey. Only journeys listed in VOID_ODYSSEY_JOURNEY_SHIPS
+  // are restricted; others (e.g. `custom`) pass through.
+  const allowedShipsForJourney = VOID_ODYSSEY_JOURNEY_SHIPS[difficulty];
+  if (allowedShipsForJourney && !allowedShipsForJourney.includes(shipClass)) {
+    throw new HttpsError('invalid-argument', 'Selected ship is not available for this journey.');
   }
   if (typeof shipName !== 'string' || shipName.trim().length === 0) {
     throw new HttpsError('invalid-argument', 'Ship name is required.');

--- a/functions/index.js
+++ b/functions/index.js
@@ -395,6 +395,18 @@ const VOID_ODYSSEY_TRAIT_IDS = [
   'stoic',
 ];
 
+// Roles selectable during game creation when difficulty === 'ships_company'.
+// Mirrors the roleOptions array in public/apps/void-odyssey/journeys.js.
+const VOID_ODYSSEY_SHIPS_COMPANY_ROLE_IDS = [
+  'fighter_pilot',
+  'weapons_officer',
+  'helmsman',
+  'chief_engineer',
+  'ships_surgeon',
+  'intelligence_analyst',
+  'marine_sergeant',
+];
+
 const VOID_ODYSSEY_TURN_SYSTEM_PROMPT = `You are the narrator for Void Odyssey, an AI-driven space exploration game. You write in second person ("You step onto the bridge..."). The genre is hard-ish sci-fi — think Firefly meets Mass Effect: grounded crews, alien encounters, political tensions, moments of wonder.
 
 You MUST respond with ONLY a valid JSON object. No prose outside the JSON. The schema is:
@@ -2155,6 +2167,7 @@ exports.voidOdysseyNewGame = onCall(async (request) => {
     captainSkills,
     shipClass,
     shipName,
+    captainRole,
   } = request.data || {};
 
   const validShipClasses = [
@@ -2200,6 +2213,19 @@ exports.voidOdysseyNewGame = onCall(async (request) => {
   }
   if (typeof captainBackstory === 'string' && captainBackstory.length > 400) {
     throw new HttpsError('invalid-argument', 'Backstory must be 400 characters or fewer.');
+  }
+
+  // Ship's Company: the player chooses a role aboard a capital vessel instead
+  // of naming the ship. Required when difficulty === 'ships_company', ignored otherwise.
+  let resolvedCharacterRole = 'captain';
+  if (difficulty === 'ships_company') {
+    if (!captainRole || !VOID_ODYSSEY_SHIPS_COMPANY_ROLE_IDS.includes(captainRole)) {
+      throw new HttpsError(
+        'invalid-argument',
+        "A valid role is required for the Ship's Company journey."
+      );
+    }
+    resolvedCharacterRole = captainRole;
   }
 
   // ── Validate skills (optional for legacy callers; required when provided) ──
@@ -2520,7 +2546,7 @@ Generate the opening scene, starting crew, location, quest hook, and first avail
 
     character: {
       name: captainName.trim(),
-      role: 'captain',
+      role: resolvedCharacterRole,
       traits: captainTraits,
       backstory: captainBackstory ? captainBackstory.trim() : '',
       stats: characterStats,

--- a/public/apps/void-odyssey/app.js
+++ b/public/apps/void-odyssey/app.js
@@ -379,6 +379,7 @@
       captainBackstory: '',
       shipClass: null,
       shipName: '',
+      captainRole: null,
     };
     VO.state.generatedGame = null;
     VO.showView('game-create');

--- a/public/apps/void-odyssey/game-create.js
+++ b/public/apps/void-odyssey/game-create.js
@@ -529,15 +529,31 @@
   }
 
   // Step 4: Choose your ship
-  // Stat bar normalization — derived from the max values across all 13 ships in
-  // public/apps/void-odyssey/ships.js. Hardcoded so we don't scan VO.SHIPS on every render.
-  var _STAT_BAR_MAX = {
-    hull: 200,
-    shields: 150,
-    fuel: 100,
-    cargo: 250,
-    crew: 200,
-  };
+  // Stat bar normalization — computed once from VO.SHIPS at module init so the
+  // bars stay in sync with ship data automatically. VO.SHIPS is an object keyed
+  // by ship id, with numeric stats under ship.stats.
+  function _computeStatBarMax() {
+    var maxes = { hull: 0, shields: 0, fuel: 0, cargo: 0, crew: 0 };
+    var ships = (VO && VO.SHIPS) || {};
+    Object.keys(ships).forEach(function (id) {
+      var stats = (ships[id] && ships[id].stats) || {};
+      if (stats.hullMax > maxes.hull) maxes.hull = stats.hullMax;
+      if (stats.shieldsMax > maxes.shields) maxes.shields = stats.shieldsMax;
+      if (stats.fuel > maxes.fuel) maxes.fuel = stats.fuel;
+      if (stats.cargoMax > maxes.cargo) maxes.cargo = stats.cargoMax;
+      if (stats.crewCapacity > maxes.crew) maxes.crew = stats.crewCapacity;
+    });
+    // Floors guard against an empty VO.SHIPS during unit testing or dev reload,
+    // preventing division-by-zero in the stat-bar percentage calc.
+    if (!maxes.hull) maxes.hull = 200;
+    if (!maxes.shields) maxes.shields = 150;
+    if (!maxes.fuel) maxes.fuel = 100;
+    if (!maxes.cargo) maxes.cargo = 250;
+    if (!maxes.crew) maxes.crew = 200;
+    return maxes;
+  }
+
+  var _STAT_BAR_MAX = _computeStatBarMax();
 
   // Tier labels per planning/void-odyssey-creation-amendment.md §8.3
   function _hullTier(v) {

--- a/public/apps/void-odyssey/game-create.js
+++ b/public/apps/void-odyssey/game-create.js
@@ -529,79 +529,256 @@
   }
 
   // Step 4: Choose your ship
+  // Stat bar normalization — derived from the max values across all 13 ships in
+  // public/apps/void-odyssey/ships.js. Hardcoded so we don't scan VO.SHIPS on every render.
+  var _STAT_BAR_MAX = {
+    hull: 200,
+    shields: 150,
+    fuel: 100,
+    cargo: 250,
+    crew: 200,
+  };
+
+  // Tier labels per planning/void-odyssey-creation-amendment.md §8.3
+  function _hullTier(v) {
+    if (v < 70) return 'Light';
+    if (v < 100) return 'Standard';
+    if (v < 140) return 'Heavy';
+    return 'Capital';
+  }
+  function _shieldTier(v) {
+    if (v < 50) return 'Minimal';
+    if (v < 80) return 'Standard';
+    if (v < 120) return 'Military';
+    return 'Capital';
+  }
+
+  function _statRow(label, value, max, tier) {
+    var pct = Math.max(0, Math.min(100, Math.round((value / max) * 100)));
+    return (
+      '<div class="ship-stat-row">' +
+      '<span class="ship-stat-label">' +
+      _esc(label) +
+      '</span>' +
+      (tier
+        ? '<span class="ship-stat-tier">' + _esc(tier) + '</span>'
+        : '<span class="ship-stat-tier ship-stat-tier--empty"></span>') +
+      '<span class="ship-stat-value">' +
+      value +
+      '</span>' +
+      '<span class="ship-stat-bar"><span class="ship-stat-bar-fill" style="width:' +
+      pct +
+      '%"></span></span>' +
+      '</div>'
+    );
+  }
+
+  function _loadoutSection(heading, items, formatter) {
+    if (!items || items.length === 0) return '';
+    var itemsHtml = items
+      .map(function (item) {
+        return '<li class="ship-loadout-item">' + formatter(item) + '</li>';
+      })
+      .join('');
+    return (
+      '<div class="ship-loadout-section">' +
+      '<div class="ship-loadout-heading">' +
+      _esc(heading) +
+      '</div>' +
+      '<ul class="ship-loadout-list">' +
+      itemsHtml +
+      '</ul>' +
+      '</div>'
+    );
+  }
+
   function _renderStep4(container) {
     var d = VO.state.wizardData;
 
+    // Guard: a journey must already be selected from Step 1
+    var journey = d.tone ? VO.JOURNEYS[d.tone] : null;
+    if (!journey) {
+      VO.renderWizardStep(1);
+      return;
+    }
+
+    var isShipsCompany = journey.id === 'ships_company';
+
+    // Resolve the 3 ships for this journey from VO.SHIPS, sorted by order
+    var ships = (journey.availableShips || [])
+      .map(function (id) {
+        return VO.SHIPS[id];
+      })
+      .filter(function (s) {
+        return !!s;
+      })
+      .sort(function (a, b) {
+        return (a.order || 0) - (b.order || 0);
+      });
+
     var html =
       '<h2 class="wizard-step-title">Choose Your Ship</h2>' +
-      '<p class="wizard-step-desc">Every captain needs a vessel. What\'s yours?</p>' +
+      '<p class="wizard-step-desc">' +
+      (isShipsCompany
+        ? 'Your assignment: pick a capital vessel, then choose your role aboard her.'
+        : "Every captain needs a vessel. What's yours?") +
+      '</p>' +
       '<div class="ship-grid">';
 
-    VO.SHIP_CLASSES.forEach(function (ship) {
+    ships.forEach(function (ship) {
       var selected = d.shipClass === ship.id;
+      var stats = ship.stats || {};
+
+      var statsHtml =
+        '<div class="ship-stat-block">' +
+        _statRow('Hull', stats.hullMax, _STAT_BAR_MAX.hull, _hullTier(stats.hullMax)) +
+        _statRow(
+          'Shields',
+          stats.shieldsMax,
+          _STAT_BAR_MAX.shields,
+          _shieldTier(stats.shieldsMax)
+        ) +
+        _statRow('Fuel', stats.fuel, _STAT_BAR_MAX.fuel, null) +
+        _statRow('Cargo Max', stats.cargoMax, _STAT_BAR_MAX.cargo, null) +
+        _statRow('Crew Capacity', stats.crewCapacity, _STAT_BAR_MAX.crew, null) +
+        '</div>';
+
+      var loadoutHtml =
+        '<div class="ship-loadout">' +
+        _loadoutSection('Weapons', ship.startingWeapons, function (w) {
+          var meta = [];
+          if (w.type) meta.push(w.type);
+          if (w.damage) meta.push(w.damage);
+          var metaHtml = meta.length
+            ? ' <span class="ship-loadout-meta">(' + _esc(meta.join(' · ')) + ')</span>'
+            : '';
+          return _esc(w.name || 'Unknown weapon') + metaHtml;
+        }) +
+        _loadoutSection('Systems', ship.startingSystems, function (s) {
+          return _esc(s.name || 'Unknown system');
+        }) +
+        _loadoutSection('Features', ship.startingFeatures, function (f) {
+          return _esc(f.name || 'Unknown feature');
+        }) +
+        '</div>';
+
       html +=
         '<button type="button" class="ship-card' +
         (selected ? ' selected' : '') +
         '" data-id="' +
-        ship.id +
+        _esc(ship.id) +
+        '" aria-pressed="' +
+        (selected ? 'true' : 'false') +
         '">' +
+        '<div class="ship-card-header">' +
         '<span class="ship-icon">' +
-        ship.icon +
+        _esc(ship.icon || '') +
         '</span>' +
         '<span class="ship-label">' +
-        ship.label +
-        '</span>' +
-        '<span class="ship-flavor">' +
-        ship.flavor +
-        '</span>' +
-        '<div class="ship-stats">' +
-        '<span class="ship-stat">Hull ' +
-        ship.stats.hullMax +
-        '</span>' +
-        '<span class="ship-stat">Cargo ' +
-        ship.stats.cargoMax +
-        '</span>' +
-        '<span class="ship-stat">Shields ' +
-        ship.stats.shieldsMax +
+        _esc(ship.className || '') +
         '</span>' +
         '</div>' +
+        '<p class="ship-flavor">' +
+        _esc(ship.description || '') +
+        '</p>' +
+        statsHtml +
+        loadoutHtml +
         '</button>';
     });
 
+    html += '</div>';
+
+    // Details region — ship name input OR role selector, depending on journey
+    if (isShipsCompany) {
+      var roles = journey.roleOptions || [];
+      var roleCardsHtml = roles
+        .map(function (role) {
+          var roleSelected = d.captainRole === role.id;
+          return (
+            '<button type="button" class="role-card' +
+            (roleSelected ? ' selected' : '') +
+            '" data-role-id="' +
+            _esc(role.id) +
+            '" aria-pressed="' +
+            (roleSelected ? 'true' : 'false') +
+            '">' +
+            '<span class="role-name">' +
+            _esc(role.name || '') +
+            '</span>' +
+            '<span class="role-focus">' +
+            _esc(role.focus || '') +
+            '</span>' +
+            '</button>'
+          );
+        })
+        .join('');
+
+      html +=
+        '<div class="form-group" id="role-selector-group" style="' +
+        (d.shipClass ? '' : 'display:none') +
+        '">' +
+        '<label class="form-label">Choose Your Role</label>' +
+        '<p class="form-hint">The ship already has a name and a history. You bring expertise and a chain of command.</p>' +
+        '<div class="role-selector">' +
+        roleCardsHtml +
+        '</div>' +
+        '</div>';
+    } else {
+      html +=
+        '<div class="form-group" id="ship-name-group" style="' +
+        (d.shipClass ? '' : 'display:none') +
+        '">' +
+        '<label class="form-label" for="ship-name">Name Your Ship</label>' +
+        '<input type="text" id="ship-name" class="form-input" placeholder="e.g. The Daedalus" maxlength="60" value="' +
+        _esc(d.shipName) +
+        '">' +
+        '</div>';
+    }
+
+    // Nav buttons
+    var nextDisabled;
+    if (!d.shipClass) {
+      nextDisabled = true;
+    } else if (isShipsCompany) {
+      nextDisabled = !d.captainRole;
+    } else {
+      nextDisabled = !(d.shipName && d.shipName.trim());
+    }
+
     html +=
-      '</div>' +
-      '<div class="form-group" id="ship-name-group" style="' +
-      (d.shipClass ? '' : 'display:none') +
-      '">' +
-      '<label class="form-label" for="ship-name">Name Your Ship</label>' +
-      '<input type="text" id="ship-name" class="form-input" placeholder="e.g. The Daedalus" maxlength="60" value="' +
-      _esc(d.shipName) +
-      '">' +
-      '</div>' +
       '<div class="wizard-nav">' +
       '<button type="button" class="btn btn-secondary" id="step4-back">← Back</button>' +
       '<button type="button" class="btn btn-primary" id="step4-next"' +
-      (d.shipClass ? '' : ' disabled') +
+      (nextDisabled ? ' disabled' : '') +
       '>Next →</button>' +
       '</div>';
 
     container.innerHTML = html;
 
+    // Wire ship card clicks — re-render so the details region and Next button
+    // always reflect the latest wizardData (matches the Step 3 pattern).
     container.querySelectorAll('.ship-card').forEach(function (card) {
       card.addEventListener('click', function () {
         d.shipClass = card.dataset.id;
-        container.querySelectorAll('.ship-card').forEach(function (c) {
-          c.classList.toggle('selected', c.dataset.id === d.shipClass);
-        });
-        document.getElementById('ship-name-group').style.display = '';
-        document.getElementById('step4-next').disabled = false;
+        _renderStep4(container);
       });
     });
 
+    // Wire role card clicks (ships_company only)
+    container.querySelectorAll('.role-card').forEach(function (card) {
+      card.addEventListener('click', function () {
+        d.captainRole = card.dataset.roleId;
+        _renderStep4(container);
+      });
+    });
+
+    // Wire ship-name input (non-ships_company only)
     var shipNameInput = document.getElementById('ship-name');
     if (shipNameInput) {
       shipNameInput.addEventListener('input', function () {
         d.shipName = shipNameInput.value;
+        var nextBtn = document.getElementById('step4-next');
+        if (nextBtn) nextBtn.disabled = !(d.shipClass && d.shipName.trim());
       });
     }
 
@@ -611,13 +788,26 @@
 
     document.getElementById('step4-next').addEventListener('click', function () {
       if (!d.shipClass) return;
-      var name =
-        document.getElementById('ship-name') && document.getElementById('ship-name').value.trim();
-      if (!name) {
-        _showFieldError('ship-name', 'Please name your ship.');
-        return;
+
+      if (isShipsCompany) {
+        if (!d.captainRole) return;
+        // Auto-populate shipName with the canonical class name so the existing
+        // backend shipName required-field validation is satisfied. For ships_company,
+        // the vessel already has a name and history — the player does not name it.
+        var selectedShip = VO.SHIPS[d.shipClass];
+        if (selectedShip && selectedShip.className) {
+          d.shipName = selectedShip.className;
+        }
+      } else {
+        var input = document.getElementById('ship-name');
+        var name = input && input.value.trim();
+        if (!name) {
+          _showFieldError('ship-name', 'Please name your ship.');
+          return;
+        }
+        d.shipName = name;
       }
-      d.shipName = name;
+
       VO.renderWizardStep(5);
     });
   }
@@ -646,6 +836,7 @@
       captainBackstory: d.captainBackstory,
       shipClass: d.shipClass,
       shipName: d.shipName,
+      captainRole: d.captainRole,
     })
       .then(function (result) {
         VO.state.generatedGame = result.data;

--- a/public/apps/void-odyssey/state.js
+++ b/public/apps/void-odyssey/state.js
@@ -322,6 +322,7 @@
       captainBackstory: '',
       shipClass: null,
       shipName: '',
+      captainRole: null,
     },
     // After Cloud Function returns (steps 6-7)
     generatedCrew: null,

--- a/public/apps/void-odyssey/styles.css
+++ b/public/apps/void-odyssey/styles.css
@@ -706,6 +706,162 @@
   color: #90a4ae;
 }
 
+.ship-card-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.ship-stat-block {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  margin-top: 0.25rem;
+}
+
+.ship-stat-row {
+  display: grid;
+  grid-template-columns: 5.5rem 4.5rem 2.25rem 1fr;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.72rem;
+  color: #b0bec5;
+}
+
+.ship-stat-label {
+  color: #90a4ae;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.ship-stat-tier {
+  color: #ffd54f;
+  font-size: 0.68rem;
+  font-weight: 600;
+}
+
+.ship-stat-tier--empty {
+  color: transparent;
+}
+
+.ship-stat-value {
+  color: #e0e0e0;
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+}
+
+.ship-stat-bar {
+  display: block;
+  height: 5px;
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 3px;
+  overflow: hidden;
+  min-width: 40px;
+}
+
+.ship-stat-bar-fill {
+  display: block;
+  height: 100%;
+  background: #ffb74d;
+  border-radius: 3px;
+}
+
+.ship-loadout {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+  padding-top: 0.5rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.ship-loadout-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.ship-loadout-heading {
+  font-size: 0.68rem;
+  color: #90a4ae;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.ship-loadout-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+}
+
+.ship-loadout-item {
+  font-size: 0.75rem;
+  color: #cfd8dc;
+  line-height: 1.35;
+}
+
+.ship-loadout-meta {
+  color: #78909c;
+  font-size: 0.7rem;
+}
+
+/* ── Role selector (Ship's Company) ──────────────────────── */
+
+.form-hint {
+  margin: 0.2rem 0 0.6rem;
+  font-size: 0.78rem;
+  color: #78909c;
+}
+
+.role-selector {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 0.6rem;
+}
+
+.role-card {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 10px;
+  padding: 0.9rem 1rem;
+  text-align: left;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  color: #e0e0e0;
+  transition:
+    border-color 0.18s,
+    background 0.18s;
+}
+
+.role-card:hover {
+  border-color: rgba(255, 183, 77, 0.35);
+  background: rgba(255, 183, 77, 0.05);
+}
+
+.role-card.selected {
+  border-color: #ffb74d;
+  background: rgba(255, 183, 77, 0.1);
+}
+
+.role-name {
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #ffd54f;
+}
+
+.role-focus {
+  font-size: 0.78rem;
+  color: #90a4ae;
+  line-height: 1.4;
+}
+
 /* ── Crew preview ────────────────────────────────────────── */
 
 .crew-preview-list {

--- a/tests/void-odyssey-constants.test.js
+++ b/tests/void-odyssey-constants.test.js
@@ -1,0 +1,122 @@
+'use strict';
+
+/**
+ * Drift tests for Void Odyssey constants that exist in two places:
+ *
+ *   • Frontend source of truth: public/apps/void-odyssey/journeys.js
+ *       (attached to window.VoidOdyssey.JOURNEYS via an IIFE)
+ *   • Backend source of truth: functions/index.js
+ *       (VOID_ODYSSEY_SHIPS_COMPANY_ROLE_IDS and VOID_ODYSSEY_JOURNEY_SHIPS)
+ *
+ * The frontend is a zero-build-step static bundle (no shared module system
+ * with the Cloud Functions backend), so we load the frontend file in a VM
+ * sandbox with a fake `window` global, then compare the resulting data
+ * structures against the backend constants. This catches drift before it
+ * reaches production as a confusing "invalid-argument" error for a selection
+ * the UI legitimately allowed.
+ *
+ * Run: cd tests && npx jest void-odyssey-constants --verbose
+ */
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const JOURNEYS_FILE = path.join(REPO_ROOT, 'public', 'apps', 'void-odyssey', 'journeys.js');
+const FUNCTIONS_FILE = path.join(REPO_ROOT, 'functions', 'index.js');
+
+// ── Load frontend VO.JOURNEYS by executing journeys.js in a VM sandbox ─────
+
+function loadFrontendJourneys() {
+  const source = fs.readFileSync(JOURNEYS_FILE, 'utf8');
+  const sandbox = { window: {} };
+  vm.createContext(sandbox);
+  vm.runInContext(source, sandbox, { filename: 'journeys.js' });
+  const journeys = sandbox.window.VoidOdyssey && sandbox.window.VoidOdyssey.JOURNEYS;
+  if (!journeys) {
+    throw new Error('Failed to load VO.JOURNEYS from journeys.js');
+  }
+  return journeys;
+}
+
+// ── Extract a named JS constant from functions/index.js by textual parse ──
+//
+// We deliberately avoid `require('../functions')` because functions/index.js
+// pulls in firebase-admin, vertexai, etc. at load time. A lightweight regex
+// extract of the constant declaration lets us assert drift without that cost.
+
+function extractConstant(source, name) {
+  // Match `const NAME = { ... };` or `const NAME = [ ... ];` at top level.
+  // We rely on the convention that these constants live at column 0 and are
+  // closed by a line that is exactly `};` or `];`.
+  const startRe = new RegExp('^const ' + name + '\\s*=\\s*([\\[\\{])', 'm');
+  const startMatch = startRe.exec(source);
+  if (!startMatch) {
+    throw new Error('Could not locate constant ' + name + ' in ' + FUNCTIONS_FILE);
+  }
+  const openChar = startMatch[1];
+  const closeChar = openChar === '[' ? ']' : '}';
+  const startIdx = startMatch.index + startMatch[0].length - 1;
+  let depth = 0;
+  let i = startIdx;
+  for (; i < source.length; i++) {
+    const c = source[i];
+    if (c === openChar) depth++;
+    else if (c === closeChar) {
+      depth--;
+      if (depth === 0) break;
+    }
+  }
+  if (depth !== 0) {
+    throw new Error('Unbalanced braces for constant ' + name);
+  }
+  const literal = source.slice(startIdx, i + 1);
+  // Evaluate the literal in a sandbox — it's pure JSON-ish data with string
+  // keys and array/object values, no code execution.
+  return vm.runInNewContext('(' + literal + ')');
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+
+describe('Void Odyssey frontend/backend constant drift', () => {
+  let frontendJourneys;
+  let functionsSource;
+
+  beforeAll(() => {
+    frontendJourneys = loadFrontendJourneys();
+    functionsSource = fs.readFileSync(FUNCTIONS_FILE, 'utf8');
+  });
+
+  test("VOID_ODYSSEY_SHIPS_COMPANY_ROLE_IDS matches journey ships_company roleOptions", () => {
+    const backendRoleIds = extractConstant(
+      functionsSource,
+      'VOID_ODYSSEY_SHIPS_COMPANY_ROLE_IDS'
+    );
+    const frontendRoleIds = (frontendJourneys.ships_company.roleOptions || []).map((r) => r.id);
+
+    expect(Array.isArray(backendRoleIds)).toBe(true);
+    expect([...backendRoleIds].sort()).toEqual([...frontendRoleIds].sort());
+  });
+
+  test('VOID_ODYSSEY_JOURNEY_SHIPS matches every journey.availableShips in journeys.js', () => {
+    const backendJourneyShips = extractConstant(functionsSource, 'VOID_ODYSSEY_JOURNEY_SHIPS');
+
+    // Every restricted journey in the backend must match the frontend list exactly.
+    Object.keys(backendJourneyShips).forEach((journeyId) => {
+      const frontendJourney = frontendJourneys[journeyId];
+      expect(frontendJourney).toBeDefined();
+      expect([...backendJourneyShips[journeyId]].sort()).toEqual(
+        [...(frontendJourney.availableShips || [])].sort()
+      );
+    });
+
+    // Every frontend journey (except `custom`, which is intentionally excluded
+    // from the backend allowlist because it is not selectable in Step 1) must
+    // have a corresponding backend entry.
+    Object.keys(frontendJourneys).forEach((journeyId) => {
+      if (journeyId === 'custom') return;
+      expect(backendJourneyShips[journeyId]).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
Replace the placeholder ship picker with a journey-filtered card grid that
surfaces each ship's full loadout. Ship cards now read from VO.SHIPS (the
13-ship authoritative registry) filtered by the selected journey's
availableShips array, and render hull/shields tier labels alongside numeric
stat bars for hull, shields, fuel, cargo max, and crew capacity plus the
starting weapons, systems, and features lists.

For the Ship's Company journey the name input is replaced with a role
selector — Fighter Pilot, Weapons Officer, Helmsman, Chief Engineer,
Ship's Surgeon, Intelligence Analyst, or Marine Sergeant — and the ship's
class name is used in lieu of a player-chosen name, matching the design
spec's "the ship already has a name and history" constraint.

The selected captainRole is plumbed through wizard state and the
voidOdysseyNewGame callable, where it replaces the hardcoded
character.role = 'captain' default for Ship's Company games. The turn
function already reads character.role to filter the narrative lens, so no
downstream changes are needed.

https://claude.ai/code/session_01Wf6kTs9W6uWAD7xFWMDRvp