### PR TITLE
feat(tortuga): add Firestore security rules for tortuga_worlds and tortuga_games

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -367,6 +367,32 @@ service cloud.firestore {
       allow read, write: if hasAdmin();
     }
 
+    // ── Tortuga ──────────────────────────────────────────
+
+    match /tortuga_worlds/{worldId} {
+      allow read: if hasApp('tortuga')
+        && (resource.data.shared == true || resource.data.createdBy == request.auth.uid);
+      allow create: if hasApp('tortuga')
+        && request.resource.data.createdBy == request.auth.uid;
+      allow update, delete: if hasApp('tortuga')
+        && resource.data.createdBy == request.auth.uid;
+    }
+
+    match /tortuga_games/{gameId} {
+      allow read, delete: if hasApp('tortuga')
+        && resource.data.owner == request.auth.uid;
+      allow create: if hasApp('tortuga')
+        && request.resource.data.owner == request.auth.uid;
+      allow update: if hasApp('tortuga')
+        && resource.data.owner == request.auth.uid
+        && request.resource.data.owner == resource.data.owner;
+
+      match /{subcoll}/{docId} {
+        allow read, write: if hasApp('tortuga')
+          && get(/databases/$(database)/documents/tortuga_games/$(gameId)).data.owner == request.auth.uid;
+      }
+    }
+
     // ── Default deny ───────────────────────────────────────
 
     match /{document=**} {

--- a/tests/firestore-rules.test.js
+++ b/tests/firestore-rules.test.js
@@ -1483,3 +1483,333 @@ describe('apps — Firestore Security Rules', function () {
     });
   });
 });
