### PR TITLE
feat(tortuga): world list browser component (issue #185)

### DIFF
--- a/public/apps/tortuga/app.js
+++ b/public/apps/tortuga/app.js
@@ -19,16 +19,40 @@
     T.state.currentMode = mode;
   };
 
+  T._openWorldEditor = function () {
+    var mapEl = document.getElementById('map-world');
+    if (mapEl) {
+      mapEl.classList.remove('hidden');
+      T.mapRenderer.init(mapEl, T.mapRenderer.PLACEHOLDER_WORLD);
+    }
+  };
+
+  T._startNewGame = function () {
+    var mapEl = document.getElementById('map-play');
+    if (mapEl) {
+      mapEl.classList.remove('hidden');
+      T.mapRenderer.init(mapEl, T.mapRenderer.PLACEHOLDER_WORLD);
+    }
+  };
+
   T.init = function (user) {
     T.state.currentUser = user;
     T.state.db = firebase.firestore();
     var mode = getMode();
     T.showMode(mode);
 
-    var containerId = mode === T.MODES.PLAY ? 'map-play' : 'map-world';
-    var containerEl = document.getElementById(containerId);
-    if (containerEl) {
-      T.mapRenderer.init(containerEl, T.mapRenderer.PLACEHOLDER_WORLD);
+    var listId = mode === T.MODES.PLAY ? 'world-list-play' : 'world-list-world';
+    var listEl = document.getElementById(listId);
+    if (listEl) {
+      T.worldList.render(listEl, {
+        onSelect: function (worldId, worldData) {
+          if (mode === T.MODES.PLAY) {
+            T._startNewGame(worldId, worldData);
+          } else {
+            T._openWorldEditor(worldId, worldData);
+          }
+        },
+      });
     }
   };
 })();

--- a/public/apps/tortuga/firestore.js
+++ b/public/apps/tortuga/firestore.js
@@ -44,6 +44,24 @@
         .update(Object.assign({}, data, { updatedAt: ts }));
     },
 
+    onOwnedWorlds: function (callback) {
+      var uid = T.state.currentUser.uid;
+      return T.state.db
+        .collection('tortuga_worlds')
+        .where('createdBy', '==', uid)
+        .onSnapshot(
+          function (snap) {
+            var docs = snap.docs.map(function (d) {
+              return Object.assign({ id: d.id }, d.data());
+            });
+            callback(docs, null);
+          },
+          function (err) {
+            callback(null, err);
+          }
+        );
+    },
+
     deleteWorld: function (id) {
       return T.state.db.collection('tortuga_worlds').doc(id).delete();
     },

--- a/public/apps/tortuga/index.html
+++ b/public/apps/tortuga/index.html
@@ -24,14 +24,7 @@
 
     <!-- Shared Olympus styles -->
     <link rel="stylesheet" href="/styles/app.css" />
-
-    <style>
-      .tortuga-map {
-        height: 600px;
-        width: 100%;
-        border-radius: 6px;
-      }
-    </style>
+    <link rel="stylesheet" href="/apps/tortuga/tortuga.css" />
   </head>
   <body>
     <!-- Shared header — rendered by app-header.js -->
@@ -50,7 +43,8 @@
         <h1 class="app-title">Cartographer</h1>
         <p class="app-subtitle">Build and explore worlds.</p>
         <div class="app-divider"></div>
-        <div id="map-world" class="tortuga-map"></div>
+        <div id="world-list-world" class="world-list"></div>
+        <div id="map-world" class="tortuga-map hidden"></div>
       </section>
 
       <!-- The Account (campaign play) mode shell -->
@@ -58,7 +52,8 @@
         <h1 class="app-title">The Account</h1>
         <p class="app-subtitle">On the account, Captain.</p>
         <div class="app-divider"></div>
-        <div id="map-play" class="tortuga-map"></div>
+        <div id="world-list-play" class="world-list"></div>
+        <div id="map-play" class="tortuga-map hidden"></div>
       </section>
     </main>
 
@@ -73,6 +68,7 @@
     <script src="/apps/tortuga/state.js"></script>
     <script src="/apps/tortuga/map-renderer.js"></script>
     <script src="/apps/tortuga/firestore.js"></script>
+    <script src="/apps/tortuga/world-list.js"></script>
     <script src="/apps/tortuga/app.js"></script>
 
     <script>

