### PR TITLE
feat(tortuga): add shared Leaflet map renderer (map-renderer.js)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -35,6 +35,7 @@ export default [
         localStorage: "readonly",
         firebase: "readonly",
         fetch: "readonly",
+        L: "readonly",
         React: "readonly",
         ReactDOM: "readonly",
         AbortController: "readonly",

--- a/public/apps/tortuga/app.js
+++ b/public/apps/tortuga/app.js
@@ -22,6 +22,13 @@
   T.init = function (user) {
     T.state.currentUser = user;
     T.state.db = firebase.firestore();
-    T.showMode(getMode());
+    var mode = getMode();
+    T.showMode(mode);
+
+    var containerId = mode === T.MODES.PLAY ? 'map-play' : 'map-world';
+    var containerEl = document.getElementById(containerId);
+    if (containerEl) {
+      T.mapRenderer.init(containerEl, T.mapRenderer.PLACEHOLDER_WORLD);
+    }
   };
 })();

--- a/public/apps/tortuga/index.html
+++ b/public/apps/tortuga/index.html
@@ -11,15 +11,26 @@
     <script defer src="/__/firebase/12.9.0/firebase-firestore-compat.js"></script>
     <script defer src="/__/firebase/init.js?useEmulator=true"></script>
 
+    <!-- Leaflet -->
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.css"
+    />
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.Default.css"
+    />
+
     <!-- Shared Olympus styles -->
     <link rel="stylesheet" href="/styles/app.css" />
 
-    <!-- App-specific styles -->
-    <!-- For small apps, inline styles here work fine.
-         When styles exceed ~100 lines, extract to an external file:
-         <link rel="stylesheet" href="/apps/tortuga/tortuga.css" /> -->
     <style>
-      /* Add custom styles for this app here */
+      .tortuga-map {
+        height: 600px;
+        width: 100%;
+        border-radius: 6px;
+      }
     </style>
   </head>
   <body>
@@ -39,7 +50,7 @@
         <h1 class="app-title">Cartographer</h1>
         <p class="app-subtitle">Build and explore worlds.</p>
         <div class="app-divider"></div>
-        <p class="placeholder-text">World management coming in a future phase.</p>
+        <div id="map-world" class="tortuga-map"></div>
       </section>
 
       <!-- The Account (campaign play) mode shell -->
@@ -47,15 +58,20 @@
         <h1 class="app-title">The Account</h1>
         <p class="app-subtitle">On the account, Captain.</p>
         <div class="app-divider"></div>
-        <p class="placeholder-text">Campaign play coming in a future phase.</p>
+        <div id="map-play" class="tortuga-map"></div>
       </section>
     </main>
 
     <!-- Shared header component -->
     <script src="/js/components/app-header.js"></script>
 
+    <!-- Leaflet -->
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+    <script src="https://unpkg.com/leaflet.markercluster@1.5.3/dist/leaflet.markercluster.js"></script>
+
     <!-- App modules: state first, then helpers, app last -->
     <script src="/apps/tortuga/state.js"></script>
+    <script src="/apps/tortuga/map-renderer.js"></script>
     <script src="/apps/tortuga/firestore.js"></script>
     <script src="/apps/tortuga/app.js"></script>
 