+
+// ── tortuga_worlds ────────────────────────────────────────────────────────────
+
+const TORTUGA_TOKEN = { apps: ['tortuga'] };
+
+function makeTortugaWorld(overrides) {
+  return Object.assign(
+    {
+      name: 'Test World',
+      createdBy: 'tortuga-owner',
+      shared: true,
+      createdAt: serverTimestamp(),
+      updatedAt: serverTimestamp(),
+    },
+    overrides || {}
+  );
+}
+
+function makeTortugaGame(overrides) {
+  return Object.assign(
+    {
+      owner: 'tortuga-owner',
+      worldId: 'world-001',
+      createdAt: serverTimestamp(),
+      turnNumber: 1,
+    },
+    overrides || {}
+  );
+}
+
+describe('tortuga_worlds — Firestore Security Rules', function () {
+  var testEnv;
+  var ownerDb;
+  var otherTortugaDb;
+  var noClaimDb;
+  var unauthDb;
+
+  beforeAll(async function () {
+    var firestoreConfig = {
+      rules: readFileSync(RULES_PATH, 'utf8'),
+    };
+
+    var emulatorHost = process.env.FIRESTORE_EMULATOR_HOST;
+    if (emulatorHost) {
+      var parts = emulatorHost.split(':');
+      var host = parts[0];
+      var portString = parts[1];
+      if (host) {
+        firestoreConfig.host = host;
+      }
+      if (portString) {
+        var parsedPort = parseInt(portString, 10);
+        if (!isNaN(parsedPort)) {
+          firestoreConfig.port = parsedPort;
+        }
+      }
+    } else {
+      firestoreConfig.host = '127.0.0.1';
+      firestoreConfig.port = 8080;
+    }
+
+    testEnv = await initializeTestEnvironment({
+      projectId: PROJECT_ID,
+      firestore: firestoreConfig,
+    });
+  });
+
+  beforeEach(async function () {
+    await testEnv.clearFirestore();
+
+    await testEnv.withSecurityRulesDisabled(async function (ctx) {
+      var db = ctx.firestore();
+      // shared world owned by tortuga-owner
+      await setDoc(doc(db, 'tortuga_worlds', 'world-shared'), makeTortugaWorld({ shared: true }));
+      // private world owned by tortuga-owner
+      await setDoc(doc(db, 'tortuga_worlds', 'world-private'), makeTortugaWorld({ shared: false }));
+    });
+
+    ownerDb = testEnv.authenticatedContext('tortuga-owner', TORTUGA_TOKEN).firestore();
+    otherTortugaDb = testEnv.authenticatedContext('tortuga-other', TORTUGA_TOKEN).firestore();
+    noClaimDb = testEnv.authenticatedContext('no-claim-user', {}).firestore();
+    unauthDb = testEnv.unauthenticatedContext().firestore();
+  });
+
+  afterAll(async function () {
+    await testEnv.cleanup();
+  });
+
+  describe('read access', function () {
+    it('allows non-owner to read a shared world', async function () {
+      await assertSucceeds(getDoc(doc(otherTortugaDb, 'tortuga_worlds', 'world-shared')));
+    });
+
+    it('allows owner to read their own unshared world', async function () {
+      await assertSucceeds(getDoc(doc(ownerDb, 'tortuga_worlds', 'world-private')));
+    });
+
+    it('denies non-owner read of an unshared world', async function () {
+      await assertFails(getDoc(doc(otherTortugaDb, 'tortuga_worlds', 'world-private')));
+    });
+
+    it('denies read for a user without tortuga claim', async function () {
+      await assertFails(getDoc(doc(noClaimDb, 'tortuga_worlds', 'world-shared')));
+    });
+
+    it('denies read for an unauthenticated user', async function () {
+      await assertFails(getDoc(doc(unauthDb, 'tortuga_worlds', 'world-shared')));
+    });
+  });
+
+  describe('create access', function () {
+    it('allows tortuga user to create a world with their own uid as createdBy', async function () {
+      await assertSucceeds(
+        setDoc(
+          doc(ownerDb, 'tortuga_worlds', 'world-new'),
+          makeTortugaWorld({ createdBy: 'tortuga-owner' })
+        )
+      );
+    });
+
+    it('denies creating a world with a different uid as createdBy', async function () {
+      await assertFails(
+        setDoc(
+          doc(otherTortugaDb, 'tortuga_worlds', 'world-spoof'),
+          makeTortugaWorld({ createdBy: 'tortuga-owner' })
+        )
+      );
+    });
+
+    it('denies create for a user without tortuga claim', async function () {
+      await assertFails(
+        setDoc(
+          doc(noClaimDb, 'tortuga_worlds', 'world-noclaim'),
+          makeTortugaWorld({ createdBy: 'no-claim-user' })
+        )
+      );
+    });
+  });
+
+  describe('update access', function () {
+    it('allows creator to update their own world', async function () {
+      await assertSucceeds(
+        setDoc(doc(ownerDb, 'tortuga_worlds', 'world-private'), makeTortugaWorld({ shared: true }))
+      );
+    });
+
+    it('denies non-creator from updating a world', async function () {
+      await assertFails(
+        setDoc(
+          doc(otherTortugaDb, 'tortuga_worlds', 'world-private'),
+          makeTortugaWorld({ shared: true })
+        )
+      );
+    });
+  });
+
+  describe('delete access', function () {
+    it('allows creator to delete their own world', async function () {
+      const { deleteDoc } = require('firebase/firestore');
+      await assertSucceeds(deleteDoc(doc(ownerDb, 'tortuga_worlds', 'world-private')));
+    });
+
+    it('denies non-creator from deleting a world', async function () {
+      const { deleteDoc } = require('firebase/firestore');
+      await assertFails(deleteDoc(doc(otherTortugaDb, 'tortuga_worlds', 'world-private')));
+    });
+  });
+});
+
+// ── tortuga_games ─────────────────────────────────────────────────────────────
+
+describe('tortuga_games — Firestore Security Rules', function () {
+  var testEnv;
+  var ownerDb;
+  var otherTortugaDb;
+  var noClaimDb;
+  var unauthDb;
+
+  beforeAll(async function () {
+    var firestoreConfig = {
+      rules: readFileSync(RULES_PATH, 'utf8'),
+    };
+
+    var emulatorHost = process.env.FIRESTORE_EMULATOR_HOST;
+    if (emulatorHost) {
+      var parts = emulatorHost.split(':');
+      var host = parts[0];
+      var portString = parts[1];
+      if (host) {
+        firestoreConfig.host = host;
+      }
+      if (portString) {
+        var parsedPort = parseInt(portString, 10);
+        if (!isNaN(parsedPort)) {
+          firestoreConfig.port = parsedPort;
+        }
+      }
+    } else {
+      firestoreConfig.host = '127.0.0.1';
+      firestoreConfig.port = 8080;
+    }
+
+    testEnv = await initializeTestEnvironment({
+      projectId: PROJECT_ID,
+      firestore: firestoreConfig,
+    });
+  });
+
+  beforeEach(async function () {
+    await testEnv.clearFirestore();
+
+    await testEnv.withSecurityRulesDisabled(async function (ctx) {
+      var db = ctx.firestore();
+      await setDoc(doc(db, 'tortuga_games', 'game-001'), makeTortugaGame({ owner: 'tortuga-owner' }));
+      // seed a ship subcollection doc for the game
+      await setDoc(doc(db, 'tortuga_games', 'game-001', 'ships', 'ship-001'), {
+        name: 'The Black Pearl',
+        hull: 100,
+      });
+    });
+
+    ownerDb = testEnv.authenticatedContext('tortuga-owner', TORTUGA_TOKEN).firestore();
+    otherTortugaDb = testEnv.authenticatedContext('tortuga-other', TORTUGA_TOKEN).firestore();
+    noClaimDb = testEnv.authenticatedContext('no-claim-user', {}).firestore();
+    unauthDb = testEnv.unauthenticatedContext().firestore();
+  });
+
+  afterAll(async function () {
+    await testEnv.cleanup();
+  });
+
+  describe('read access', function () {
+    it('allows game owner to read their game', async function () {
+      await assertSucceeds(getDoc(doc(ownerDb, 'tortuga_games', 'game-001')));
+    });
+
+    it('denies non-owner read of a game', async function () {
+      await assertFails(getDoc(doc(otherTortugaDb, 'tortuga_games', 'game-001')));
+    });
+
+    it('denies read for a user without tortuga claim', async function () {
+      await assertFails(getDoc(doc(noClaimDb, 'tortuga_games', 'game-001')));
+    });
+
+    it('denies read for an unauthenticated user', async function () {
+      await assertFails(getDoc(doc(unauthDb, 'tortuga_games', 'game-001')));
+    });
+  });
+
+  describe('create access', function () {
+    it('allows tortuga user to create a game with their own uid as owner', async function () {
+      await assertSucceeds(
+        setDoc(
+          doc(ownerDb, 'tortuga_games', 'game-new'),
+          makeTortugaGame({ owner: 'tortuga-owner' })
+        )
+      );
+    });
+
+    it('denies creating a game without tortuga claim', async function () {
+      await assertFails(
+        setDoc(
+          doc(noClaimDb, 'tortuga_games', 'game-noclaim'),
+          makeTortugaGame({ owner: 'no-claim-user' })
+        )
+      );
+    });
+  });
+
+  describe('update access', function () {
+    it('allows owner to update their game', async function () {
+      await assertSucceeds(
+        setDoc(doc(ownerDb, 'tortuga_games', 'game-001'), makeTortugaGame({ turnNumber: 2 }))
+      );
+    });
+
+    it('denies non-owner from updating a game', async function () {
+      await assertFails(
+        setDoc(
+          doc(otherTortugaDb, 'tortuga_games', 'game-001'),
+          makeTortugaGame({ owner: 'tortuga-other', turnNumber: 2 })
+        )
+      );
+    });
+  });
+
+  describe('delete access', function () {
+    it('allows owner to delete their game', async function () {
+      const { deleteDoc } = require('firebase/firestore');
+      await assertSucceeds(deleteDoc(doc(ownerDb, 'tortuga_games', 'game-001')));
+    });
+
+    it('denies non-owner from deleting a game', async function () {
+      const { deleteDoc } = require('firebase/firestore');
+      await assertFails(deleteDoc(doc(otherTortugaDb, 'tortuga_games', 'game-001')));
+    });
+  });
+
+  describe('subcollection access', function () {
+    it('allows game owner to read a subcollection document', async function () {
+      await assertSucceeds(
+        getDoc(doc(ownerDb, 'tortuga_games', 'game-001', 'ships', 'ship-001'))
+      );
+    });
+
+    it('denies non-owner read of a subcollection document', async function () {
+      await assertFails(
+        getDoc(doc(otherTortugaDb, 'tortuga_games', 'game-001', 'ships', 'ship-001'))
+      );
+    });
+
+    it('allows game owner to write a subcollection document', async function () {
+      await assertSucceeds(
+        setDoc(doc(ownerDb, 'tortuga_games', 'game-001', 'ships', 'ship-002'), {
+          name: 'The Flying Dutchman',
+          hull: 80,
+        })
+      );
+    });
+
+    it('denies non-owner write to a subcollection document', async function () {
+      await assertFails(
+        setDoc(doc(otherTortugaDb, 'tortuga_games', 'game-001', 'ships', 'ship-002'), {
+          name: 'The Flying Dutchman',
+          hull: 80,
+        })
+      );
+    });
+  });
+});


### PR DESCRIPTION
Adds hasApp('tortuga')-gated rules for tortuga_worlds (shared-by-default reads,
creator-restricted writes) and tortuga_games (owner-private, including subcollections).
Includes Jest emulator tests covering shared-world read by non-owner, private-world
denial, creator-vs-non-creator write enforcement, game owner-only access, and
subcollection ownership propagation. Closes #182.

https://claude.ai/code/session_01JkgS9w9Zuh5tpe6tHmtzX3