### PR TITLE
feat(void-odyssey): add editable AI crew generation at wizard step 5

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -425,6 +425,24 @@ const VOID_ODYSSEY_JOURNEY_SHIPS = {
   ships_company: ['fleet_carrier', 'line_battleship', 'heavy_cruiser'],
 };
 
+// All valid ship class IDs. Used for input validation in voidOdysseyGenerateCrew
+// and voidOdysseyNewGame — kept in one place so additions stay in sync.
+const VOID_ODYSSEY_SHIP_CLASS_IDS = [
+  'light_freighter',
+  'scout_corvette',
+  'gunship',
+  'salvage_rig',
+  'survey_vessel',
+  'blockade_runner',
+  'corvette_warfit',
+  'carrier_escort',
+  'diplomatic_cruiser',
+  'long_range_cruiser',
+  'fleet_carrier',
+  'line_battleship',
+  'heavy_cruiser',
+];
+
 const VOID_ODYSSEY_TURN_SYSTEM_PROMPT = `You are the narrator for Void Odyssey, an AI-driven space exploration game. You write in second person ("You step onto the bridge..."). The genre is hard-ish sci-fi — think Firefly meets Mass Effect: grounded crews, alien encounters, political tensions, moments of wonder.
 
 You MUST respond with ONLY a valid JSON object. No prose outside the JSON. The schema is:
@@ -2156,6 +2174,8 @@ Traits: ${captainTraits.join(', ')}`;
  *   journey: string            — journey / tone ID
  *   captainName: string        — captain name (for prompt context)
  *   captainTraits: string[]    — 2-3 trait IDs
+ *   captainSkills: object?     — {skillId: level} skill allocations (for prompt context)
+ *   captainBackstory: string?  — optional backstory (for prompt context)
  *   shipClass: string          — ship class ID
  *   captainRole: string?       — role ID, required for ships_company journey
  *
