### PR TITLE
chore(functions): migrate Void Odyssey AI to @google/genai SDK

### DIFF
--- a/functions/gemini.js
+++ b/functions/gemini.js
@@ -8,7 +8,8 @@ let genAIClient;
 function getClient() {
   if (!genAIClient) {
     const { getApps } = require('firebase-admin/app');
-    const app = getApps().length > 0 ? getApps()[0] : null;
+    const apps = getApps();
+    const app = apps.length > 0 ? apps[0] : null;
     const projectId =
       process.env.GCLOUD_PROJECT ||
       process.env.GCP_PROJECT ||

--- a/functions/gemini.js
+++ b/functions/gemini.js
@@ -1,21 +1,25 @@
 'use strict';
 
-const { VertexAI } = require('@google-cloud/vertexai');
+const { GoogleGenAI } = require('@google/genai');
 const { HttpsError } = require('firebase-functions/v2/https');
 
-let vertexAI;
+let genAIClient;
 
-function getVertexAI() {
-  if (!vertexAI) {
+function getClient() {
+  if (!genAIClient) {
     const { getApps } = require('firebase-admin/app');
     const app = getApps().length > 0 ? getApps()[0] : null;
     const projectId =
       process.env.GCLOUD_PROJECT ||
       process.env.GCP_PROJECT ||
       (app && app.options && app.options.projectId);
-    vertexAI = new VertexAI({ project: projectId, location: 'us-central1' });
+    genAIClient = new GoogleGenAI({
+      vertexai: true,
+      project: projectId,
+      location: 'us-central1',
+    });
   }
-  return vertexAI;
+  return genAIClient;
 }
 
 /**
@@ -31,20 +35,17 @@ async function callGemini({
   jsonMode = true,
 }) {
   try {
-    const model = getVertexAI().getGenerativeModel({
+    const response = await getClient().models.generateContent({
       model: modelName,
-      systemInstruction: { parts: [{ text: systemInstruction }] },
-      generationConfig: {
+      contents: [{ role: 'user', parts: [{ text: userMessage }] }],
+      config: {
+        systemInstruction,
         maxOutputTokens,
         ...(jsonMode && { responseMimeType: 'application/json' }),
       },
     });
 
-    const result = await model.generateContent({
-      contents: [{ role: 'user', parts: [{ text: userMessage }] }],
-    });
-
-    const candidate = result.response?.candidates?.[0];
+    const candidate = response.candidates?.[0];
     const finishReason = candidate?.finishReason;
     if (finishReason === 'MAX_TOKENS') {
       console.error('callGemini: response truncated by MAX_TOKENS');
@@ -53,7 +54,7 @@ async function callGemini({
       });
     }
 
-    const rawText = candidate?.content?.parts?.[0]?.text;
+    const rawText = response.text;
     if (!rawText) {
       throw new HttpsError('internal', 'Empty response from AI.');
     }

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -8,7 +8,7 @@
       "name": "olympus-functions",
       "version": "0.1.0",
       "dependencies": {
-        "@google-cloud/vertexai": "^1.9.0",
+        "@google/genai": "^1.0.0",
         "firebase-admin": "^13.0.0",
         "firebase-functions": "^6.0.0",
         "google-auth-library": "^9.0.0"
@@ -210,19 +210,6 @@
       "optional": true,
       "bin": {
         "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/@google-cloud/vertexai": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/@google-cloud/vertexai/-/vertexai-1.10.3.tgz",
-      "integrity": "sha512-YcEaYPyUVVRz4adNiR4jQQeq/XSOUwH6SERL7NGdZlCXKY+7BofFQpcd71HgdSkzTgERcVQ3TZquNwXNqlTQXQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@google/genai": "^1.45.0",
-        "google-auth-library": "^9.1.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@google/genai": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -8,7 +8,7 @@
     "node": "22"
   },
   "dependencies": {
-    "@google-cloud/vertexai": "^1.9.0",
+    "@google/genai": "^1.0.0",
     "firebase-admin": "^13.0.0",
     "firebase-functions": "^6.0.0",
     "google-auth-library": "^9.0.0"

--- a/tests/gemini.test.js
+++ b/tests/gemini.test.js
@@ -9,8 +9,8 @@
  * Run: cd tests && npx jest gemini --verbose
  */
 
-// Set project env var BEFORE any require so getClient() uses it directly
-// and skips the firebase-admin/app lookup.
+// Set project env var BEFORE any require so getClient() reads the projectId
+// from the environment instead of from the Firebase admin app options.
 process.env.GCLOUD_PROJECT = 'test-project';
 
 // Mock GoogleGenAI before requiring gemini.js.

--- a/tests/gemini.test.js
+++ b/tests/gemini.test.js
@@ -3,30 +3,30 @@
 /**
  * Unit tests for functions/gemini.js
  *
- * Mocks @google-cloud/vertexai to test callGemini in isolation.
+ * Mocks @google/genai to test callGemini in isolation.
  * Does not require the Firestore emulator.
  *
  * Run: cd tests && npx jest gemini --verbose
  */
 
-// Set project env var BEFORE any require so getVertexAI() uses it directly
+// Set project env var BEFORE any require so getClient() uses it directly
 // and skips the firebase-admin/app lookup.
 process.env.GCLOUD_PROJECT = 'test-project';
 
-// Mock VertexAI before requiring gemini.js.
+// Mock GoogleGenAI before requiring gemini.js.
 const mockGenerateContent = jest.fn();
-const mockGetGenerativeModel = jest.fn(() => ({ generateContent: mockGenerateContent }));
-jest.mock('@google-cloud/vertexai', () => ({
-  VertexAI: jest.fn(() => ({ getGenerativeModel: mockGetGenerativeModel })),
+jest.mock('@google/genai', () => ({
+  GoogleGenAI: jest.fn(() => ({
+    models: { generateContent: mockGenerateContent },
+  })),
 }));
 
 const { callGemini } = require('../functions/gemini');
 
-function makeVertexResponse({ text, finishReason = 'STOP' }) {
+function makeGenAiResponse({ text, finishReason = 'STOP' }) {
   return {
-    response: {
-      candidates: [{ finishReason, content: { parts: [{ text }] } }],
-    },
+    text,
+    candidates: [{ finishReason, content: { parts: [{ text }] } }],
   };
 }
 
@@ -37,7 +37,7 @@ beforeEach(() => {
 describe('callGemini', () => {
   test('returns parsed JSON for a normal response', async () => {
     const payload = { narrative: 'You dock at the station.', mood: 'calm' };
-    mockGenerateContent.mockResolvedValue(makeVertexResponse({ text: JSON.stringify(payload) }));
+    mockGenerateContent.mockResolvedValue(makeGenAiResponse({ text: JSON.stringify(payload) }));
 
     const result = await callGemini({
       modelName: 'gemini-2.5-flash',
@@ -47,12 +47,23 @@ describe('callGemini', () => {
     });
 
     expect(result).toEqual(payload);
+    // Verify the new flat SDK call shape — guards against reverting to the
+    // old nested @google-cloud/vertexai API.
+    expect(mockGenerateContent).toHaveBeenCalledWith({
+      model: 'gemini-2.5-flash',
+      contents: [{ role: 'user', parts: [{ text: 'Do something.' }] }],
+      config: {
+        systemInstruction: 'You are a narrator.',
+        maxOutputTokens: 1024,
+        responseMimeType: 'application/json',
+      },
+    });
   });
 
   test('strips markdown fences before parsing JSON', async () => {
     const payload = { narrative: 'Engines fire.' };
     const fenced = '```json\n' + JSON.stringify(payload) + '\n```';
-    mockGenerateContent.mockResolvedValue(makeVertexResponse({ text: fenced }));
+    mockGenerateContent.mockResolvedValue(makeGenAiResponse({ text: fenced }));
 
     const result = await callGemini({
       modelName: 'gemini-2.5-flash',
@@ -65,7 +76,7 @@ describe('callGemini', () => {
   });
 
   test('returns raw text when jsonMode is false', async () => {
-    mockGenerateContent.mockResolvedValue(makeVertexResponse({ text: 'plain text response' }));
+    mockGenerateContent.mockResolvedValue(makeGenAiResponse({ text: 'plain text response' }));
 
     const result = await callGemini({
       modelName: 'gemini-2.5-flash',
@@ -76,11 +87,16 @@ describe('callGemini', () => {
     });
 
     expect(result).toBe('plain text response');
+    // responseMimeType must be omitted when jsonMode is false.
+    expect(mockGenerateContent.mock.calls[0][0].config).toEqual({
+      systemInstruction: 'sys',
+      maxOutputTokens: 256,
+    });
   });
 
   test('throws resource-exhausted HttpsError when finishReason is MAX_TOKENS', async () => {
     mockGenerateContent.mockResolvedValue(
-      makeVertexResponse({ text: '{"narrative": "truncated', finishReason: 'MAX_TOKENS' })
+      makeGenAiResponse({ text: '{"narrative": "truncated', finishReason: 'MAX_TOKENS' })
     );
 
     await expect(
@@ -97,7 +113,7 @@ describe('callGemini', () => {
   });
 
   test('throws internal HttpsError when response text is empty', async () => {
-    mockGenerateContent.mockResolvedValue({ response: { candidates: [] } });
+    mockGenerateContent.mockResolvedValue({ candidates: [] });
 
     await expect(
       callGemini({


### PR DESCRIPTION
The @google-cloud/vertexai package was deprecated on 2025-06-24 with a
hard shutdown date of 2026-06-24. Swap to the unified Google Gen AI SDK
(@google/genai) using the Vertex AI backend. The gemini-2.5-flash model
ID and all call-site behavior are unchanged — callGemini preserves the
same signature, error contract, markdown-fence stripping, and
MAX_TOKENS handling.

https://claude.ai/code/session_01W3nftf4StHnw9qnUXfesq5