### PR TITLE
feat(tortuga): foundation — state.js, firestore.js, app.js with mode router

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -39,7 +39,8 @@ export default [
         ReactDOM: "readonly",
         AbortController: "readonly",
         OlympusAnalytics: "readonly",
-        setTimeout: "readonly"
+        setTimeout: "readonly",
+        URLSearchParams: "readonly"
       }
     },
     rules: {

--- a/public/apps/tortuga/app.js
+++ b/public/apps/tortuga/app.js
@@ -1,0 +1,27 @@
+(function () {
+  'use strict';
+
+  window.Tortuga = window.Tortuga || {};
+  var T = window.Tortuga;
+
+  function getMode() {
+    var params = new URLSearchParams(window.location.search);
+    var m = params.get('mode');
+    return m === T.MODES.PLAY ? T.MODES.PLAY : T.MODES.WORLD;
+  }
+
+  T.showMode = function (mode) {
+    var shells = [T.MODES.WORLD, T.MODES.PLAY];
+    shells.forEach(function (m) {
+      var el = document.getElementById('shell-' + m);
+      if (el) el.classList.toggle('hidden', m !== mode);
+    });
+    T.state.currentMode = mode;
+  };
+
+  T.init = function (user) {
+    T.state.currentUser = user;
+    T.state.db = firebase.firestore();
+    T.showMode(getMode());
+  };
+})();

--- a/public/apps/tortuga/firestore.js
+++ b/public/apps/tortuga/firestore.js
@@ -1,0 +1,87 @@
+(function () {
+  'use strict';
+
+  window.Tortuga = window.Tortuga || {};
+  var T = window.Tortuga;
+
+  T.firestore = {
+    // ── Worlds ────────────────────────────────────────────
+
+    listWorlds: function (callback) {
+      return T.state.db
+        .collection('tortuga_worlds')
+        .where('shared', '==', true)
+        .onSnapshot(
+          function (snap) {
+            var docs = snap.docs.map(function (d) {
+              return Object.assign({ id: d.id }, d.data());
+            });
+            callback(docs, null);
+          },
+          function (err) {
+            callback(null, err);
+          }
+        );
+    },
+
+    createWorld: function (data) {
+      var uid = T.state.currentUser.uid;
+      var ts = firebase.firestore.FieldValue.serverTimestamp();
+      return T.state.db.collection('tortuga_worlds').add(
+        Object.assign({}, data, {
+          createdBy: uid,
+          createdAt: ts,
+          updatedAt: ts,
+        })
+      );
+    },
+
+    updateWorld: function (id, data) {
+      var ts = firebase.firestore.FieldValue.serverTimestamp();
+      return T.state.db
+        .collection('tortuga_worlds')
+        .doc(id)
+        .update(Object.assign({}, data, { updatedAt: ts }));
+    },
+
+    deleteWorld: function (id) {
+      return T.state.db.collection('tortuga_worlds').doc(id).delete();
+    },
+
+    // ── Games ─────────────────────────────────────────────
+
+    listGames: function (callback) {
+      var uid = T.state.currentUser.uid;
+      return T.state.db
+        .collection('tortuga_games')
+        .where('owner', '==', uid)
+        .onSnapshot(
+          function (snap) {
+            var docs = snap.docs.map(function (d) {
+              return Object.assign({ id: d.id }, d.data());
+            });
+            callback(docs, null);
+          },
+          function (err) {
+            callback(null, err);
+          }
+        );
+    },
+
+    createGame: function (data) {
+      var uid = T.state.currentUser.uid;
+      var ts = firebase.firestore.FieldValue.serverTimestamp();
+      return T.state.db.collection('tortuga_games').add(
+        Object.assign({}, data, {
+          owner: uid,
+          createdAt: ts,
+          lastPlayedAt: ts,
+        })
+      );
+    },
+
+    deleteGame: function (id) {
+      return T.state.db.collection('tortuga_games').doc(id).delete();
+    },
+  };
+})();

--- a/public/apps/tortuga/index.html
+++ b/public/apps/tortuga/index.html
@@ -34,28 +34,30 @@
 
     <!-- Main content — hidden until authenticated -->
     <main class="app-main hidden" id="app-main">
-      <h1 class="app-title">Tortuga</h1>
-      <p class="app-subtitle">On the account, Captain.</p>
-      <div class="app-divider"></div>
+      <!-- Cartographer (world builder) mode shell -->
+      <section id="shell-world" class="hidden">
+        <h1 class="app-title">Cartographer</h1>
+        <p class="app-subtitle">Build and explore worlds.</p>
+        <div class="app-divider"></div>
+        <p class="placeholder-text">World management coming in a future phase.</p>
+      </section>
 
-      <!-- Your app content goes here -->
+      <!-- The Account (campaign play) mode shell -->
+      <section id="shell-play" class="hidden">
+        <h1 class="app-title">The Account</h1>
+        <p class="app-subtitle">On the account, Captain.</p>
+        <div class="app-divider"></div>
+        <p class="placeholder-text">Campaign play coming in a future phase.</p>
+      </section>
     </main>
 
     <!-- Shared header component -->
     <script src="/js/components/app-header.js"></script>
 
-    <!-- App modules — when your app grows beyond ~300 lines of JS, split into
-         external files using the namespace pattern (see symposium for a full example):
-
-         <script src="/apps/tortuga/state.js"></script>
-         <script src="/apps/tortuga/app.js"></script>
-
-         Each file should be an IIFE that reads/extends window.Tortuga:
-           (function () {
-             var Tortuga = window.Tortuga = window.Tortuga || {};
-             Tortuga.state = { ... };
-           })();
-    -->
+    <!-- App modules: state first, then helpers, app last -->
+    <script src="/apps/tortuga/state.js"></script>
+    <script src="/apps/tortuga/firestore.js"></script>
+    <script src="/apps/tortuga/app.js"></script>
 
     <script>
       document.addEventListener('DOMContentLoaded', function () {
@@ -65,22 +67,14 @@
             return;
           }
 
-          // Render the shared header
           window.OlympusHeader.render('Tortuga');
 
-          // Hide loading, show main content
           document.getElementById('app-loading').classList.add('hidden');
           document.getElementById('app-main').classList.remove('hidden');
 
-          // Initialize your app here
-          initializeApp(user);
+          window.Tortuga.init(user);
         });
       });
-
-      function initializeApp(user) {
-        // Your app logic goes here
-        // user.uid, user.email, etc. are available
-      }
     </script>
   </body>
 </html>

--- a/public/apps/tortuga/state.js
+++ b/public/apps/tortuga/state.js
@@ -1,0 +1,15 @@
+(function () {
+  'use strict';
+
+  window.Tortuga = window.Tortuga || {};
+  var T = window.Tortuga;
+
+  T.MODES = { WORLD: 'world', PLAY: 'play' };
+  T.DEFAULT_MODE = 'world';
+
+  T.state = {
+    db: null,
+    currentUser: null,
+    currentMode: null,
+  };
+})();


### PR DESCRIPTION
Sets up the IIFE namespace pattern for Tortuga (window.Tortuga) and
wires dual-mode routing (?mode=world → Cartographer shell, ?mode=play
→ The Account shell) with placeholder DOM for each mode. Adds
tortuga_worlds and tortuga_games CRUD helpers in firestore.js.

Also adds URLSearchParams to ESLint public globals.

Closes #183