--- a/public/apps/tortuga/tortuga.css
+++ b/public/apps/tortuga/tortuga.css
@@ -1,0 +1,138 @@
+/* ── World List ────────────────────────────────────────────── */
+
+.world-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 1rem;
+  margin: 1rem 0;
+}
+
+.world-card {
+  display: flex;
+  flex-direction: column;
+  background: var(--color-surface, #1e1e2e);
+  border: 1px solid var(--color-border, #333);
+  border-radius: 8px;
+  overflow: hidden;
+  cursor: pointer;
+  transition:
+    border-color 0.15s,
+    transform 0.1s;
+}
+
+.world-card:hover {
+  border-color: var(--color-accent, #7c6aff);
+  transform: translateY(-2px);
+}
+
+.world-card-thumb {
+  width: 100%;
+  height: 120px;
+  object-fit: cover;
+  background: var(--color-bg, #12121a);
+}
+
+.world-card-thumb--placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2.5rem;
+  background: var(--color-bg, #12121a);
+}
+
+.world-card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.75rem;
+}
+
+.world-card-name {
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: var(--color-text, #e0e0e0);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.world-card-meta {
+  font-size: 0.78rem;
+  color: var(--color-text-muted, #888);
+}
+
+.world-card-badge {
+  display: inline-block;
+  margin-top: 0.25rem;
+  padding: 0.1rem 0.5rem;
+  background: var(--color-accent-dim, rgba(124, 106, 255, 0.2));
+  color: var(--color-accent, #7c6aff);
+  border-radius: 999px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  align-self: flex-start;
+}
+
+/* ── Skeleton ──────────────────────────────────────────────── */
+
+@keyframes world-card-pulse {
+  0%,
+  100% {
+    opacity: 0.4;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+.world-card--skeleton {
+  cursor: default;
+  pointer-events: none;
+}
+
+.world-card--skeleton:hover {
+  border-color: var(--color-border, #333);
+  transform: none;
+}
+
+.skeleton-block {
+  width: 100%;
+  height: 120px;
+  background: var(--color-border, #333);
+  animation: world-card-pulse 1.4s ease-in-out infinite;
+}
+
+.skeleton-line {
+  height: 0.75rem;
+  border-radius: 4px;
+  background: var(--color-border, #333);
+  animation: world-card-pulse 1.4s ease-in-out infinite;
+}
+
+.skeleton-line--title {
+  width: 70%;
+}
+
+.skeleton-line--sub {
+  width: 50%;
+  margin-top: 0.25rem;
+}
+
+/* ── Empty state ───────────────────────────────────────────── */
+
+.world-list-empty {
+  grid-column: 1 / -1;
+  text-align: center;
+  color: var(--color-text-muted, #888);
+  font-style: italic;
+  padding: 2rem 0;
+}
+
+/* ── Map container ─────────────────────────────────────────── */
+
+.tortuga-map {
+  height: 600px;
+  width: 100%;
+  border-radius: 6px;
+}

--- a/public/apps/tortuga/world-list.js
+++ b/public/apps/tortuga/world-list.js
@@ -1,0 +1,190 @@
+(function () {
+  'use strict';
+
+  window.Tortuga = window.Tortuga || {};
+  var T = window.Tortuga;
+
+  var ERA_LABELS = {
+    caribbean_golden_age: 'Caribbean Golden Age',
+    mediterranean_corsair: 'Mediterranean Corsair',
+    indian_ocean: 'Indian Ocean',
+    freeform: 'Freeform',
+  };
+
+  function renderSkeleton(container) {
+    container.innerHTML = '';
+    for (var i = 0; i < 3; i++) {
+      var card = document.createElement('div');
+      card.className = 'world-card world-card--skeleton';
+
+      var block = document.createElement('div');
+      block.className = 'skeleton-block';
+      card.appendChild(block);
+
+      var body = document.createElement('div');
+      body.className = 'world-card-body';
+
+      var lineTitle = document.createElement('div');
+      lineTitle.className = 'skeleton-line skeleton-line--title';
+      body.appendChild(lineTitle);
+
+      var lineSub = document.createElement('div');
+      lineSub.className = 'skeleton-line skeleton-line--sub';
+      body.appendChild(lineSub);
+
+      card.appendChild(body);
+      container.appendChild(card);
+    }
+  }
+
+  function renderEmpty(container) {
+    container.innerHTML = '';
+    var msg = document.createElement('p');
+    msg.className = 'world-list-empty';
+    msg.textContent = 'No worlds found. Use The Cartographer to create one.';
+    container.appendChild(msg);
+  }
+
+  function buildCard(world, onSelect) {
+    var card = document.createElement('div');
+    card.className = 'world-card';
+
+    var thumb;
+    if (world.thumbnail) {
+      thumb = document.createElement('img');
+      thumb.className = 'world-card-thumb';
+      thumb.src = world.thumbnail;
+      thumb.alt = '';
+    } else {
+      thumb = document.createElement('div');
+      thumb.className = 'world-card-thumb world-card-thumb--placeholder';
+      thumb.textContent = '🗺️';
+    }
+    card.appendChild(thumb);
+
+    var body = document.createElement('div');
+    body.className = 'world-card-body';
+
+    var nameEl = document.createElement('span');
+    nameEl.className = 'world-card-name';
+    nameEl.textContent = world.name || 'Untitled World';
+    body.appendChild(nameEl);
+
+    var eraLabel = ERA_LABELS[world.era] || world.era || 'Unknown Era';
+    var settlementCount = (world.settlements || []).length;
+
+    var metaEl = document.createElement('span');
+    metaEl.className = 'world-card-meta';
+    metaEl.textContent =
+      eraLabel + ' · ' + settlementCount + ' settlement' + (settlementCount !== 1 ? 's' : '');
+    body.appendChild(metaEl);
+
+    if (world.createdBy === T.state.currentUser.uid) {
+      var badge = document.createElement('span');
+      badge.className = 'world-card-badge';
+      badge.textContent = 'Your World';
+      body.appendChild(badge);
+    }
+
+    card.appendChild(body);
+
+    card.addEventListener('click', function () {
+      onSelect(world.id, world);
+    });
+
+    return card;
+  }
+
+  function renderWorlds(container, sharedWorlds, ownedWorlds, onSelect) {
+    // Merge: owned worlds take precedence (covers owned-but-not-shared)
+    var merged = Object.assign({}, sharedWorlds, ownedWorlds);
+    var worlds = Object.keys(merged).map(function (id) {
+      return merged[id];
+    });
+
+    if (worlds.length === 0) {
+      renderEmpty(container);
+      return;
+    }
+
+    worlds.sort(function (a, b) {
+      var ta = a.updatedAt && a.updatedAt.toMillis ? a.updatedAt.toMillis() : 0;
+      var tb = b.updatedAt && b.updatedAt.toMillis ? b.updatedAt.toMillis() : 0;
+      return tb - ta;
+    });
+
+    container.innerHTML = '';
+    worlds.forEach(function (w) {
+      container.appendChild(buildCard(w, onSelect));
+    });
+  }
+
+  T.worldList = {
+    _container: null,
+    _onSelect: null,
+    _unsubscribes: [],
+    _sharedWorlds: {},
+    _ownedWorlds: {},
+    _sharedLoaded: false,
+    _ownedLoaded: false,
+
+    _mergeAndRender: function () {
+      if (!this._sharedLoaded || !this._ownedLoaded) return;
+      renderWorlds(this._container, this._sharedWorlds, this._ownedWorlds, this._onSelect);
+    },
+
+    render: function (containerEl, opts) {
+      this.destroy();
+
+      this._container = containerEl;
+      this._onSelect = opts.onSelect || function () {};
+      this._sharedWorlds = {};
+      this._ownedWorlds = {};
+      this._sharedLoaded = false;
+      this._ownedLoaded = false;
+
+      renderSkeleton(containerEl);
+
+      var self = this;
+
+      var unsubShared = T.firestore.listWorlds(function (worlds, err) {
+        if (err) {
+          console.error('[world-list] shared worlds error', err);
+          self._sharedLoaded = true;
+          self._mergeAndRender();
+          return;
+        }
+        self._sharedWorlds = {};
+        worlds.forEach(function (w) {
+          self._sharedWorlds[w.id] = w;
+        });
+        self._sharedLoaded = true;
+        self._mergeAndRender();
+      });
+
+      var unsubOwned = T.firestore.onOwnedWorlds(function (worlds, err) {
+        if (err) {
+          console.error('[world-list] owned worlds error', err);
+          self._ownedLoaded = true;
+          self._mergeAndRender();
+          return;
+        }
+        self._ownedWorlds = {};
+        worlds.forEach(function (w) {
+          self._ownedWorlds[w.id] = w;
+        });
+        self._ownedLoaded = true;
+        self._mergeAndRender();
+      });
+
+      this._unsubscribes = [unsubShared, unsubOwned];
+    },
+
+    destroy: function () {
+      this._unsubscribes.forEach(function (u) {
+        if (typeof u === 'function') u();
+      });
+      this._unsubscribes = [];
+    },
+  };
+})();


### PR DESCRIPTION
## Summary

- Adds `world-list.js` — a shared `T.worldList` component used by both The Cartographer (`?mode=world`) and The Account (`?mode=play`) to browse available worlds before entering a map
- Adds `tortuga.css` for world card grid styles, skeleton shimmer animation, and empty state
- `firestore.js`: new `onOwnedWorlds(callback)` snapshot listener querying `createdBy == uid`
- `app.js`: world-list-first init flow; `T._openWorldEditor` and `T._startNewGame` stubs wire up the map on world select
- `index.html`: links `tortuga.css`, adds world-list containers, loads `world-list.js`, starts map divs hidden

## What the component does

- Runs two parallel Firestore snapshot listeners (shared worlds + user's own worlds) and deduplicates by world id — honoring the Firestore rule that only `shared == true` or `createdBy == uid` worlds are readable
- Shows a 3-card skeleton while both queries are pending; re-renders on every snapshot change
- Renders a responsive card grid: thumbnail (or `🗺️` placeholder), world name, era label, settlement count, and a "Your World" badge for owned worlds
- Empty state when no worlds exist
- Click handler calls `opts.onSelect(worldId, worldData)` — no routing logic inside the component

## Test plan

- [ ] `npm run lint:fix && npm run format` — no errors or warnings
- [ ] `npm run emulator`, navigate to `localhost:5000/apps/tortuga/`
- [ ] Skeleton cards appear briefly while Firestore resolves
- [ ] Empty state renders in both `?mode=world` and `?mode=play` with no worlds seeded
- [ ] Seed a world with `shared: true` in emulator UI → appears in both modes
- [ ] Seed a world with `shared: false, createdBy: <your-uid>` → appears (owned)
- [ ] Seed a world with `shared: false, createdBy: <other-uid>` → does **not** appear (Firestore rules block it)
- [ ] Click a card → map div unhides and renders placeholder world

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)