### PR TITLE
feat(tortuga): land/water ratio check with soft ocean-dominant nudge (closes #188)

### DIFF
--- a/public/apps/tortuga/app.js
+++ b/public/apps/tortuga/app.js
@@ -54,8 +54,20 @@
       var importEl = document.getElementById('cartographer-import');
       if (importEl) {
         T.importer.render(importEl, {
-          onParsed: function (_parsed, previewWorld) {
-            T._previewImportedWorld(previewWorld);
+          onParsed: function (parsed, previewWorld) {
+            var warningEl = document.getElementById('land-heavy-warning');
+            if (parsed.landPercentage > T.LAND_HEAVY_THRESHOLD && warningEl) {
+              warningEl.classList.remove('hidden');
+              document.getElementById('land-heavy-continue').onclick = function () {
+                warningEl.classList.add('hidden');
+                T._previewImportedWorld(previewWorld);
+              };
+              document.getElementById('land-heavy-cancel').onclick = function () {
+                warningEl.classList.add('hidden');
+              };
+            } else {
+              T._previewImportedWorld(previewWorld);
+            }
           },
         });
       }

--- a/public/apps/tortuga/cartographer/importer.js
+++ b/public/apps/tortuga/cartographer/importer.js
@@ -75,8 +75,13 @@
 
     var coastlines = [];
     var lakes = [];
+    var landCells = 0;
+    var oceanCells = 0;
     pack.features.forEach(function (f) {
-      if (!f || !Array.isArray(f.vertices) || f.vertices.length === 0) return;
+      if (!f) return;
+      if (f.type === 'island') landCells += f.cells || 0;
+      else if (f.type === 'ocean') oceanCells += f.cells || 0;
+      if (!Array.isArray(f.vertices) || f.vertices.length === 0) return;
       var ring = _dereferenceVertices(f.vertices, pack.vertices);
       if (ring.length < 3) return;
       if (f.type === 'island') {
@@ -85,6 +90,8 @@
         lakes.push({ name: f.name || 'Lake', polygon: ring });
       }
     });
+    var landPercentage =
+      landCells + oceanCells > 0 ? Math.round((landCells / (landCells + oceanCells)) * 100) : 0;
 
     var burgs = [];
     pack.burgs.forEach(function (b) {
@@ -151,6 +158,7 @@
       biomes: biomes,
       burgs: burgs,
       stateBorders: stateBorders,
+      landPercentage: landPercentage,
     };
   }
 

--- a/public/apps/tortuga/index.html
+++ b/public/apps/tortuga/index.html
@@ -44,6 +44,20 @@
         <p class="app-subtitle">Build and explore worlds.</p>
         <div class="app-divider"></div>
         <div id="cartographer-import"></div>
+        <div id="land-heavy-warning" class="land-heavy-warning hidden">
+          <span class="land-heavy-warning-icon" aria-hidden="true">&#9888;</span>
+          <span class="land-heavy-warning-text"
+            >This map is land-heavy. Tortuga plays best on oceanic maps.</span
+          >
+          <div class="land-heavy-warning-actions">
+            <button class="btn-cancel" id="land-heavy-cancel" type="button">
+              Choose Another Map
+            </button>
+            <button class="app-btn app-btn--sm" id="land-heavy-continue" type="button">
+              Continue Anyway
+            </button>
+          </div>
+        </div>
         <div id="world-list-world" class="world-list"></div>
         <div id="map-world" class="tortuga-map hidden"></div>
       </section>

--- a/public/apps/tortuga/state.js
+++ b/public/apps/tortuga/state.js
@@ -6,6 +6,7 @@
 
   T.MODES = { WORLD: 'world', PLAY: 'play' };
   T.DEFAULT_MODE = 'world';
+  T.LAND_HEAVY_THRESHOLD = 60;
 
   T.state = {
     db: null,

--- a/public/apps/tortuga/tortuga.css
+++ b/public/apps/tortuga/tortuga.css
@@ -198,6 +198,63 @@
   color: #e05555;
 }
 
+/* ── Buttons ───────────────────────────────────────────────── */
+
+.btn-cancel {
+  padding: 0.4rem 0.8rem;
+  font-size: 0.8rem;
+  color: #90a4ae;
+  background: none;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  cursor: pointer;
+  transition:
+    color 0.2s,
+    border-color 0.2s;
+}
+
+.btn-cancel:hover {
+  color: #e0e0e0;
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+.app-btn--sm {
+  padding: 0.4rem 0.9rem;
+  font-size: 0.8rem;
+}
+
+/* ── Land-heavy warning banner ─────────────────────────────── */
+
+.land-heavy-warning {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  margin: 0.75rem 0;
+  background: rgba(255, 167, 38, 0.08);
+  border: 1px solid rgba(255, 167, 38, 0.25);
+  border-radius: 8px;
+  font-size: 0.85rem;
+  color: #ffa726;
+}
+
+.land-heavy-warning-icon {
+  font-size: 1rem;
+  flex-shrink: 0;
+}
+
+.land-heavy-warning-text {
+  flex: 1;
+  min-width: 0;
+}
+
+.land-heavy-warning-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+
 /* ── Map container ─────────────────────────────────────────── */
 
 .tortuga-map {

--- a/tests/tortuga-importer.test.js
+++ b/tests/tortuga-importer.test.js
@@ -118,6 +118,32 @@ describe('Tortuga importer — parseAzgaarJson', () => {
   });
 });
 
+describe('Tortuga importer — land/water ratio', () => {
+  test('ocean-dominant map has low landPercentage', () => {
+    // Fixture: ocean=100 cells, islands=10+2=12 cells → ~10%
+    const result = importer.parseAzgaarJson(azgaarJsonSample());
+    expect(result.landPercentage).toBeLessThan(20);
+  });
+
+  test('land-heavy map has landPercentage above 60', () => {
+    const sample = azgaarJsonSample();
+    // Shrink ocean, grow continent island
+    sample.pack.features[1].cells = 10; // ocean
+    sample.pack.features[2].cells = 200; // continent island
+    const result = importer.parseAzgaarJson(sample);
+    expect(result.landPercentage).toBeGreaterThan(60);
+  });
+
+  test('landPercentage is 0 when no cells on any feature', () => {
+    const sample = azgaarJsonSample();
+    sample.pack.features.forEach((f) => {
+      if (f && typeof f.cells !== 'undefined') f.cells = 0;
+    });
+    const result = importer.parseAzgaarJson(sample);
+    expect(result.landPercentage).toBe(0);
+  });
+});
+
 // Opt-in: parse a real Azgaar export when present locally (gitignored, 5MB+).
 // Drop any *.json file under tests/fixtures/ to enable this branch.
 describe('Tortuga importer — real Azgaar fixtures (opt-in)', () => {


### PR DESCRIPTION
Adds T.LAND_HEAVY_THRESHOLD constant (60%), computes landPercentage from
pack.features[].cells in parseAzgaarJson, and shows a non-blocking orange
warning banner when land exceeds the threshold. Continue Anyway proceeds
to the map preview; Choose Another Map dismisses the banner silently.

https://claude.ai/code/session_01TAWmmGkFd9Nbp7MxDDEJ1d