--- a/public/apps/tortuga/map-renderer.js
+++ b/public/apps/tortuga/map-renderer.js
@@ -1,0 +1,356 @@
+(function () {
+  'use strict';
+
+  window.Tortuga = window.Tortuga || {};
+  var T = window.Tortuga;
+
+  var LAYERS = {
+    BASE: 'base',
+    SETTLEMENTS: 'settlements',
+    HAZARDS: 'hazards',
+    TRADE_ROUTES: 'tradeRoutes',
+    FACTION_TERRITORY: 'factionTerritory',
+    WIND_CURRENTS: 'windCurrents',
+  };
+
+  var _map = null;
+  var _layers = {};
+  var _visibility = {};
+
+  function _clearLayers() {
+    Object.keys(_layers).forEach(function (k) {
+      _layers[k].clearLayers();
+    });
+  }
+
+  function _renderBase(world) {
+    if (!world || !world.coastlines) return;
+    world.coastlines.forEach(function (polygon) {
+      L.polygon(polygon, {
+        color: '#4a7c59',
+        fillColor: '#2d5a3d',
+        fillOpacity: 0.6,
+        weight: 2,
+      }).addTo(_layers[LAYERS.BASE]);
+    });
+  }
+
+  function _renderSettlements(world) {
+    if (!world || !world.settlements) return;
+    world.settlements.forEach(function (s) {
+      L.marker(s.pos, { title: s.name })
+        .bindPopup(
+          '<strong>' +
+            s.name +
+            '</strong><br>' +
+            (s.type || '') +
+            (s.faction ? '<br>' + s.faction : '')
+        )
+        .addTo(_layers[LAYERS.SETTLEMENTS]);
+    });
+  }
+
+  function _renderHazards(world) {
+    if (!world || !world.hazards) return;
+    world.hazards.forEach(function (h) {
+      L.polygon(h.polygon, {
+        color: '#cc4444',
+        fillColor: '#ff0000',
+        fillOpacity: 0.25,
+        weight: 1,
+      })
+        .bindPopup('<strong>' + (h.name || 'Hazard') + '</strong><br>' + (h.type || ''))
+        .addTo(_layers[LAYERS.HAZARDS]);
+    });
+  }
+
+  function _renderTradeRoutes(world) {
+    if (!world || !world.tradeRoutes) return;
+    world.tradeRoutes.forEach(function (r) {
+      L.polyline(r.points, {
+        color: '#c8a84b',
+        weight: 2,
+        dashArray: '6 4',
+        opacity: 0.85,
+      })
+        .bindPopup(r.name || 'Trade route')
+        .addTo(_layers[LAYERS.TRADE_ROUTES]);
+    });
+  }
+
+  function _renderFactionTerritory(world) {
+    if (!world || !world.factionTerritory) return;
+    world.factionTerritory.forEach(function (ft) {
+      L.polygon(ft.polygon, {
+        color: ft.color || '#888888',
+        fillColor: ft.color || '#888888',
+        fillOpacity: 0.2,
+        weight: 1,
+      })
+        .bindPopup('<strong>' + (ft.name || 'Territory') + '</strong><br>' + (ft.faction || ''))
+        .addTo(_layers[LAYERS.FACTION_TERRITORY]);
+    });
+  }
+
+  // Wind/current zones rendered as styled polygons with direction in tooltip.
+  // Full SVG arrow overlays are a Phase 2 enhancement.
+  function _renderWindCurrents(world) {
+    if (!world || !world.windCurrentZones) return;
+    world.windCurrentZones.forEach(function (wz) {
+      L.polygon(wz.bounds, {
+        color: '#6699cc',
+        fillColor: '#99bbdd',
+        fillOpacity: 0.15,
+        weight: 1,
+        dashArray: '4 4',
+      })
+        .bindPopup(
+          '<strong>' +
+            (wz.name || 'Wind zone') +
+            '</strong><br>' +
+            (wz.direction || '') +
+            (wz.strength ? ' &mdash; ' + wz.strength : '')
+        )
+        .addTo(_layers[LAYERS.WIND_CURRENTS]);
+    });
+  }
+
+  T.mapRenderer = {
+    LAYERS: LAYERS,
+
+    PLACEHOLDER_WORLD: {
+      bounds: [
+        [0, 0],
+        [600, 800],
+      ],
+      coastlines: [
+        [
+          [100, 150],
+          [80, 300],
+          [120, 450],
+          [200, 500],
+          [300, 520],
+          [380, 480],
+          [420, 350],
+          [400, 200],
+          [300, 120],
+          [200, 100],
+        ],
+        [
+          [200, 600],
+          [180, 650],
+          [220, 680],
+          [260, 660],
+          [270, 620],
+          [240, 595],
+        ],
+      ],
+      settlements: [
+        {
+          id: 's1',
+          name: 'Port Royal',
+          pos: [200, 200],
+          type: 'colonial_port',
+          faction: 'British Crown',
+        },
+        {
+          id: 's2',
+          name: 'Tortuga',
+          pos: [300, 400],
+          type: 'free_port',
+          faction: 'Pirate Brethren',
+        },
+        {
+          id: 's3',
+          name: 'Havana',
+          pos: [150, 380],
+          type: 'colonial_port',
+          faction: 'Spanish Crown',
+        },
+        { id: 's4', name: 'Nassau', pos: [350, 500], type: 'fort', faction: 'British Crown' },
+        { id: 's5', name: 'Hidden Cove', pos: [230, 630], type: 'hidden_cove', faction: null },
+      ],
+      hazards: [
+        {
+          id: 'h1',
+          name: "Devil's Reef",
+          polygon: [
+            [50, 100],
+            [70, 130],
+            [60, 160],
+            [40, 150],
+            [30, 120],
+          ],
+          type: 'reef',
+        },
+        {
+          id: 'h2',
+          name: 'Storm Band',
+          polygon: [
+            [500, 0],
+            [550, 100],
+            [560, 250],
+            [510, 350],
+            [480, 250],
+            [490, 100],
+          ],
+          type: 'storm',
+        },
+      ],
+      tradeRoutes: [
+        {
+          id: 'tr1',
+          name: 'Royal Trade Route',
+          points: [
+            [200, 200],
+            [150, 380],
+            [300, 400],
+          ],
+        },
+        {
+          id: 'tr2',
+          name: 'Caribbean Run',
+          points: [
+            [300, 400],
+            [350, 500],
+            [230, 630],
+          ],
+        },
+      ],
+      factionTerritory: [
+        {
+          id: 'ft1',
+          name: 'British Waters',
+          faction: 'British Crown',
+          color: '#cc4400',
+          polygon: [
+            [80, 100],
+            [80, 350],
+            [250, 380],
+            [260, 200],
+            [180, 80],
+          ],
+        },
+        {
+          id: 'ft2',
+          name: 'Spanish Domain',
+          faction: 'Spanish Crown',
+          color: '#ddaa00',
+          polygon: [
+            [100, 350],
+            [100, 520],
+            [280, 540],
+            [300, 420],
+            [250, 380],
+          ],
+        },
+      ],
+      windCurrentZones: [
+        {
+          id: 'wz1',
+          name: 'Trade Winds',
+          direction: 'E → W',
+          bounds: [
+            [400, 0],
+            [500, 0],
+            [500, 800],
+            [400, 800],
+          ],
+          strength: 'moderate',
+        },
+        {
+          id: 'wz2',
+          name: 'Gulf Current',
+          direction: 'S → N',
+          bounds: [
+            [0, 700],
+            [300, 700],
+            [300, 800],
+            [0, 800],
+          ],
+          strength: 'strong',
+        },
+      ],
+    },
+
+    init: function (containerEl, world) {
+      if (_map) this.destroy();
+
+      _map = L.map(containerEl, {
+        crs: L.CRS.Simple,
+        minZoom: -2,
+        maxZoom: 4,
+        zoomControl: true,
+      });
+
+      _layers[LAYERS.BASE] = L.layerGroup();
+      _layers[LAYERS.SETTLEMENTS] = L.markerClusterGroup();
+      _layers[LAYERS.HAZARDS] = L.layerGroup();
+      _layers[LAYERS.TRADE_ROUTES] = L.layerGroup();
+      _layers[LAYERS.FACTION_TERRITORY] = L.layerGroup();
+      _layers[LAYERS.WIND_CURRENTS] = L.layerGroup();
+
+      Object.keys(_layers).forEach(function (k) {
+        _layers[k].addTo(_map);
+        _visibility[k] = true;
+      });
+
+      if (world) this.setWorld(world);
+    },
+
+    destroy: function () {
+      if (_map) {
+        _map.remove();
+        _map = null;
+        _layers = {};
+        _visibility = {};
+      }
+    },
+
+    setWorld: function (world) {
+      if (!_map) return;
+      _clearLayers();
+      _renderBase(world);
+      _renderSettlements(world);
+      _renderHazards(world);
+      _renderTradeRoutes(world);
+      _renderFactionTerritory(world);
+      _renderWindCurrents(world);
+      this.fitBounds(world);
+    },
+
+    fitBounds: function (world) {
+      if (!_map || !world || !world.bounds) return;
+      _map.fitBounds(world.bounds);
+    },
+
+    showLayer: function (name) {
+      if (!_map || !_layers[name]) return;
+      _layers[name].addTo(_map);
+      _visibility[name] = true;
+    },
+
+    hideLayer: function (name) {
+      if (!_map || !_layers[name]) return;
+      _map.removeLayer(_layers[name]);
+      _visibility[name] = false;
+    },
+
+    toggleLayer: function (name) {
+      if (_visibility[name]) this.hideLayer(name);
+      else this.showLayer(name);
+    },
+
+    isLayerVisible: function (name) {
+      return !!_visibility[name];
+    },
+
+    // Phase 2 hook: register and display a caller-supplied Leaflet layer (e.g. playerFleet).
+    addExternalLayer: function (name, leafletLayer) {
+      if (!_map) return;
+      _layers[name] = leafletLayer;
+      _visibility[name] = true;
+      leafletLayer.addTo(_map);
+    },
+  };
+})();


### PR DESCRIPTION
Implements the Phase 0 shared map renderer backed by Leaflet (L.CRS.Simple)
loaded from CDN. Exposes T.mapRenderer with init/destroy/setWorld/fitBounds,
layer show/hide/toggle/isVisible controls, and an addExternalLayer hook for
the Phase 2 player/fleet layer. Initializes with a placeholder Caribbean
world in both Cartographer and The Account shells.

Closes #184

https://claude.ai/code/session_01GmDtvrZ6zyDvFex4H73Tvy