### PR TITLE
fix(tortuga): pivot importer to Azgaar "Save as JSON" format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,7 @@ node_modules/
 
 # dataconnect generated files
 .dataconnect
+
+# Large Azgaar JSON exports used as manual-test artifacts
+# (Jest uses a small synthetic fixture in azgaar-json-sample.js instead)
+tests/fixtures/*.json

--- a/planning/tortuga-design.md
+++ b/planning/tortuga-design.md
@@ -86,13 +86,14 @@ Script load order in `index.html` follows the existing pattern: `state.js` → m
 
 ### Input formats
 
-- **Azgaar `.map`** (custom text format) — primary target, since it carries the most data including burgs, states, climate, and routes
-- **Azgaar GeoJSON** — secondary, simpler to parse, smaller feature set
-- Both are parsed client-side; no upload to Cloud Functions needed for ingest
+- **Azgaar JSON** (the full "Menu → Save → Save as JSON" export) — primary target. Single file carrying `info`, `pack.{burgs, states, features, vertices, cells, rivers, routes}`, and `biomesData`. Has everything we need.
+- **Azgaar `.map`** (custom text format) — secondary, may be added later for users who only have a `.map` save.
+- **Azgaar GeoJSON exports are NOT supported.** Azgaar partitions GeoJSON output into separate files (cells, routes, rivers, markers, zones); none of those carry burgs/states on their own, so they can't produce a playable world. The importer rejects them with a message pointing the user at "Save as JSON".
+- All formats are parsed client-side; no upload to Cloud Functions needed for ingest.
 
 ### Pipeline
 
-1. **Upload** — User drops a `.map` or `.geojson` into the importer.
+1. **Upload** — User drops an Azgaar `.json` (full "Save as JSON" export) into the importer. `.map` parsing is a future addition.
 2. **Parse** — Extract: coastline polygons, water cells, biomes, burgs (potential ports), state borders, rivers (deep-water inland reach), climate (storm bands).
 3. **Recommend** — Inspect water-to-land ratio. If land > ~60%, surface a soft warning: _"This map is land-heavy. Tortuga plays best on oceanic maps. Continue anyway?"_
 4. **Overlay generation** — Apply pirate flair:

--- a/public/apps/tortuga/cartographer/importer.js
+++ b/public/apps/tortuga/cartographer/importer.js
@@ -1,179 +1,153 @@
 (function () {
   'use strict';
 
-  window.Tortuga = window.Tortuga || {};
-  var T = window.Tortuga;
-
   /*
-   * Intermediate world-data shape produced by parseGeoJSON:
-   * {
-   *   sourceFormat: 'azgaar-geojson',
-   *   bounds:       [[minY, minX], [maxY, maxX]],  // Leaflet CRS.Simple [lat, lng] = [y, x]
-   *   dimensions:   { width: number, height: number },
-   *   coastlines:   [ [[y, x], ...], ... ],         // one ring per land polygon
-   *   waterCells:   [ { polygon: [[y, x], ...] } ], // ocean/sea/lake areas
-   *   biomes:       [ { name: string, polygon: [[y, x], ...] } ],
-   *   burgs:        [ { id, name, pos: [y, x], population, stateId, isPort } ],
-   *   stateBorders: [ { id, name, color, polygon: [[y, x], ...] } ],
-   * }
+   * Azgaar Fantasy Map Generator "Save as JSON" full export.
    *
-   * Azgaar GeoJSON coordinates are [x, y] (GeoJSON convention); we swap to
-   * Leaflet [lat, lng] = [y, x] throughout so the shape is renderer-ready.
+   * Top-level keys: info, settings, mapCoordinates, pack, grid, biomesData, notes, nameBases.
+   * Tortuga's importer only reads what it needs from `info`, `pack`, and `biomesData`.
+   *
+   * pack.burgs[]    — settlements. burgs[0] is a blank slot, real entries have i > 0.
+   * pack.states[]   — political states (faction source). states[0] is "Neutrals", skip it.
+   * pack.features[] — land/water masses, each carries vertex indices into pack.vertices[].
+   * pack.vertices[] — { i, p:[x,y], v:[...], c:[...] }
+   * pack.cells[]    — terrain cells; `.f` points at a feature; `.v` are vertex indices; `.p` is centroid.
+   *
+   * Coordinates in Azgaar are pixel-space [x, y] (y increases downward).
+   * We swap to Leaflet [lat, lng] = [y, x] for L.CRS.Simple. We do NOT flip y;
+   * the renderer treats the map as a raster canvas where y-down is fine.
+   *
+   * Intermediate world-data shape produced by parseAzgaarJson:
+   * {
+   *   sourceFormat: 'azgaar-json',
+   *   info:         { name, seed, version, width, height },
+   *   bounds:       [[minY, minX], [maxY, maxX]],
+   *   dimensions:   { width, height },
+   *   coastlines:   [ [[y, x], ...], ... ],          // one ring per island/continent
+   *   lakes:        [ { name, polygon: [[y, x], ...] } ],
+   *   biomes:       [ { id, name, color } ],          // catalog only; per-cell lookup via cells[].biome
+   *   burgs:        [ { id, name, pos: [y, x], population, stateId, isPort, isCapital, group } ],
+   *   stateBorders: [ { id, name, color, fullName, capitalBurgId } ],
+   * }
    */
 