@@ -2173,7 +2193,15 @@ exports.voidOdysseyGenerateCrew = onCall(async (request) => {
   }
 
   // ── Input validation ───────────────────────────────────────
-  const { journey, captainName, captainTraits, shipClass, captainRole } = request.data || {};
+  const {
+    journey,
+    captainName,
+    captainTraits,
+    captainSkills,
+    captainBackstory,
+    shipClass,
+    captainRole,
+  } = request.data || {};
 
   if (!journey || !VOID_ODYSSEY_JOURNEY_IDS.includes(journey)) {
     throw new HttpsError('invalid-argument', 'Invalid journey selection.');
@@ -2184,23 +2212,7 @@ exports.voidOdysseyGenerateCrew = onCall(async (request) => {
   if (!captainTraits.every((t) => VOID_ODYSSEY_TRAIT_IDS.includes(t))) {
     throw new HttpsError('invalid-argument', 'Invalid captain trait selection.');
   }
-
-  const validShipClasses = [
-    'light_freighter',
-    'scout_corvette',
-    'gunship',
-    'salvage_rig',
-    'survey_vessel',
-    'blockade_runner',
-    'corvette_warfit',
-    'carrier_escort',
-    'diplomatic_cruiser',
-    'long_range_cruiser',
-    'fleet_carrier',
-    'line_battleship',
-    'heavy_cruiser',
-  ];
-  if (!shipClass || !validShipClasses.includes(shipClass)) {
+  if (!shipClass || !VOID_ODYSSEY_SHIP_CLASS_IDS.includes(shipClass)) {
     throw new HttpsError('invalid-argument', 'Invalid ship class selection.');
   }
 
@@ -2286,6 +2298,25 @@ exports.voidOdysseyGenerateCrew = onCall(async (request) => {
       ? `Captain's role aboard the ship: ${captainRole}`
       : '';
 
+  // Summarise non-zero skills so the AI can tailor crew to complement the captain.
+  const skillsLine = (() => {
+    if (!captainSkills || typeof captainSkills !== 'object' || Array.isArray(captainSkills)) {
+      return '';
+    }
+    const notable = Object.entries(captainSkills)
+      .filter(([, lvl]) => typeof lvl === 'number' && lvl > 0)
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 5)
+      .map(([id, lvl]) => `${id} (lv${lvl})`)
+      .join(', ');
+    return notable ? `Captain's skills: ${notable}` : '';
+  })();
+
+  const backstoryLine =
+    typeof captainBackstory === 'string' && captainBackstory.trim()
+      ? `Captain's backstory: ${captainBackstory.trim().slice(0, 400)}`
+      : '';
+
   const systemPrompt = `You generate starting crew members for Void Odyssey, an AI-driven space exploration game set in a hard-ish sci-fi universe (Firefly meets Mass Effect — grounded crews, alien encounters, political tensions, moments of wonder).
 
 You MUST respond with ONLY a valid JSON object. No prose outside the JSON. The schema is:
@@ -2302,6 +2333,7 @@ You MUST respond with ONLY a valid JSON object. No prose outside the JSON. The s
 Constraints:
 - Generate exactly 2-3 crew members appropriate for the ship class and journey tone
 - Each crew member should fill a distinct operational need for the ship
+- Consider the captain's skills when choosing crew roles — crew should complement, not duplicate, the captain's strengths
 - Match crew personalities and backgrounds to the journey's themes
 - Names should feel plausible for a near-future sci-fi setting (human or alien-inspired)
 - Bios should be specific and evocative — a hint of history, a quirk, a reason they're on this ship
@@ -2317,6 +2349,8 @@ Ship: ${shipClassLabels[shipClass]}
 
 ${captainLine}
 Captain's traits: ${captainTraits.join(', ')}
+${skillsLine}
+${backstoryLine}
 ${roleLine}
 
 Produce crew that fit this ship's operational needs and this journey's tone. A ${jd.name.toLowerCase()} crew should feel distinct from a warpath crew.`;
@@ -2342,14 +2376,20 @@ Produce crew that fit this ship's operational needs and this journey's tone. A $
   }
 
   const validRoles = ['pilot', 'engineer', 'medic', 'gunner', 'science', 'general'];
-  const crew = crewRaw.map((m) => ({
-    name: typeof m.name === 'string' && m.name.trim() ? m.name.trim().slice(0, 60) : 'Crew Member',
-    role: validRoles.includes(m.role) ? m.role : 'general',
-    description:
-      typeof m.description === 'string' && m.description.trim()
-        ? m.description.trim().slice(0, 500)
-        : '',
-  }));
+  const crew = crewRaw.map((m) => {
+    if (!m || typeof m !== 'object') {
+      throw new HttpsError('internal', 'AI returned an invalid crew member.');
+    }
+    return {
+      name:
+        typeof m.name === 'string' && m.name.trim() ? m.name.trim().slice(0, 60) : 'Crew Member',
+      role: validRoles.includes(m.role) ? m.role : 'general',
+      description:
+        typeof m.description === 'string' && m.description.trim()
+          ? m.description.trim().slice(0, 500)
+          : '',
+    };
+  });
 
   return { crew };
 });
@@ -2402,22 +2442,6 @@ exports.voidOdysseyNewGame = onCall(async (request) => {
     crew: preGeneratedCrew,
   } = request.data || {};
 
-  const validShipClasses = [
-    'light_freighter',
-    'scout_corvette',
-    'gunship',
-    'salvage_rig',
-    'survey_vessel',
-    'blockade_runner',
-    'corvette_warfit',
-    'carrier_escort',
-    'diplomatic_cruiser',
-    'long_range_cruiser',
-    'fleet_carrier',
-    'line_battleship',
-    'heavy_cruiser',
-  ];
-
   if (!difficulty || !VOID_ODYSSEY_JOURNEY_IDS.includes(difficulty)) {
     throw new HttpsError('invalid-argument', 'Invalid difficulty selection.');
   }
@@ -2434,7 +2458,7 @@ exports.voidOdysseyNewGame = onCall(async (request) => {
   if (!captainTraits.every((t) => VOID_ODYSSEY_TRAIT_IDS.includes(t))) {
     throw new HttpsError('invalid-argument', 'Invalid captain trait selection.');
   }
-  if (!shipClass || !validShipClasses.includes(shipClass)) {
+  if (!shipClass || !VOID_ODYSSEY_SHIP_CLASS_IDS.includes(shipClass)) {
     throw new HttpsError('invalid-argument', 'Invalid ship class selection.');
   }
   // Enforce journey/ship pairing server-side so a modified client cannot pick
@@ -2529,6 +2553,9 @@ exports.voidOdysseyNewGame = onCall(async (request) => {
       throw new HttpsError('invalid-argument', 'crew must be an array of 2–3 members.');
     }
     resolvedPreGeneratedCrew = preGeneratedCrew.map((m) => {
+      if (!m || typeof m !== 'object') {
+        throw new HttpsError('invalid-argument', 'Each crew member must be an object.');
+      }
       if (typeof m.name !== 'string' || !m.name.trim()) {
         throw new HttpsError('invalid-argument', 'Each crew member must have a name.');
       }

--- a/functions/index.js
+++ b/functions/index.js
@@ -2145,6 +2145,216 @@ Traits: ${captainTraits.join(', ')}`;
 });
 
 /**
+ * voidOdysseyGenerateCrew — generates 2–3 starting crew members for the wizard.
+ *
+ * Lightweight: no Firestore writes. Called at Step 5; the crew is passed to
+ * voidOdysseyNewGame at Step 6 so the player can edit names/bios first.
+ *
+ * Caller must be authenticated and have the 'void-odyssey' app claim.
+ *
+ * Data:
+ *   journey: string            — journey / tone ID
+ *   captainName: string        — captain name (for prompt context)
+ *   captainTraits: string[]    — 2-3 trait IDs
+ *   shipClass: string          — ship class ID
+ *   captainRole: string?       — role ID, required for ships_company journey
+ *
+ * Returns:
+ *   crew: { name, role, description }[]  — 2–3 crew members
+ */
+exports.voidOdysseyGenerateCrew = onCall(async (request) => {
+  // ── Auth + claim check ─────────────────────────────────────
+  if (!request.auth) {
+    throw new HttpsError('unauthenticated', 'You must be signed in to play Void Odyssey.');
+  }
+  const tokenApps = request.auth.token.apps;
+  if (!Array.isArray(tokenApps) || !tokenApps.includes('void-odyssey')) {
+    throw new HttpsError('permission-denied', "You don't have access to Void Odyssey.");
+  }
+
+  // ── Input validation ───────────────────────────────────────
+  const { journey, captainName, captainTraits, shipClass, captainRole } = request.data || {};
+
+  if (!journey || !VOID_ODYSSEY_JOURNEY_IDS.includes(journey)) {
+    throw new HttpsError('invalid-argument', 'Invalid journey selection.');
+  }
+  if (!Array.isArray(captainTraits) || captainTraits.length < 2 || captainTraits.length > 3) {
+    throw new HttpsError('invalid-argument', 'Select 2–3 captain traits.');
+  }
+  if (!captainTraits.every((t) => VOID_ODYSSEY_TRAIT_IDS.includes(t))) {
+    throw new HttpsError('invalid-argument', 'Invalid captain trait selection.');
+  }
+
+  const validShipClasses = [
+    'light_freighter',
+    'scout_corvette',
+    'gunship',
+    'salvage_rig',
+    'survey_vessel',
+    'blockade_runner',
+    'corvette_warfit',
+    'carrier_escort',
+    'diplomatic_cruiser',
+    'long_range_cruiser',
+    'fleet_carrier',
+    'line_battleship',
+    'heavy_cruiser',
+  ];
+  if (!shipClass || !validShipClasses.includes(shipClass)) {
+    throw new HttpsError('invalid-argument', 'Invalid ship class selection.');
+  }
+
+  if (journey === 'ships_company') {
+    if (!captainRole || !VOID_ODYSSEY_SHIPS_COMPANY_ROLE_IDS.includes(captainRole)) {
+      throw new HttpsError(
+        'invalid-argument',
+        "A valid role is required for the Ship's Company journey."
+      );
+    }
+  }
+
+  // ── Build AI prompt ────────────────────────────────────────
+  const journeyDetails = {
+    frontier_explorer: {
+      name: 'Frontier Explorer',
+      tone: 'discovery-focused, wonder, first contact',
+      themes: ['exploration', 'science', 'first contact', 'moral dilemmas'],
+    },
+    smugglers_run: {
+      name: "Smuggler's Run",
+      tone: 'gritty trade, intrigue, moral grey areas',
+      themes: ['trade', 'deception', 'reputation', 'rival crews', 'authority evasion'],
+    },
+    warpath: {
+      name: 'Warpath',
+      tone: 'military campaigns, tactical combat, high stakes',
+      themes: ['military campaigns', 'tactical decisions', 'crew survival', 'sacrifice'],
+    },
+    deep_salvage: {
+      name: 'Deep Salvage',
+      tone: 'atmospheric horror, derelict wrecks, resource scarcity',
+      themes: ['salvage operations', 'mystery', 'resource scarcity', 'crew psychology'],
+    },
+    first_contact: {
+      name: 'First Contact',
+      tone: 'cerebral, diplomatic, xenolinguistic stakes',
+      themes: ['diplomacy', 'xenolinguistics', 'cultural exchange', 'ethical dilemmas'],
+    },
+    the_long_haul: {
+      name: 'The Long Haul',
+      tone: 'intimate character-driven voyage, isolation, crew bonds',
+      themes: ['crew relationships', 'resource management', 'isolation', 'adaptation'],
+    },
+    ships_company: {
+      name: "Ship's Company",
+      tone: 'capital warship crew role, chain of command, institutional drama',
+      themes: ['chain of command', 'personal heroism', 'departmental loyalty', 'cost of war'],
+    },
+    custom: {
+      name: 'Custom Journey',
+      tone: 'flexible — adapt to whatever story emerges',
+      themes: [],
+    },
+  };
+
+  const shipClassLabels = {
+    light_freighter: 'Light Freighter — high cargo, moderate speed, light weapons',
+    scout_corvette: 'Scout Corvette — fast, great sensors, light cargo',
+    gunship: 'Gunship — heavy weapons, slow, low cargo',
+    salvage_rig: 'Salvage Rig — versatile, moderate stats, lots of quirks',
+    survey_vessel: 'Survey Vessel — scientific instruments, moderate cargo, non-combat',
+    blockade_runner: 'Blockade Runner — very fast, low profile, small cargo',
+    corvette_warfit: 'Corvette (warfit) — fast warship, balanced weapons and speed',
+    carrier_escort: 'Carrier Escort — heavy armor, point-defense, fleet support role',
+    diplomatic_cruiser: 'Diplomatic Cruiser — spacious, high presence, non-combat systems',
+    long_range_cruiser: 'Long-Range Cruiser — extended fuel, large crew quarters, self-sufficient',
+    fleet_carrier: 'Fleet Carrier — massive, fighter bays, command facilities',
+    line_battleship: 'Line Battleship — heaviest armor and weapons, slow',
+    heavy_cruiser: 'Heavy Cruiser — balanced capital ship, versatile weapons',
+  };
+
+  const jd = journeyDetails[journey] || journeyDetails.custom;
+  const themesLine = jd.themes.length > 0 ? `Themes: ${jd.themes.join(', ')}` : '';
+
+  const captainLine =
+    typeof captainName === 'string' && captainName.trim()
+      ? `Captain's name: ${captainName.trim().slice(0, 60)}`
+      : "Captain's name: (unnamed)";
+
+  const roleLine =
+    journey === 'ships_company' && captainRole
+      ? `Captain's role aboard the ship: ${captainRole}`
+      : '';
+
+  const systemPrompt = `You generate starting crew members for Void Odyssey, an AI-driven space exploration game set in a hard-ish sci-fi universe (Firefly meets Mass Effect — grounded crews, alien encounters, political tensions, moments of wonder).
+
+You MUST respond with ONLY a valid JSON object. No prose outside the JSON. The schema is:
+{
+  "crew": [
+    {
+      "name": string,
+      "role": string (one of: pilot, engineer, medic, gunner, science, general),
+      "description": string (1-2 sentences, flavor bio; grounded and specific, fits the journey tone)
+    }
+  ]
+}
+
+Constraints:
+- Generate exactly 2-3 crew members appropriate for the ship class and journey tone
+- Each crew member should fill a distinct operational need for the ship
+- Match crew personalities and backgrounds to the journey's themes
+- Names should feel plausible for a near-future sci-fi setting (human or alien-inspired)
+- Bios should be specific and evocative — a hint of history, a quirk, a reason they're on this ship
+- Do NOT mention the captain by name; crew bios are about themselves`;
+
+  const userMessage = `Generate starting crew for a new Void Odyssey campaign.
+
+Journey: ${jd.name}
+Tone: ${jd.tone}
+${themesLine}
+
+Ship: ${shipClassLabels[shipClass]}
+
+${captainLine}
+Captain's traits: ${captainTraits.join(', ')}
+${roleLine}
+
+Produce crew that fit this ship's operational needs and this journey's tone. A ${jd.name.toLowerCase()} crew should feel distinct from a warpath crew.`;
+
+  let aiResponse;
+  try {
+    aiResponse = await callGemini({
+      modelName: VOID_ODYSSEY_MODEL,
+      systemInstruction: systemPrompt,
+      userMessage,
+      maxOutputTokens: 1024,
+    });
+  } catch (err) {
+    if (err instanceof HttpsError) throw err;
+    console.error('voidOdysseyGenerateCrew Gemini error:', err);
+    throw new HttpsError('internal', 'Failed to generate crew. Please try again.');
+  }
+
+  // ── Validate AI response ───────────────────────────────────
+  const crewRaw = Array.isArray(aiResponse?.crew) ? aiResponse.crew : [];
+  if (crewRaw.length < 2 || crewRaw.length > 3) {
+    throw new HttpsError('internal', 'AI returned an unexpected number of crew members.');
+  }
+
+  const validRoles = ['pilot', 'engineer', 'medic', 'gunner', 'science', 'general'];
+  const crew = crewRaw.map((m) => ({
+    name: typeof m.name === 'string' && m.name.trim() ? m.name.trim().slice(0, 60) : 'Crew Member',
+    role: validRoles.includes(m.role) ? m.role : 'general',
+    description:
+      typeof m.description === 'string' && m.description.trim()
+        ? m.description.trim().slice(0, 500)
+        : '',
+  }));
+
+  return { crew };
+});
+
+/**
  * voidOdysseyNewGame — creates a new Void Odyssey campaign.
  *
  * Caller must be authenticated and have the 'void-odyssey' app claim.
@@ -2156,6 +2366,9 @@ Traits: ${captainTraits.join(', ')}`;
  *   captainBackstory: string   — optional backstory (empty string if none)
  *   shipClass: string          — 'light_freighter' | 'scout_corvette' | 'gunship' | 'salvage_rig'
  *   shipName: string           — player-chosen ship name
+ *   crew: { name, role, description }[]  — optional; pre-generated crew from voidOdysseyGenerateCrew
+ *                                           (player may have edited names/bios). When provided,
+ *                                           AI generates only the opening scene, not crew.
  *
  * Returns:
  *   gameId: string
@@ -2186,6 +2399,7 @@ exports.voidOdysseyNewGame = onCall(async (request) => {
     shipClass,
     shipName,
     captainRole,
+    crew: preGeneratedCrew,
   } = request.data || {};
 
   const validShipClasses = [
@@ -2300,6 +2514,32 @@ exports.voidOdysseyNewGame = onCall(async (request) => {
     }
   }
 
+  // ── Validate pre-generated crew (optional) ────────────────
+  // When the wizard's Step 5 pre-generated crew is passed in, validate and
+  // normalise it. If absent, the AI will generate crew as part of the opening scene.
+  const validCrewRoles = ['pilot', 'engineer', 'medic', 'gunner', 'science', 'general'];
+  let resolvedPreGeneratedCrew = null;
+
+  if (preGeneratedCrew !== undefined && preGeneratedCrew !== null) {
+    if (
+      !Array.isArray(preGeneratedCrew) ||
+      preGeneratedCrew.length < 2 ||
+      preGeneratedCrew.length > 3
+    ) {
+      throw new HttpsError('invalid-argument', 'crew must be an array of 2–3 members.');
+    }
+    resolvedPreGeneratedCrew = preGeneratedCrew.map((m) => {
+      if (typeof m.name !== 'string' || !m.name.trim()) {
+        throw new HttpsError('invalid-argument', 'Each crew member must have a name.');
+      }
+      return {
+        name: m.name.trim().slice(0, 60),
+        role: validCrewRoles.includes(m.role) ? m.role : 'general',
+        description: typeof m.description === 'string' ? m.description.trim().slice(0, 500) : '',
+      };
+    });
+  }
+
   // ── Build AI prompt ────────────────────────────────────────
   const difficultyLabels = {
     frontier_explorer: 'Frontier Explorer (discovery-focused, lower danger)',
@@ -2327,7 +2567,59 @@ exports.voidOdysseyNewGame = onCall(async (request) => {
     heavy_cruiser: 'Heavy Cruiser (balanced capital ship, versatile weapons)',
   };
 
-  const systemPrompt = `You are the narrator for Void Odyssey, an AI-driven space exploration game. You write in second person ("You step onto the bridge..."). The genre is hard-ish sci-fi with room for the mysterious — think Firefly meets Mass Effect: grounded crews, alien encounters, political tensions, moments of wonder.
+  const backstoryNote =
+    captainBackstory && captainBackstory.trim()
+      ? `Captain's backstory: ${captainBackstory.trim()}`
+      : 'No backstory provided — you may invent a brief one consistent with the traits.';
+
+  // When crew is pre-generated, omit the crew array from the AI schema so the
+  // model focuses only on the opening scene and references the provided crew by name.
+  let systemPrompt;
+  let userMessage;
+
+  if (resolvedPreGeneratedCrew) {
+    const crewContext = resolvedPreGeneratedCrew
+      .map((m) => `- ${m.name} (${m.role})${m.description ? ': ' + m.description : ''}`)
+      .join('\n');
+
+    systemPrompt = `You are the narrator for Void Odyssey, an AI-driven space exploration game. You write in second person ("You step onto the bridge..."). The genre is hard-ish sci-fi with room for the mysterious — think Firefly meets Mass Effect: grounded crews, alien encounters, political tensions, moments of wonder.
+
+You must respond with ONLY a valid JSON object. No prose outside the JSON. The schema is:
+{
+  "narrative": string (200-300 words, the opening story beat — sets the scene, introduces a situation or threat, ends on a hook),
+  "startingLocationName": string (name of the starting location),
+  "startingLocationType": string (one of: station, planet, moon, asteroid_field, derelict, anomaly),
+  "startingLocationDescription": string (2-3 sentences),
+  "startingLocationAtmosphere": string (1-3 mood keywords, e.g. "industrial_decay"),
+  "questHook": string (one sentence describing the first quest hook that emerged from the opening scene),
+  "availableActions": [
+    { "id": string, "label": string (max 8 words), "type": string (one of: dialogue, navigation, combat, investigation) }
+  ],
+  "mood": string (one of: tense, calm, wonder, danger, tense_curiosity, wry, reverent)
+}
+
+Constraints:
+- Generate exactly 3-4 available actions
+- The narrative must reference the captain by name and at least one crew member by name
+- Honor the difficulty/tone setting in the narrative style and situation
+- The starting location must feel specific and interesting, not generic
+- Do NOT generate crew — they are provided below; reference them naturally in the narrative`;
+
+    userMessage = `Create the opening of a new Void Odyssey campaign with these player choices:
+
+Difficulty/Tone: ${difficultyLabels[difficulty]}
+Captain's Name: ${captainName.trim()}
+Captain's Traits: ${captainTraits.join(', ')}
+${backstoryNote}
+Ship Class: ${shipClassLabels[shipClass]}
+Ship Name: ${shipName.trim()}
+
+Your Crew (already assigned — reference them by name in the narrative):
+${crewContext}
+
+Generate the opening scene, location, quest hook, and first available actions.`;
+  } else {
+    systemPrompt = `You are the narrator for Void Odyssey, an AI-driven space exploration game. You write in second person ("You step onto the bridge..."). The genre is hard-ish sci-fi with room for the mysterious — think Firefly meets Mass Effect: grounded crews, alien encounters, political tensions, moments of wonder.
 
 You must respond with ONLY a valid JSON object. No prose outside the JSON. The schema is:
 {
@@ -2359,12 +2651,7 @@ Constraints:
 - Honor the difficulty/tone setting in the narrative style and situation
 - The starting location must feel specific and interesting, not generic`;
 
-  const backstoryNote =
-    captainBackstory && captainBackstory.trim()
-      ? `Captain's backstory: ${captainBackstory.trim()}`
-      : 'No backstory provided — you may invent a brief one consistent with the traits.';
-
-  const userMessage = `Create the opening of a new Void Odyssey campaign with these player choices:
+    userMessage = `Create the opening of a new Void Odyssey campaign with these player choices:
 
 Difficulty/Tone: ${difficultyLabels[difficulty]}
 Captain's Name: ${captainName.trim()}
@@ -2374,6 +2661,7 @@ Ship Class: ${shipClassLabels[shipClass]}
 Ship Name: ${shipName.trim()}
 
 Generate the opening scene, starting crew, location, quest hook, and first available actions.`;
+  }
 
   // ── Call Gemini API ─────────────────────────────────────────
   let aiResponse;
@@ -2535,7 +2823,17 @@ Generate the opening scene, starting crew, location, quest hook, and first avail
 
   const shipStats = SHIP_CLASS_DEFAULTS[shipClass] || SHIP_CLASS_DEFAULTS.light_freighter;
 
-  const crew = aiResponse.crew || [];
+  // Use pre-generated (and player-edited) crew when provided; fall back to AI crew.
+  const crew = resolvedPreGeneratedCrew
+    ? resolvedPreGeneratedCrew.map((m) => ({
+        name: m.name,
+        role: m.role,
+        // description → backstory; species/personality filled with defaults
+        backstory: m.description || '',
+        species: 'human',
+        personality: [],
+      }))
+    : aiResponse.crew || [];
   const activeCrew = crew.map((m, i) => ({
     id: `crew_${i}_${gameId.slice(0, 6)}`,
     name: m.name,

--- a/public/apps/void-odyssey/app.js
+++ b/public/apps/void-odyssey/app.js
@@ -382,6 +382,7 @@
       captainRole: null,
     };
     VO.state.generatedGame = null;
+    VO.state.generatedCrew = null;
     VO.showView('game-create');
     VO.renderWizardStep(1);
   }

--- a/public/apps/void-odyssey/game-create.js
+++ b/public/apps/void-odyssey/game-create.js
@@ -854,6 +854,8 @@
       journey: d.tone,
       captainName: d.captainName,
       captainTraits: d.captainTraits,
+      captainSkills: d.captainSkills,
+      captainBackstory: d.captainBackstory,
       shipClass: d.shipClass,
       captainRole: d.captainRole,
     })

--- a/public/apps/void-odyssey/game-create.js
+++ b/public/apps/void-odyssey/game-create.js
@@ -828,11 +828,19 @@
     });
   }
 
-  // Step 5: Generate and review starting crew (Cloud Function call + Firestore write)
+  // Step 5: Generate and review starting crew (voidOdysseyGenerateCrew — no Firestore write).
+  // The game is created in Step 6 using the (possibly edited) crew.
   function _renderStep5(container) {
     var d = VO.state.wizardData;
 
-    // Show spinner while we call the Cloud Function
+    // If crew was already generated (e.g. user pressed Back from Step 6),
+    // skip the API call and show the existing editable cards directly.
+    if (VO.state.generatedCrew) {
+      _renderCrewCards(container, VO.state.generatedCrew);
+      return;
+    }
+
+    // Show spinner while the Cloud Function runs
     container.innerHTML =
       '<h2 class="wizard-step-title">Assembling Your Crew</h2>' +
       '<p class="wizard-step-desc">The Oracle is conjuring your starting crew&hellip;</p>' +
@@ -841,73 +849,110 @@
       '<p class="wizard-generating-text">Generating crew manifest&hellip;</p>' +
       '</div>';
 
-    // Call the Cloud Function (generates crew + opening scene in one shot, writes game to Firestore)
-    var fn = VO.state.functions.httpsCallable('voidOdysseyNewGame');
+    var fn = VO.state.functions.httpsCallable('voidOdysseyGenerateCrew');
     fn({
-      // Legacy field name; carries narrative tone / journey ID
-      difficulty: d.tone,
+      journey: d.tone,
       captainName: d.captainName,
       captainTraits: d.captainTraits,
-      captainSkills: d.captainSkills,
-      captainBackstory: d.captainBackstory,
       shipClass: d.shipClass,
-      shipName: d.shipName,
       captainRole: d.captainRole,
     })
       .then(function (result) {
-        VO.state.generatedGame = result.data;
-        _renderCrewReview(container, result.data.crew);
+        VO.state.generatedCrew = result.data.crew;
+        _renderCrewCards(container, VO.state.generatedCrew);
       })
       .catch(function (err) {
-        console.error('voidOdysseyNewGame error:', err);
+        console.error('voidOdysseyGenerateCrew error:', err);
         container.innerHTML =
           '<h2 class="wizard-step-title">Something Went Wrong</h2>' +
           '<p class="wizard-error">' +
-          _esc(err.message || 'Failed to generate game. Please try again.') +
+          _esc(err.message || 'Failed to generate crew. Please try again.') +
           '</p>' +
           '<div class="wizard-nav">' +
-          '<button type="button" class="btn btn-secondary" id="step5-retry">← Try Again</button>' +
+          '<button type="button" class="btn btn-secondary" id="step5-retry">&#8592; Try Again</button>' +
           '</div>';
         document.getElementById('step5-retry').addEventListener('click', function () {
+          VO.state.generatedCrew = null;
           VO.renderWizardStep(5);
         });
       });
   }
 
-  function _renderCrewReview(container, crew) {
+  function _renderCrewCards(container, crew) {
     var html =
       '<h2 class="wizard-step-title">Meet Your Crew</h2>' +
-      '<p class="wizard-step-desc">The Oracle has assembled your starting crew. Review them before launch.</p>' +
+      '<p class="wizard-step-desc">' +
+      'The Oracle has assembled your starting crew. Edit names or bios before continuing.' +
+      '</p>' +
       '<div class="crew-preview-list">';
 
-    (crew || []).forEach(function (member) {
+    (crew || []).forEach(function (member, i) {
       html +=
-        '<div class="crew-preview-card">' +
+        '<div class="crew-preview-card" data-crew-index="' +
+        i +
+        '">' +
         '<div class="crew-preview-header">' +
-        '<span class="crew-preview-name">' +
+        '<input' +
+        ' type="text"' +
+        ' class="crew-preview-name-input"' +
+        ' data-crew-index="' +
+        i +
+        '"' +
+        ' maxlength="60"' +
+        ' value="' +
         _esc(member.name) +
-        '</span>' +
+        '"' +
+        ' aria-label="Crew member name"' +
+        ' />' +
         '<span class="crew-preview-role">' +
         _esc(member.role) +
         '</span>' +
         '</div>' +
-        '<p class="crew-preview-bio">' +
-        _esc(member.backstory) +
-        '</p>' +
+        '<textarea' +
+        ' class="crew-preview-bio-input"' +
+        ' data-crew-index="' +
+        i +
+        '"' +
+        ' maxlength="500"' +
+        ' rows="3"' +
+        ' aria-label="Crew member bio"' +
+        '>' +
+        _esc(member.description) +
+        '</textarea>' +
         '</div>';
     });
 
     html +=
       '</div>' +
       '<div class="wizard-nav">' +
-      '<button type="button" class="btn btn-secondary" id="step5-back">← Reroll</button>' +
-      '<button type="button" class="btn btn-primary" id="step5-next">Launch Campaign →</button>' +
+      '<button type="button" class="btn btn-secondary" id="step5-regenerate">Regenerate</button>' +
+      '<button type="button" class="btn btn-primary" id="step5-next">Continue &rarr;</button>' +
       '</div>';
 
     container.innerHTML = html;
 
-    document.getElementById('step5-back').addEventListener('click', function () {
-      VO.state.generatedGame = null;
+    // Sync name edits back into VO.state.generatedCrew
+    container.querySelectorAll('.crew-preview-name-input').forEach(function (input) {
+      input.addEventListener('input', function () {
+        var idx = parseInt(input.dataset.crewIndex, 10);
+        if (VO.state.generatedCrew && VO.state.generatedCrew[idx] !== undefined) {
+          VO.state.generatedCrew[idx].name = input.value;
+        }
+      });
+    });
+
+    // Sync bio edits back into VO.state.generatedCrew
+    container.querySelectorAll('.crew-preview-bio-input').forEach(function (textarea) {
+      textarea.addEventListener('input', function () {
+        var idx = parseInt(textarea.dataset.crewIndex, 10);
+        if (VO.state.generatedCrew && VO.state.generatedCrew[idx] !== undefined) {
+          VO.state.generatedCrew[idx].description = textarea.value;
+        }
+      });
+    });
+
+    document.getElementById('step5-regenerate').addEventListener('click', function () {
+      VO.state.generatedCrew = null;
       VO.renderWizardStep(5);
     });
 
@@ -916,14 +961,64 @@
     });
   }
 
-  // Step 6: Display opening scene
+  // Step 6: Create the game (calls voidOdysseyNewGame with edited crew), then display opening scene.
   function _renderStep6(container) {
-    var game = VO.state.generatedGame;
-    if (!game) {
+    var d = VO.state.wizardData;
+
+    // If no crew was generated, go back to Step 5
+    if (!VO.state.generatedCrew) {
       VO.renderWizardStep(5);
       return;
     }
 
+    // Phase B: game already created — display the opening scene
+    if (VO.state.generatedGame) {
+      _renderOpeningScene(container, VO.state.generatedGame);
+      return;
+    }
+
+    // Phase A: call voidOdysseyNewGame with the (edited) crew to create the game
+    container.innerHTML =
+      '<h2 class="wizard-step-title">Creating Your Campaign</h2>' +
+      '<p class="wizard-step-desc">The Oracle is weaving your opening scene&hellip;</p>' +
+      '<div class="wizard-generating">' +
+      '<div class="app-spinner"></div>' +
+      '<p class="wizard-generating-text">Writing your story&hellip;</p>' +
+      '</div>';
+
+    var fn = VO.state.functions.httpsCallable('voidOdysseyNewGame');
+    fn({
+      difficulty: d.tone,
+      captainName: d.captainName,
+      captainTraits: d.captainTraits,
+      captainSkills: d.captainSkills,
+      captainBackstory: d.captainBackstory,
+      shipClass: d.shipClass,
+      shipName: d.shipName,
+      captainRole: d.captainRole,
+      crew: VO.state.generatedCrew,
+    })
+      .then(function (result) {
+        VO.state.generatedGame = result.data;
+        _renderOpeningScene(container, result.data);
+      })
+      .catch(function (err) {
+        console.error('voidOdysseyNewGame error:', err);
+        container.innerHTML =
+          '<h2 class="wizard-step-title">Something Went Wrong</h2>' +
+          '<p class="wizard-error">' +
+          _esc(err.message || 'Failed to create campaign. Please try again.') +
+          '</p>' +
+          '<div class="wizard-nav">' +
+          '<button type="button" class="btn btn-secondary" id="step6-back">&#8592; Back to Crew</button>' +
+          '</div>';
+        document.getElementById('step6-back').addEventListener('click', function () {
+          VO.renderWizardStep(5);
+        });
+      });
+  }
+
+  function _renderOpeningScene(container, game) {
     var actions = game.availableActions || [];
     var actionsHtml = actions
       .map(function (a) {
@@ -952,7 +1047,7 @@
       '<p class="action-panel-note">(Full turn actions available in Phase 2)</p>' +
       '</div>' +
       '<div class="wizard-nav wizard-nav--center">' +
-      '<button type="button" class="btn btn-primary" id="step6-enter">Enter the Void →</button>' +
+      '<button type="button" class="btn btn-primary" id="step6-enter">Enter the Void &rarr;</button>' +
       '</div>';
 
     document.getElementById('step6-enter').addEventListener('click', function () {


### PR DESCRIPTION
Implements issue #147. Step 5 now calls a new lightweight Cloud Function
(voidOdysseyGenerateCrew) that returns 2-3 contextual crew suggestions
without creating a Firestore document. Players can edit crew names and
bios in-place before proceeding. Step 6 creates the game via
voidOdysseyNewGame, passing the edited crew so the Firestore write
incorporates player changes.

- Add voidOdysseyGenerateCrew Cloud Function: validates journey/ship/
  captain inputs, calls Gemini with journey tone and ship context, returns
  {crew: [{name, role, description}]}
- Modify voidOdysseyNewGame to accept optional pre-generated crew param;
  when provided, skips AI crew generation and uses a crew-context prompt
  for the opening scene only (backwards-compatible)
- Rewrite _renderStep5 with editable name inputs and bio textareas;
  edits sync back to VO.state.generatedCrew; Regenerate clears and
  re-calls; Back from Step 6 re-shows existing crew without re-calling
- Add Phase A loading state to _renderStep6 (calls voidOdysseyNewGame
  with edited crew); Phase B shows opening scene as before
- Reset VO.state.generatedCrew = null in _startNewGame alongside
  existing generatedGame reset

https://claude.ai/code/session_01SoAfMniQaq93kSG59TRPtc