### PR TITLE
fix(void-odyssey): disable thinking and raise token limits for campaign generation

### DIFF
--- a/functions/gemini.js
+++ b/functions/gemini.js
@@ -28,8 +28,15 @@ function getClient() {
  * Strips markdown fences and parses the result when in JSON mode.
  * Throws HttpsError on failure.
  *
- * @param {number} [thinkingBudget] - Optional thinking token budget. Set to 0 to disable thinking
- *   for simple tasks where reasoning is unnecessary. Omit to use the model default.
+ * @param {object} options
+ * @param {string} options.modelName - Vertex AI model name (e.g. 'gemini-2.5-flash').
+ * @param {string} options.systemInstruction - System prompt sent to the model.
+ * @param {string} options.userMessage - User turn content.
+ * @param {number} options.maxOutputTokens - Maximum tokens in the model response.
+ * @param {boolean} [options.jsonMode=true] - When true, sets responseMimeType to application/json
+ *   and JSON-parses the result. Set to false to receive raw text.
+ * @param {number} [options.thinkingBudget] - Optional thinking token budget. Set to 0 to disable
+ *   thinking for simple tasks where reasoning is unnecessary. Omit to use the model default.
  */
 async function callGemini({
   modelName,

--- a/functions/gemini.js
+++ b/functions/gemini.js
@@ -27,6 +27,9 @@ function getClient() {
  * Calls Gemini via Vertex AI and returns the parsed JSON response (or raw text if jsonMode is false).
  * Strips markdown fences and parses the result when in JSON mode.
  * Throws HttpsError on failure.
+ *
+ * @param {number} [thinkingBudget] - Optional thinking token budget. Set to 0 to disable thinking
+ *   for simple tasks where reasoning is unnecessary. Omit to use the model default.
  */
 async function callGemini({
   modelName,
@@ -34,6 +37,7 @@ async function callGemini({
   userMessage,
   maxOutputTokens,
   jsonMode = true,
+  thinkingBudget,
 }) {
   try {
     const response = await getClient().models.generateContent({
@@ -43,6 +47,9 @@ async function callGemini({
         systemInstruction,
         maxOutputTokens,
         ...(jsonMode && { responseMimeType: 'application/json' }),
+        ...(thinkingBudget !== undefined && {
+          thinkingConfig: { thinkingBudget },
+        }),
       },
     });
 

--- a/functions/index.js
+++ b/functions/index.js
@@ -2311,7 +2311,8 @@ Traits: ${captainTraits.join(', ')}`;
       modelName: VOID_ODYSSEY_MODEL,
       systemInstruction: systemPrompt,
       userMessage,
-      maxOutputTokens: 512,
+      maxOutputTokens: 1024,
+      thinkingBudget: 0,
     });
   } catch (err) {
     if (err instanceof HttpsError) throw err;
@@ -2531,7 +2532,8 @@ Produce crew that fit this ship's operational needs and this journey's tone. A $
       modelName: VOID_ODYSSEY_MODEL,
       systemInstruction: systemPrompt,
       userMessage,
-      maxOutputTokens: 1024,
+      maxOutputTokens: 2048,
+      thinkingBudget: 0,
     });
   } catch (err) {
     if (err instanceof HttpsError) throw err;

--- a/tests/gemini.test.js
+++ b/tests/gemini.test.js
@@ -112,6 +112,42 @@ describe('callGemini', () => {
     });
   });
 
+  test('passes thinkingConfig when thinkingBudget is provided', async () => {
+    const payload = { backstory: 'You grew up on a mining rig.' };
+    mockGenerateContent.mockResolvedValue(makeGenAiResponse({ text: JSON.stringify(payload) }));
+
+    await callGemini({
+      modelName: 'gemini-2.5-flash',
+      systemInstruction: 'sys',
+      userMessage: 'user',
+      maxOutputTokens: 1024,
+      thinkingBudget: 0,
+    });
+
+    expect(mockGenerateContent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: expect.objectContaining({
+          thinkingConfig: { thinkingBudget: 0 },
+        }),
+      })
+    );
+  });
+
+  test('omits thinkingConfig when thinkingBudget is not provided', async () => {
+    const payload = { narrative: 'You dock at the station.' };
+    mockGenerateContent.mockResolvedValue(makeGenAiResponse({ text: JSON.stringify(payload) }));
+
+    await callGemini({
+      modelName: 'gemini-2.5-flash',
+      systemInstruction: 'sys',
+      userMessage: 'user',
+      maxOutputTokens: 1024,
+    });
+
+    const config = mockGenerateContent.mock.calls[0][0].config;
+    expect(config).not.toHaveProperty('thinkingConfig');
+  });
+
   test('throws internal HttpsError when response text is empty', async () => {
     mockGenerateContent.mockResolvedValue({ candidates: [] });
 


### PR DESCRIPTION
gemini-2.5-flash thinking tokens count against maxOutputTokens, causing the
backstory (512 token limit) and crew (1024 token limit) generation calls to
hit MAX_TOKENS before producing a complete JSON response.

Fix: set thinkingBudget: 0 for these simple structured tasks (no reasoning
needed) and double the output token budgets as an extra safety margin.
Also adds thinkingBudget as an optional param to callGemini for future use.

https://claude.ai/code/session_01G6RmBrZsEWRFPSgoYv1vYr