-  var OCEAN_BIOMES = ['ocean', 'sea ice'];
-
-  function _isOceanBiome(name) {
-    return OCEAN_BIOMES.indexOf((name || '').toLowerCase()) !== -1;
-  }
-
-  // GeoJSON [x, y] → Leaflet [y, x]
   function _toLeaflet(coord) {
     return [coord[1], coord[0]];
   }
 
-  function _ringToLeaflet(ring) {
-    return ring.map(_toLeaflet);
+  function _dereferenceVertices(vertexIdxs, vertices) {
+    var ring = [];
+    for (var i = 0; i < vertexIdxs.length; i++) {
+      var v = vertices[vertexIdxs[i]];
+      if (v && v.p) ring.push(_toLeaflet(v.p));
+    }
+    return ring;
   }
 
-  // Returns the first exterior ring of a Polygon or MultiPolygon as [[y,x],...].
-  // For MultiPolygon we flatten all exterior rings.
-  function _extractExteriorRings(geom) {
-    if (geom.type === 'Polygon') {
-      return [_ringToLeaflet(geom.coordinates[0])];
-    }
-    if (geom.type === 'MultiPolygon') {
-      return geom.coordinates.map(function (poly) {
-        return _ringToLeaflet(poly[0]);
-      });
-    }
-    return [];
+  function _isAzgaarJson(json) {
+    return (
+      json &&
+      typeof json === 'object' &&
+      json.info &&
+      json.pack &&
+      Array.isArray(json.pack.burgs) &&
+      Array.isArray(json.pack.features) &&
+      Array.isArray(json.pack.vertices)
+    );
   }
 
-  function _computeBounds(features) {
-    var minX = Infinity,
-      minY = Infinity,
-      maxX = -Infinity,
-      maxY = -Infinity;
-
-    function scanCoord(c) {
-      if (c[0] < minX) minX = c[0];
-      if (c[0] > maxX) maxX = c[0];
-      if (c[1] < minY) minY = c[1];
-      if (c[1] > maxY) maxY = c[1];
+  function parseAzgaarJson(json) {
+    if (!_isAzgaarJson(json)) {
+      throw new Error(
+        'Not an Azgaar JSON export. Use Azgaar\'s "Save → Save as JSON" option (not the partitioned GeoJSON exports).'
+      );
     }
 
-    function scanGeom(geom) {
-      if (!geom) return;
-      if (geom.type === 'Point') {
-        scanCoord(geom.coordinates);
-      } else if (geom.type === 'LineString') {
-        geom.coordinates.forEach(scanCoord);
-      } else if (geom.type === 'Polygon') {
-        geom.coordinates.forEach(function (ring) {
-          ring.forEach(scanCoord);
-        });
-      } else if (geom.type === 'MultiPolygon') {
-        geom.coordinates.forEach(function (poly) {
-          poly.forEach(function (ring) {
-            ring.forEach(scanCoord);
-          });
-        });
-      }
-    }
+    var info = json.info || {};
+    var pack = json.pack;
+    var biomesData = json.biomesData || {};
 
-    features.forEach(function (f) {
-      scanGeom(f.geometry);
-    });
-
-    if (!isFinite(minX))
-      return [
-        [0, 0],
-        [1000, 1000],
-      ];
-    // Leaflet [lat, lng] = [y, x]
-    return [
-      [minY, minX],
-      [maxY, maxX],
-    ];
-  }
-
-  function parseGeoJSON(geojson) {
-    if (!geojson || geojson.type !== 'FeatureCollection' || !Array.isArray(geojson.features)) {
-      throw new Error('Not a valid GeoJSON FeatureCollection.');
-    }
-    if (geojson.features.length === 0) {
-      throw new Error('GeoJSON contains no features.');
+    var width = info.width || 0;
+    var height = info.height || 0;
+    if (!width || !height) {
+      throw new Error('Azgaar JSON is missing map dimensions in `info`.');
     }
 
     var coastlines = [];
-    var waterCells = [];
-    var biomes = [];
-    var burgs = [];
-    var stateBorders = [];
-
-    geojson.features.forEach(function (feature, idx) {
-      var props = feature.properties || {};
-      var geom = feature.geometry;
-      if (!geom) return;
-
-      var type = (props.type || '').toLowerCase();
-
-      if (type === 'burg' && geom.type === 'Point') {
-        burgs.push({
-          id: 'burg_' + (props.i != null ? props.i : idx),
-          name: props.name || 'Unknown',
-          pos: _toLeaflet(geom.coordinates),
-          population: props.population || 0,
-          stateId: props.state != null ? props.state : null,
-          isPort: !!props.port,
-        });
-      } else if (type === 'state' && (geom.type === 'Polygon' || geom.type === 'MultiPolygon')) {
-        var stateRings = _extractExteriorRings(geom);
-        stateRings.forEach(function (ring, ri) {
-          stateBorders.push({
-            id: 'state_' + (props.i != null ? props.i : idx) + '_' + ri,
-            name: props.name || 'Unknown State',
-            color: props.color || '#888888',
-            polygon: ring,
-          });
-        });
-      } else if (type === 'biome' && (geom.type === 'Polygon' || geom.type === 'MultiPolygon')) {
-        var biomeName = props.name || 'Unknown';
-        var biomeRings = _extractExteriorRings(geom);
-        biomeRings.forEach(function (ring) {
-          biomes.push({ name: biomeName, polygon: ring });
-          if (_isOceanBiome(biomeName)) {
-            waterCells.push({ polygon: ring });
-          } else {
-            coastlines.push(ring);
-          }
-        });
-      } else if (type === 'lake' && (geom.type === 'Polygon' || geom.type === 'MultiPolygon')) {
-        _extractExteriorRings(geom).forEach(function (ring) {
-          waterCells.push({ polygon: ring });
-        });
+    var lakes = [];
+    pack.features.forEach(function (f) {
+      if (!f || !Array.isArray(f.vertices) || f.vertices.length === 0) return;
+      var ring = _dereferenceVertices(f.vertices, pack.vertices);
+      if (ring.length < 3) return;
+      if (f.type === 'island') {
+        coastlines.push(ring);
+      } else if (f.type === 'lake') {
+        lakes.push({ name: f.name || 'Lake', polygon: ring });
       }
     });
 
+    var burgs = [];
+    pack.burgs.forEach(function (b) {
+      if (!b || !b.i) return;
+      burgs.push({
+        id: 'burg_' + b.i,
+        name: b.name || 'Unknown',
+        pos: [b.y, b.x],
+        population: typeof b.population === 'number' ? b.population : 0,
+        stateId: b.state || 0,
+        isPort: !!b.port,
+        isCapital: !!b.capital,
+        group: b.group || null,
+        culture: b.culture || 0,
+        type: b.type || null,
+      });
+    });
+
     if (burgs.length === 0) {
-      throw new Error('No burg features found — is this an Azgaar GeoJSON export?');
-    }
-    if (coastlines.length === 0 && waterCells.length === 0) {
-      throw new Error('Could not identify land or water features.');
+      throw new Error('Azgaar JSON contained no burgs (settlements).');
     }
 
-    var bounds = _computeBounds(geojson.features);
+    var stateBorders = [];
+    pack.states.forEach(function (s) {
+      if (!s || !s.i) return;
+      stateBorders.push({
+        id: 'state_' + s.i,
+        name: s.name || 'Unknown State',
+        fullName: s.fullName || s.name || 'Unknown State',
+        color: s.color || '#888888',
+        capitalBurgId: s.capital ? 'burg_' + s.capital : null,
+      });
+    });
+
+    var biomes = [];
+    var biomeNames = biomesData.name || [];
+    var biomeColors = biomesData.color || [];
+    for (var bi = 0; bi < biomeNames.length; bi++) {
+      biomes.push({
+        id: bi,
+        name: biomeNames[bi],
+        color: biomeColors[bi] || '#888888',
+      });
+    }
+
+    var bounds = [
+      [0, 0],
+      [height, width],
+    ];
 
     return {
-      sourceFormat: 'azgaar-geojson',
-      bounds: bounds,
-      dimensions: {
-        width: bounds[1][1] - bounds[0][1],
-        height: bounds[1][0] - bounds[0][0],
+      sourceFormat: 'azgaar-json',
+      info: {
+        name: info.mapName || 'Unnamed Map',
+        seed: info.seed || null,
+        version: info.version || null,
+        width: width,
+        height: height,
       },
+      bounds: bounds,
+      dimensions: { width: width, height: height },
       coastlines: coastlines,
-      waterCells: waterCells,
+      lakes: lakes,
       biomes: biomes,
       burgs: burgs,
       stateBorders: stateBorders,
@@ -183,32 +157,35 @@
   // Build the renderer-compatible preview world from the parsed intermediate shape.
   // Overlay generation (T-104–T-107) will replace this with richer data later.
   function _toPreviewWorld(parsed) {
+    var stateColorById = {};
+    parsed.stateBorders.forEach(function (s) {
+      stateColorById[s.id] = s.color;
+    });
+
     return {
       bounds: parsed.bounds,
       coastlines: parsed.coastlines,
       settlements: parsed.burgs.map(function (b) {
+        var stateId = 'state_' + b.stateId;
         return {
           id: b.id,
           name: b.name,
           pos: b.pos,
-          type: b.isPort ? 'port' : 'burg',
-          faction: null,
+          type: b.isPort ? 'port' : b.isCapital ? 'capital' : 'burg',
+          faction: b.stateId ? stateId : null,
+          factionColor: stateColorById[stateId] || null,
         };
       }),
-      hazards: [],
+      hazards: parsed.lakes.map(function (l, i) {
+        return { id: 'lake_' + i, name: l.name, type: 'lake', polygon: l.polygon };
+      }),
       tradeRoutes: [],
-      factionTerritory: parsed.stateBorders.map(function (s) {
-        return {
-          id: s.id,
-          name: s.name,
-          faction: s.name,
-          color: s.color,
-          polygon: s.polygon,
-        };
-      }),
+      factionTerritory: [],
       windCurrentZones: [],
     };
   }
+
+  // ---- Browser UI bindings (skipped in Node test environments) ----
 
   function _showError(dropZoneEl, errorEl, msg) {
     errorEl.textContent = msg;
@@ -225,8 +202,8 @@
     if (!file) return;
 
     var lower = file.name.toLowerCase();
-    if (!lower.endsWith('.geojson') && !lower.endsWith('.json')) {
-      _showError(dropZoneEl, errorEl, 'Please drop a .geojson or .json file.');
+    if (!lower.endsWith('.json')) {
+      _showError(dropZoneEl, errorEl, 'Please drop an Azgaar .json export.');
       return;
     }
 
@@ -236,9 +213,9 @@
     var reader = new FileReader();
     reader.onload = function (e) {
       dropZoneEl.classList.remove('drop-zone--loading');
-      var geojson;
+      var json;
       try {
-        geojson = JSON.parse(e.target.result);
+        json = JSON.parse(e.target.result);
       } catch (parseErr) {
         var msg = 'File is not valid JSON: ' + parseErr.message;
         _showError(dropZoneEl, errorEl, msg);
@@ -248,7 +225,7 @@
 
       var parsed;
       try {
-        parsed = parseGeoJSON(geojson);
+        parsed = parseAzgaarJson(json);
       } catch (err) {
         _showError(dropZoneEl, errorEl, err.message);
         if (callbacks.onError) callbacks.onError(err.message);
@@ -267,54 +244,69 @@
     reader.readAsText(file);
   }
 
-  T.importer = {
-    render: function (containerEl, callbacks) {
-      containerEl.innerHTML =
-        '<div class="import-panel">' +
-        '<h2 class="import-panel-title">Import World</h2>' +
-        '<p class="import-panel-hint">Drop an Azgaar Fantasy Map Generator <code>.geojson</code> export below.</p>' +
-        '<div class="drop-zone" id="cartographer-drop-zone">' +
-        '<span class="drop-zone-label">Drop .geojson here</span>' +
-        '<label class="drop-zone-pick">or <span class="drop-zone-pick-link">choose a file</span>' +
-        '<input type="file" accept=".geojson,.json" id="cartographer-file-input" style="display:none">' +
-        '</label>' +
-        '</div>' +
-        '<div class="import-error hidden" id="cartographer-import-error"></div>' +
-        '</div>';
+  function render(containerEl, callbacks) {
+    containerEl.innerHTML =
+      '<div class="import-panel">' +
+      '<h2 class="import-panel-title">Import World</h2>' +
+      '<p class="import-panel-hint">In Azgaar Fantasy Map Generator, use ' +
+      '<strong>Menu → Save → Save as JSON</strong> to export the full map, ' +
+      'then drop the <code>.json</code> file here. ' +
+      '(The partitioned GeoJSON exports — cells, routes, rivers, markers, zones — are not supported.)</p>' +
+      '<div class="drop-zone" id="cartographer-drop-zone">' +
+      '<span class="drop-zone-label">Drop Azgaar .json here</span>' +
+      '<label class="drop-zone-pick">or <span class="drop-zone-pick-link">choose a file</span>' +
+      '<input type="file" accept=".json,application/json" id="cartographer-file-input" style="display:none">' +
+      '</label>' +
+      '</div>' +
+      '<div class="import-error hidden" id="cartographer-import-error"></div>' +
+      '</div>';
 
-      var dropZoneEl = containerEl.querySelector('#cartographer-drop-zone');
-      var fileInputEl = containerEl.querySelector('#cartographer-file-input');
-      var errorEl = containerEl.querySelector('#cartographer-import-error');
+    var dropZoneEl = containerEl.querySelector('#cartographer-drop-zone');
+    var fileInputEl = containerEl.querySelector('#cartographer-file-input');
+    var errorEl = containerEl.querySelector('#cartographer-import-error');
 
-      dropZoneEl.addEventListener('dragover', function (e) {
-        e.preventDefault();
-        dropZoneEl.classList.add('drop-zone--active');
-      });
+    dropZoneEl.addEventListener('dragover', function (e) {
+      e.preventDefault();
+      dropZoneEl.classList.add('drop-zone--active');
+    });
 
-      dropZoneEl.addEventListener('dragleave', function () {
-        dropZoneEl.classList.remove('drop-zone--active');
-      });
+    dropZoneEl.addEventListener('dragleave', function () {
+      dropZoneEl.classList.remove('drop-zone--active');
+    });
 
-      dropZoneEl.addEventListener('drop', function (e) {
-        e.preventDefault();
-        dropZoneEl.classList.remove('drop-zone--active');
-        var file = e.dataTransfer.files && e.dataTransfer.files[0];
-        _processFile(file, dropZoneEl, errorEl, callbacks);
-      });
+    dropZoneEl.addEventListener('drop', function (e) {
+      e.preventDefault();
+      dropZoneEl.classList.remove('drop-zone--active');
+      var file = e.dataTransfer.files && e.dataTransfer.files[0];
+      _processFile(file, dropZoneEl, errorEl, callbacks);
+    });
 
-      dropZoneEl.addEventListener('click', function (e) {
-        // Only trigger file picker when clicking the label area, not the whole zone accidentally.
-        if (e.target !== fileInputEl) fileInputEl.click();
-      });
+    dropZoneEl.addEventListener('click', function (e) {
+      if (e.target !== fileInputEl) fileInputEl.click();
+    });
 
-      fileInputEl.addEventListener('change', function () {
-        var file = fileInputEl.files && fileInputEl.files[0];
-        _processFile(file, dropZoneEl, errorEl, callbacks);
-        // Reset so the same file can be re-selected after an error.
-        fileInputEl.value = '';
-      });
-    },
+    fileInputEl.addEventListener('change', function () {
+      var file = fileInputEl.files && fileInputEl.files[0];
+      _processFile(file, dropZoneEl, errorEl, callbacks);
+      fileInputEl.value = '';
+    });
+  }
 
-    parseGeoJSON: parseGeoJSON,
+  var api = {
+    parseAzgaarJson: parseAzgaarJson,
+    toPreviewWorld: _toPreviewWorld,
+    render: render,
   };
+
+  if (typeof window !== 'undefined') {
+    window.Tortuga = window.Tortuga || {};
+    window.Tortuga.importer = api;
+  }
+
+  // CommonJS export for Jest tests (Node-only path, ignored in the browser).
+  // eslint-disable-next-line no-undef
+  if (typeof module !== 'undefined' && module.exports) {
+    // eslint-disable-next-line no-undef
+    module.exports = api;
+  }
 })();

--- a/tests/fixtures/azgaar-json-sample.js
+++ b/tests/fixtures/azgaar-json-sample.js
@@ -1,0 +1,111 @@
+// Minimal synthetic Azgaar "Save as JSON" export used by tortuga-importer.test.js.
+// Mirrors the shape of pack.{burgs,states,features,vertices,cells} and biomesData
+// from a real Azgaar v1.122.x export. Coordinates are in pixel space [x, y].
+//
+// Real Azgaar exports run ~5MB; this fixture is just enough to exercise every
+// parser branch: dimensions, vertex deref, island vs lake vs ocean features,
+// blank-slot burgs/states, port flag, biome catalog.
+
+module.exports = {
+  azgaarJsonSample: function () {
+    return {
+      info: {
+        version: '1.122.7',
+        mapName: 'TestIsle',
+        seed: '12345',
+        width: 1000,
+        height: 800,
+      },
+      pack: {
+        // vertex 0 unused; vertices 1–6 form a triangle island and a triangle lake
+        vertices: [
+          { i: 0, p: [0, 0], v: [], c: [] },
+          { i: 1, p: [100, 100], v: [], c: [] }, // island A
+          { i: 2, p: [200, 100], v: [], c: [] },
+          { i: 3, p: [150, 200], v: [], c: [] },
+          { i: 4, p: [500, 500], v: [], c: [] }, // lake
+          { i: 5, p: [600, 500], v: [], c: [] },
+          { i: 6, p: [550, 600], v: [], c: [] },
+          { i: 7, p: [800, 300], v: [], c: [] }, // tiny isle B
+          { i: 8, p: [820, 300], v: [], c: [] },
+          { i: 9, p: [810, 320], v: [], c: [] },
+        ],
+        features: [
+          0, // Azgaar uses 0 as a placeholder at index 0
+          { i: 1, type: 'ocean', cells: 100, area: 0, vertices: [] },
+          { i: 2, type: 'island', group: 'continent', cells: 10, vertices: [1, 2, 3] },
+          { i: 3, type: 'lake', group: 'freshwater', name: 'Mirror Lake', cells: 3, vertices: [4, 5, 6] },
+          { i: 4, type: 'island', group: 'isle', cells: 2, vertices: [7, 8, 9] },
+        ],
+        burgs: [
+          0, // blank slot
+          {
+            i: 1,
+            cell: 100,
+            x: 150,
+            y: 150,
+            name: 'Port Royal',
+            state: 1,
+            culture: 1,
+            population: 12.5,
+            port: 1,
+            capital: 1,
+            group: 'capital',
+            type: 'Naval',
+            feature: 2,
+          },
+          {
+            i: 2,
+            cell: 101,
+            x: 175,
+            y: 175,
+            name: 'Highmount',
+            state: 1,
+            culture: 1,
+            population: 4.3,
+            port: 0,
+            capital: 0,
+            group: 'town',
+          },
+          {
+            i: 3,
+            cell: 200,
+            x: 810,
+            y: 310,
+            name: "Smuggler's Rest",
+            state: 0, // neutral / wild
+            culture: 2,
+            population: 0.6,
+            port: 1,
+            group: 'hamlet',
+          },
+        ],
+        states: [
+          { i: 0, name: 'Neutrals' }, // skipped
+          {
+            i: 1,
+            name: 'Albion',
+            fullName: 'Kingdom of Albion',
+            color: '#cc4400',
+            capital: 1,
+            culture: 1,
+          },
+          {
+            i: 2,
+            name: 'Castile',
+            fullName: 'Crown of Castile',
+            color: '#ddaa00',
+            capital: 0, // no capital — capitalBurgId should be null
+            culture: 2,
+          },
+        ],
+        cells: [], // not used by the current parser
+      },
+      biomesData: {
+        i: [0, 1, 2, 3],
+        name: ['Marine', 'Hot desert', 'Grassland', 'Tropical forest'],
+        color: ['#466eab', '#fbe79f', '#c8d68f', '#b6d95d'],
+      },
+    };
+  },
+};

--- a/tests/tortuga-importer.test.js
+++ b/tests/tortuga-importer.test.js
@@ -1,0 +1,169 @@
+const path = require('path');
+const importer = require(path.join(
+  __dirname,
+  '..',
+  'public',
+  'apps',
+  'tortuga',
+  'cartographer',
+  'importer.js'
+));
+const { azgaarJsonSample } = require('./fixtures/azgaar-json-sample.js');
+
+describe('Tortuga importer — parseAzgaarJson', () => {
+  test('rejects a clearly non-Azgaar payload', () => {
+    expect(() => importer.parseAzgaarJson({ type: 'FeatureCollection', features: [] })).toThrow(
+      /Not an Azgaar JSON export/
+    );
+  });
+
+  test('rejects Azgaar JSON missing dimensions', () => {
+    const sample = azgaarJsonSample();
+    sample.info.width = 0;
+    expect(() => importer.parseAzgaarJson(sample)).toThrow(/missing map dimensions/);
+  });
+
+  test('rejects Azgaar JSON with no real burgs', () => {
+    const sample = azgaarJsonSample();
+    sample.pack.burgs = [0]; // only the blank slot
+    expect(() => importer.parseAzgaarJson(sample)).toThrow(/no burgs/);
+  });
+
+  test('extracts info, bounds, and dimensions', () => {
+    const result = importer.parseAzgaarJson(azgaarJsonSample());
+    expect(result.sourceFormat).toBe('azgaar-json');
+    expect(result.info).toMatchObject({
+      name: 'TestIsle',
+      seed: '12345',
+      version: '1.122.7',
+      width: 1000,
+      height: 800,
+    });
+    expect(result.bounds).toEqual([
+      [0, 0],
+      [800, 1000],
+    ]);
+    expect(result.dimensions).toEqual({ width: 1000, height: 800 });
+  });
+
+  test('coastlines come from island features, dereferenced to [y, x]', () => {
+    const result = importer.parseAzgaarJson(azgaarJsonSample());
+    // Two islands in the fixture: continent (vertices 1,2,3) and isle (7,8,9)
+    expect(result.coastlines).toHaveLength(2);
+    // Continent first; verify vertex deref + [x,y] → [y,x] swap
+    expect(result.coastlines[0]).toEqual([
+      [100, 100], // v1 was [100, 100], swap gives [100, 100] (square coord)
+      [100, 200], // v2 was [200, 100] → [100, 200]
+      [200, 150], // v3 was [150, 200] → [200, 150]
+    ]);
+  });
+
+  test('lakes are captured separately from coastlines, with names', () => {
+    const result = importer.parseAzgaarJson(azgaarJsonSample());
+    expect(result.lakes).toHaveLength(1);
+    expect(result.lakes[0].name).toBe('Mirror Lake');
+    expect(result.lakes[0].polygon).toEqual([
+      [500, 500], // v4: [500, 500]
+      [500, 600], // v5: [600, 500] → [500, 600]
+      [600, 550], // v6: [550, 600] → [600, 550]
+    ]);
+  });
+
+  test('burgs skip the blank slot, preserve isPort/isCapital, and use [y, x] position', () => {
+    const result = importer.parseAzgaarJson(azgaarJsonSample());
+    expect(result.burgs).toHaveLength(3);
+
+    const portRoyal = result.burgs.find((b) => b.id === 'burg_1');
+    expect(portRoyal).toMatchObject({
+      id: 'burg_1',
+      name: 'Port Royal',
+      pos: [150, 150],
+      stateId: 1,
+      isPort: true,
+      isCapital: true,
+      group: 'capital',
+      type: 'Naval',
+    });
+
+    const highmount = result.burgs.find((b) => b.id === 'burg_2');
+    expect(highmount.isPort).toBe(false);
+    expect(highmount.isCapital).toBe(false);
+
+    const smugglers = result.burgs.find((b) => b.id === 'burg_3');
+    expect(smugglers.stateId).toBe(0); // wild/neutral
+    expect(smugglers.isPort).toBe(true);
+  });
+
+  test('stateBorders skip Neutrals (i=0) and handle missing capital', () => {
+    const result = importer.parseAzgaarJson(azgaarJsonSample());
+    expect(result.stateBorders).toHaveLength(2);
+
+    const albion = result.stateBorders.find((s) => s.id === 'state_1');
+    expect(albion).toMatchObject({
+      name: 'Albion',
+      fullName: 'Kingdom of Albion',
+      color: '#cc4400',
+      capitalBurgId: 'burg_1',
+    });
+
+    const castile = result.stateBorders.find((s) => s.id === 'state_2');
+    expect(castile.capitalBurgId).toBeNull();
+  });
+
+  test('biomes catalog maps parallel name/color arrays', () => {
+    const result = importer.parseAzgaarJson(azgaarJsonSample());
+    expect(result.biomes).toHaveLength(4);
+    expect(result.biomes[0]).toEqual({ id: 0, name: 'Marine', color: '#466eab' });
+    expect(result.biomes[3]).toEqual({ id: 3, name: 'Tropical forest', color: '#b6d95d' });
+  });
+});
+
+// Opt-in: parse a real Azgaar export when present locally (gitignored, 5MB+).
+// Drop any *.json file under tests/fixtures/ to enable this branch.
+describe('Tortuga importer — real Azgaar fixtures (opt-in)', () => {
+  const fs = require('fs');
+  const fixturesDir = path.join(__dirname, 'fixtures');
+  const realFixtures = fs.existsSync(fixturesDir)
+    ? fs.readdirSync(fixturesDir).filter((f) => f.toLowerCase().endsWith('.json'))
+    : [];
+
+  if (realFixtures.length === 0) {
+    test.skip('no real Azgaar JSON fixtures present — skipping', () => {});
+    return;
+  }
+
+  realFixtures.forEach((filename) => {
+    test(`parses ${filename} without throwing and finds burgs/states/coastlines`, () => {
+      const json = JSON.parse(fs.readFileSync(path.join(fixturesDir, filename), 'utf8'));
+      const parsed = importer.parseAzgaarJson(json);
+      expect(parsed.burgs.length).toBeGreaterThan(0);
+      expect(parsed.stateBorders.length).toBeGreaterThan(0);
+      expect(parsed.coastlines.length).toBeGreaterThan(0);
+      const preview = importer.toPreviewWorld(parsed);
+      expect(preview.settlements.length).toBe(parsed.burgs.length);
+    });
+  });
+});
+
+describe('Tortuga importer — toPreviewWorld', () => {
+  test('builds a renderer-compatible world with settlements + lake hazards', () => {
+    const parsed = importer.parseAzgaarJson(azgaarJsonSample());
+    const preview = importer.toPreviewWorld(parsed);
+
+    expect(preview.bounds).toEqual(parsed.bounds);
+    expect(preview.coastlines).toBe(parsed.coastlines);
+    expect(preview.settlements).toHaveLength(3);
+
+    const portRoyal = preview.settlements.find((s) => s.id === 'burg_1');
+    expect(portRoyal.type).toBe('port');
+    expect(portRoyal.faction).toBe('state_1');
+    expect(portRoyal.factionColor).toBe('#cc4400');
+
+    const wildBurg = preview.settlements.find((s) => s.id === 'burg_3');
+    expect(wildBurg.faction).toBeNull();
+    expect(wildBurg.factionColor).toBeNull();
+
+    expect(preview.hazards).toHaveLength(1);
+    expect(preview.hazards[0]).toMatchObject({ name: 'Mirror Lake', type: 'lake' });
+  });
+});


### PR DESCRIPTION
## Summary

- Manual testing of #186 (T-101) revealed Azgaar's GeoJSON exports are partitioned by data type (Cells / Routes / Rivers / Markers / Zones) — none contain burgs, so every real export failed with `No burg features found`. The fix pivots the parser to read Azgaar's "Menu → Save → Save as JSON" full export instead.
- New `parseAzgaarJson()` walks `pack.{burgs, states, features, vertices}` + `biomesData`, dereferences vertex indices to build coastline/lake polygons, skips Azgaar's blank index-0 slots, preserves `port`/`capital`/`group`/`type` on burgs and color/fullName on states.
- Import UI now directs users to "Save as JSON", accepts only `.json`, and explicitly flags the partitioned-GeoJSON case with a clearer error.
- 10 new Jest tests against a small synthetic fixture, plus an opt-in test that parses any real Azgaar `.json` dropped under `tests/fixtures/` (a 5MB Paneia export parses in ~80ms).
- Design doc §3 input-formats rewritten to match reality: JSON primary, `.map` secondary (T-102 reframed), partitioned GeoJSON unsupported.
- Large Azgaar exports are gitignored; the small synthetic fixture lives in `tests/fixtures/azgaar-json-sample.js`.

Refs #186, #187.

## Test plan

- [ ] `cd tests && npx jest tortuga-importer` — 11 tests pass (10 synthetic + 1 opt-in real fixture if present)
- [ ] In the Cartographer UI, drop the Paneia JSON export → import succeeds, settlements and coastlines render
- [ ] Try dropping a partitioned GeoJSON file → error message points the user at "Save as JSON"
- [ ] `npm run lint && npm run format:check` clean for changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)