### PR TITLE
feat(tortuga): overlay generator — classify coastal burgs into settlement types (closes #189)

### DIFF
--- a/public/apps/tortuga/cartographer/overlay.js
+++ b/public/apps/tortuga/cartographer/overlay.js
@@ -1,0 +1,225 @@
+(function () {
+  'use strict';
+
+  /*
+   * Tortuga overlay generator — T-104 / T-105 (hidden coves).
+   *
+   * Transforms the intermediate shape produced by importer.parseAzgaarJson into
+   * a pirate-themed world whose settlements match the tortuga_worlds.settlements[]
+   * schema from §9 of the design doc:
+   *   { id, name, type, position, parentFaction, baseSize, hidden }
+   *
+   * Settlement types: colonial_port, free_port, fort, hidden_cove, native_village, ruins
+   *
+   * Classification is deterministic: same parsed input + same options → same output.
+   * Branching decisions use a lightweight hash of the burg ID rather than Math.random().
+   *
+   * applyOverlay(parsed, options) is the top-level entry point. It returns a
+   * renderer-compatible world shape (same keys as importer._toPreviewWorld) but
+   * with fully classified settlements. Callers should prefer applyOverlay over
+   * importer.toPreviewWorld once this module is loaded.
+   */
+
+  var SETTLEMENT_TYPES = {
+    COLONIAL_PORT: 'colonial_port',
+    FREE_PORT: 'free_port',
+    FORT: 'fort',
+    HIDDEN_COVE: 'hidden_cove',
+    NATIVE_VILLAGE: 'native_village',
+    RUINS: 'ruins',
+  };
+
+  var DENSITY_COVE_COUNT = {
+    sparse: 5,
+    standard: 10,
+    dense: 20,
+  };
+
+  var COVE_NAMES = [
+    "The Devil's Notch",
+    "Wraith's Anchorage",
+    "Corsair's Inlet",
+    'The Blind Eye',
+    "Widow's Reach",
+    'Skeleton Cove',
+    "The Rat's Hole",
+    'Murk Bay',
+    'The Forgotten Shore',
+    "Jackal's Landing",
+    'Serpent Cove',
+    'The Dark Passage',
+  ];
+
+  // Deterministic djb2-style hash of a string → float in [0, 1).
+  function _hash(str) {
+    var h = 5381;
+    for (var i = 0; i < str.length; i++) {
+      h = (h * 33 + str.charCodeAt(i)) & 0x7fffffff;
+    }
+    return h / 0x7fffffff;
+  }
+
+  function _populationBand(population) {
+    if (population >= 8) return 'large';
+    if (population >= 2) return 'medium';
+    return 'small';
+  }
+
+  /*
+   * Classify a single coastal burg into a settlement type.
+   * Returns null if the burg is not coastal (isPort === false).
+   */
+  function _classifyBurg(burg) {
+    if (!burg.isPort) return null;
+
+    var pop = _populationBand(burg.population);
+    var h = _hash(burg.id);
+    var type;
+
+    if (burg.stateId === 0) {
+      // Neutral / wild — no state allegiance
+      if (pop === 'small') {
+        type = SETTLEMENT_TYPES.NATIVE_VILLAGE;
+      } else {
+        type = SETTLEMENT_TYPES.FREE_PORT;
+      }
+    } else {
+      // Belongs to a state
+      if (pop === 'small' && h < 0.07) {
+        // Rare ruins override for any small state burg
+        type = SETTLEMENT_TYPES.RUINS;
+      } else if (burg.isCapital) {
+        type = pop === 'small' ? SETTLEMENT_TYPES.FORT : SETTLEMENT_TYPES.COLONIAL_PORT;
+      } else {
+        if (pop === 'large') {
+          type = SETTLEMENT_TYPES.COLONIAL_PORT;
+        } else if (pop === 'medium') {
+          type = h < 0.5 ? SETTLEMENT_TYPES.COLONIAL_PORT : SETTLEMENT_TYPES.FORT;
+        } else {
+          // small, non-capital
+          type = h < 0.55 ? SETTLEMENT_TYPES.FORT : SETTLEMENT_TYPES.RUINS;
+        }
+      }
+    }
+
+    return {
+      id: burg.id,
+      name: burg.name,
+      type: type,
+      position: burg.pos,
+      parentFaction: burg.stateId > 0 ? 'state_' + burg.stateId : null,
+      baseSize: pop,
+      hidden: false,
+    };
+  }
+
+  /*
+   * Classify all coastal burgs from the parsed world.
+   * Non-coastal burgs (isPort === false) are excluded.
+   *
+   * @param {Array} burgs       - from parseAzgaarJson result
+   * @param {Array} stateBorders - from parseAzgaarJson result (unused here, reserved for future era logic)
+   * @param {Object} options    - { density: 'sparse'|'standard'|'dense', era: string }
+   * @returns {Array}           - settlement objects matching §9 schema
+   */
+  function classifySettlements(burgs, stateBorders, options) {
+    void stateBorders; // reserved for era-based faction archetype logic (T-106)
+    void options;
+    var settlements = [];
+    for (var i = 0; i < burgs.length; i++) {
+      var s = _classifyBurg(burgs[i]);
+      if (s !== null) settlements.push(s);
+    }
+    return settlements;
+  }
+
+  /*
+   * Generate N hidden coves — small uncharted settlements not in the source data.
+   * Positions are sampled deterministically along the provided coastline rings.
+   *
+   * @param {Array} bounds      - [[minY, minX], [maxY, maxX]]
+   * @param {Array} coastlines  - array of rings, each ring is [[y, x], ...]
+   * @param {Object} options    - { density: 'sparse'|'standard'|'dense' }
+   * @returns {Array}           - hidden cove settlement objects
+   */
+  function generateHiddenCoves(bounds, coastlines, options) {
+    var density = (options && options.density) || 'standard';
+    var count = DENSITY_COVE_COUNT[density] || DENSITY_COVE_COUNT.standard;
+
+    if (!coastlines || coastlines.length === 0) return [];
+
+    var coves = [];
+    for (var i = 0; i < count; i++) {
+      var ringIdx = i % coastlines.length;
+      var ring = coastlines[ringIdx];
+      // Pick a vertex via a hash derived from the cove index
+      var h = _hash('cove_' + i);
+      var vertIdx = Math.floor(h * ring.length);
+      var basePos = ring[vertIdx] || ring[0];
+
+      // Deterministic nudge so coves don't stack exactly on burg positions.
+      // Nudge is proportional to map height (bounds[1][0]).
+      var mapHeight = bounds && bounds[1] ? bounds[1][0] : 800;
+      var nudge = (mapHeight / 200) * (_hash('nudge_' + i) - 0.5);
+      var position = [basePos[0] + nudge, basePos[1] + nudge];
+
+      coves.push({
+        id: 'cove_' + i,
+        name: COVE_NAMES[i % COVE_NAMES.length],
+        type: SETTLEMENT_TYPES.HIDDEN_COVE,
+        position: position,
+        parentFaction: null,
+        baseSize: 'small',
+        hidden: true,
+      });
+    }
+    return coves;
+  }
+
+  /*
+   * Apply the full overlay pipeline to a parsed world, returning a renderer-
+   * compatible world shape with enriched settlements.
+   *
+   * This is the replacement for importer._toPreviewWorld. Once T-108 wires up
+   * the cartographer UI, callers should use applyOverlay instead of toPreviewWorld.
+   *
+   * @param {Object} parsed  - result of importer.parseAzgaarJson
+   * @param {Object} options - { density: 'sparse'|'standard'|'dense', era: string }
+   * @returns {Object}       - renderer-compatible world
+   */
+  function applyOverlay(parsed, options) {
+    var opts = options || {};
+    var classified = classifySettlements(parsed.burgs, parsed.stateBorders, opts);
+    var coves = generateHiddenCoves(parsed.bounds, parsed.coastlines, opts);
+
+    return {
+      bounds: parsed.bounds,
+      coastlines: parsed.coastlines,
+      settlements: classified.concat(coves),
+      hazards: parsed.lakes.map(function (l, i) {
+        return { id: 'lake_' + i, name: l.name, type: 'lake', polygon: l.polygon };
+      }),
+      tradeRoutes: [],
+      factionTerritory: [],
+      windCurrentZones: [],
+    };
+  }
+
+  var api = {
+    classifySettlements: classifySettlements,
+    generateHiddenCoves: generateHiddenCoves,
+    applyOverlay: applyOverlay,
+  };
+
+  if (typeof window !== 'undefined') {
+    window.Tortuga = window.Tortuga || {};
+    window.Tortuga.overlay = api;
+  }
+
+  // CommonJS export for Jest tests (Node-only path, ignored in the browser).
+  // eslint-disable-next-line no-undef
+  if (typeof module !== 'undefined' && module.exports) {
+    // eslint-disable-next-line no-undef
+    module.exports = api;
+  }
+})();

--- a/public/apps/tortuga/index.html
+++ b/public/apps/tortuga/index.html
@@ -84,6 +84,7 @@
     <script src="/apps/tortuga/map-renderer.js"></script>
     <script src="/apps/tortuga/firestore.js"></script>
     <script src="/apps/tortuga/world-list.js"></script>
+    <script src="/apps/tortuga/cartographer/overlay.js"></script>
     <script src="/apps/tortuga/cartographer/importer.js"></script>
     <script src="/apps/tortuga/app.js"></script>
 

--- a/public/apps/tortuga/map-renderer.js
+++ b/public/apps/tortuga/map-renderer.js
@@ -38,13 +38,14 @@
   function _renderSettlements(world) {
     if (!world || !world.settlements) return;
     world.settlements.forEach(function (s) {
-      L.marker(s.pos, { title: s.name })
+      var factionLabel = s.parentFaction || s.faction || null;
+      L.marker(s.position || s.pos, { title: s.name })
         .bindPopup(
           '<strong>' +
             s.name +
             '</strong><br>' +
             (s.type || '') +
-            (s.faction ? '<br>' + s.faction : '')
+            (factionLabel ? '<br>' + factionLabel : '')
         )
         .addTo(_layers[LAYERS.SETTLEMENTS]);
     });

--- a/tests/tortuga-overlay.test.js
+++ b/tests/tortuga-overlay.test.js
@@ -1,0 +1,295 @@
+const path = require('path');
+const overlay = require(path.join(
+  __dirname,
+  '..',
+  'public',
+  'apps',
+  'tortuga',
+  'cartographer',
+  'overlay.js'
+));
+const { azgaarJsonSample } = require('./fixtures/azgaar-json-sample.js');
+const importer = require(path.join(
+  __dirname,
+  '..',
+  'public',
+  'apps',
+  'tortuga',
+  'cartographer',
+  'importer.js'
+));
+
+// Fixture burgs extracted from the azgaarJsonSample:
+//   burg_1 — Port Royal:       isPort=true,  isCapital=true,  stateId=1, population=12.5 (large)
+//   burg_2 — Highmount:        isPort=false, isCapital=false, stateId=1, population=4.3  (medium)
+//   burg_3 — Smuggler's Rest:  isPort=true,  isCapital=false, stateId=0, population=0.6  (small)
+
+const VALID_TYPES = [
+  'colonial_port',
+  'free_port',
+  'fort',
+  'hidden_cove',
+  'native_village',
+  'ruins',
+];
+
+describe('Tortuga overlay — classifySettlements', () => {
+  let parsed;
+
+  beforeEach(() => {
+    parsed = importer.parseAzgaarJson(azgaarJsonSample());
+  });
+
+  test('excludes non-coastal burgs (isPort=false)', () => {
+    const settlements = overlay.classifySettlements(parsed.burgs, parsed.stateBorders, {});
+    const ids = settlements.map((s) => s.id);
+    expect(ids).not.toContain('burg_2'); // Highmount has isPort=false
+  });
+
+  test('includes all coastal burgs (isPort=true)', () => {
+    const settlements = overlay.classifySettlements(parsed.burgs, parsed.stateBorders, {});
+    const ids = settlements.map((s) => s.id);
+    expect(ids).toContain('burg_1'); // Port Royal
+    expect(ids).toContain('burg_3'); // Smuggler's Rest
+  });
+
+  test('large state capital becomes colonial_port', () => {
+    const settlements = overlay.classifySettlements(parsed.burgs, parsed.stateBorders, {});
+    const portRoyal = settlements.find((s) => s.id === 'burg_1');
+    expect(portRoyal.type).toBe('colonial_port');
+  });
+
+  test('small neutral coastal burg becomes native_village', () => {
+    const settlements = overlay.classifySettlements(parsed.burgs, parsed.stateBorders, {});
+    const smugglers = settlements.find((s) => s.id === 'burg_3');
+    expect(smugglers.type).toBe('native_village');
+  });
+
+  test('output schema has all required §9 fields', () => {
+    const settlements = overlay.classifySettlements(parsed.burgs, parsed.stateBorders, {});
+    settlements.forEach((s) => {
+      expect(s).toHaveProperty('id');
+      expect(s).toHaveProperty('name');
+      expect(s).toHaveProperty('type');
+      expect(s).toHaveProperty('position');
+      expect(s).toHaveProperty('parentFaction');
+      expect(s).toHaveProperty('baseSize');
+      expect(s).toHaveProperty('hidden');
+    });
+  });
+
+  test('hidden is always false for classified burgs', () => {
+    const settlements = overlay.classifySettlements(parsed.burgs, parsed.stateBorders, {});
+    settlements.forEach((s) => expect(s.hidden).toBe(false));
+  });
+
+  test('parentFaction is null for neutral burgs (stateId=0)', () => {
+    const settlements = overlay.classifySettlements(parsed.burgs, parsed.stateBorders, {});
+    const smugglers = settlements.find((s) => s.id === 'burg_3');
+    expect(smugglers.parentFaction).toBeNull();
+  });
+
+  test('parentFaction is state id string for state-owned burgs', () => {
+    const settlements = overlay.classifySettlements(parsed.burgs, parsed.stateBorders, {});
+    const portRoyal = settlements.find((s) => s.id === 'burg_1');
+    expect(portRoyal.parentFaction).toBe('state_1');
+  });
+
+  test('position matches the burg pos [y, x]', () => {
+    const settlements = overlay.classifySettlements(parsed.burgs, parsed.stateBorders, {});
+    const portRoyal = settlements.find((s) => s.id === 'burg_1');
+    expect(portRoyal.position).toEqual([150, 150]); // burg_1 has y:150, x:150
+  });
+
+  test('baseSize is large for Port Royal (population 12.5)', () => {
+    const settlements = overlay.classifySettlements(parsed.burgs, parsed.stateBorders, {});
+    const portRoyal = settlements.find((s) => s.id === 'burg_1');
+    expect(portRoyal.baseSize).toBe('large');
+  });
+
+  test('baseSize is small for Smuggler Rest (population 0.6)', () => {
+    const settlements = overlay.classifySettlements(parsed.burgs, parsed.stateBorders, {});
+    const smugglers = settlements.find((s) => s.id === 'burg_3');
+    expect(smugglers.baseSize).toBe('small');
+  });
+
+  test('all output types are valid settlement type strings', () => {
+    const settlements = overlay.classifySettlements(parsed.burgs, parsed.stateBorders, {});
+    settlements.forEach((s) => expect(VALID_TYPES).toContain(s.type));
+  });
+
+  test('is deterministic — same input produces same output', () => {
+    const a = overlay.classifySettlements(parsed.burgs, parsed.stateBorders, {});
+    const b = overlay.classifySettlements(parsed.burgs, parsed.stateBorders, {});
+    expect(a).toEqual(b);
+  });
+
+  test('does not produce all-colonial_port output on a diverse fixture', () => {
+    // Build a larger set of burgs with variety
+    const burgs = [
+      { id: 'burg_a', name: 'BigPort', pos: [100, 100], population: 15, stateId: 1, isPort: true, isCapital: true },
+      { id: 'burg_b', name: 'SmallHamlet', pos: [200, 200], population: 0.5, stateId: 0, isPort: true, isCapital: false },
+      { id: 'burg_c', name: 'MidCove', pos: [300, 300], population: 3, stateId: 2, isPort: true, isCapital: false },
+      { id: 'burg_d', name: 'TinyOutpost', pos: [400, 400], population: 0.3, stateId: 1, isPort: true, isCapital: false },
+      { id: 'burg_e', name: 'FreeHarbor', pos: [500, 500], population: 5, stateId: 0, isPort: true, isCapital: false },
+    ];
+    const results = overlay.classifySettlements(burgs, [], {});
+    const types = results.map((s) => s.type);
+    const uniqueTypes = [...new Set(types)];
+    expect(uniqueTypes.length).toBeGreaterThan(1);
+  });
+});
+
+describe('Tortuga overlay — generateHiddenCoves', () => {
+  let parsed;
+
+  beforeEach(() => {
+    parsed = importer.parseAzgaarJson(azgaarJsonSample());
+  });
+
+  test('returns 5 coves for sparse density', () => {
+    const coves = overlay.generateHiddenCoves(parsed.bounds, parsed.coastlines, {
+      density: 'sparse',
+    });
+    expect(coves).toHaveLength(5);
+  });
+
+  test('returns 10 coves for standard density (default)', () => {
+    const coves = overlay.generateHiddenCoves(parsed.bounds, parsed.coastlines, {
+      density: 'standard',
+    });
+    expect(coves).toHaveLength(10);
+  });
+
+  test('returns 20 coves for dense density', () => {
+    const coves = overlay.generateHiddenCoves(parsed.bounds, parsed.coastlines, {
+      density: 'dense',
+    });
+    expect(coves).toHaveLength(20);
+  });
+
+  test('defaults to standard count when no options provided', () => {
+    const coves = overlay.generateHiddenCoves(parsed.bounds, parsed.coastlines, {});
+    expect(coves).toHaveLength(10);
+  });
+
+  test('all coves have hidden: true', () => {
+    const coves = overlay.generateHiddenCoves(parsed.bounds, parsed.coastlines, {});
+    coves.forEach((c) => expect(c.hidden).toBe(true));
+  });
+
+  test('all coves have type: hidden_cove', () => {
+    const coves = overlay.generateHiddenCoves(parsed.bounds, parsed.coastlines, {});
+    coves.forEach((c) => expect(c.type).toBe('hidden_cove'));
+  });
+
+  test('all coves have parentFaction: null', () => {
+    const coves = overlay.generateHiddenCoves(parsed.bounds, parsed.coastlines, {});
+    coves.forEach((c) => expect(c.parentFaction).toBeNull());
+  });
+
+  test('all coves have baseSize: small', () => {
+    const coves = overlay.generateHiddenCoves(parsed.bounds, parsed.coastlines, {});
+    coves.forEach((c) => expect(c.baseSize).toBe('small'));
+  });
+
+  test('all coves have required schema fields', () => {
+    const coves = overlay.generateHiddenCoves(parsed.bounds, parsed.coastlines, {});
+    coves.forEach((c) => {
+      expect(c).toHaveProperty('id');
+      expect(c).toHaveProperty('name');
+      expect(c).toHaveProperty('type');
+      expect(c).toHaveProperty('position');
+      expect(c).toHaveProperty('parentFaction');
+      expect(c).toHaveProperty('baseSize');
+      expect(c).toHaveProperty('hidden');
+    });
+  });
+
+  test('returns empty array when coastlines is empty', () => {
+    const coves = overlay.generateHiddenCoves(parsed.bounds, [], { density: 'standard' });
+    expect(coves).toHaveLength(0);
+  });
+
+  test('is deterministic — same input produces same output', () => {
+    const a = overlay.generateHiddenCoves(parsed.bounds, parsed.coastlines, {
+      density: 'standard',
+    });
+    const b = overlay.generateHiddenCoves(parsed.bounds, parsed.coastlines, {
+      density: 'standard',
+    });
+    expect(a).toEqual(b);
+  });
+
+  test('positions are arrays of two numbers', () => {
+    const coves = overlay.generateHiddenCoves(parsed.bounds, parsed.coastlines, {});
+    coves.forEach((c) => {
+      expect(Array.isArray(c.position)).toBe(true);
+      expect(c.position).toHaveLength(2);
+      expect(typeof c.position[0]).toBe('number');
+      expect(typeof c.position[1]).toBe('number');
+    });
+  });
+});
+
+describe('Tortuga overlay — applyOverlay', () => {
+  let parsed;
+
+  beforeEach(() => {
+    parsed = importer.parseAzgaarJson(azgaarJsonSample());
+  });
+
+  test('returns all required top-level keys', () => {
+    const world = overlay.applyOverlay(parsed, {});
+    expect(world).toHaveProperty('bounds');
+    expect(world).toHaveProperty('coastlines');
+    expect(world).toHaveProperty('settlements');
+    expect(world).toHaveProperty('hazards');
+    expect(world).toHaveProperty('tradeRoutes');
+    expect(world).toHaveProperty('factionTerritory');
+    expect(world).toHaveProperty('windCurrentZones');
+  });
+
+  test('settlements combines classified burgs and hidden coves', () => {
+    const world = overlay.applyOverlay(parsed, { density: 'standard' });
+    const classified = overlay.classifySettlements(parsed.burgs, parsed.stateBorders, {});
+    const coves = overlay.generateHiddenCoves(parsed.bounds, parsed.coastlines, {
+      density: 'standard',
+    });
+    expect(world.settlements).toHaveLength(classified.length + coves.length);
+  });
+
+  test('hidden coves in the combined array have hidden: true', () => {
+    const world = overlay.applyOverlay(parsed, {});
+    const coves = world.settlements.filter((s) => s.type === 'hidden_cove');
+    expect(coves.length).toBeGreaterThan(0);
+    coves.forEach((c) => expect(c.hidden).toBe(true));
+  });
+
+  test('classified settlements in the combined array have hidden: false', () => {
+    const world = overlay.applyOverlay(parsed, {});
+    const regular = world.settlements.filter((s) => s.type !== 'hidden_cove');
+    regular.forEach((s) => expect(s.hidden).toBe(false));
+  });
+
+  test('lake hazards are preserved', () => {
+    const world = overlay.applyOverlay(parsed, {});
+    expect(world.hazards.length).toBeGreaterThan(0);
+    const lake = world.hazards.find((h) => h.type === 'lake');
+    expect(lake).toBeDefined();
+    expect(lake.name).toBe('Mirror Lake');
+  });
+
+  test('tradeRoutes, factionTerritory, and windCurrentZones are empty arrays', () => {
+    const world = overlay.applyOverlay(parsed, {});
+    expect(world.tradeRoutes).toEqual([]);
+    expect(world.factionTerritory).toEqual([]);
+    expect(world.windCurrentZones).toEqual([]);
+  });
+
+  test('bounds and coastlines are passed through unchanged', () => {
+    const world = overlay.applyOverlay(parsed, {});
+    expect(world.bounds).toEqual(parsed.bounds);
+    expect(world.coastlines).toBe(parsed.coastlines);
+  });
+});


### PR DESCRIPTION
Add cartographer/overlay.js (T-104 / T-105 hidden coves) with three
exported functions: classifySettlements, generateHiddenCoves, applyOverlay.

Coastal burgs are classified deterministically into colonial_port,
free_port, fort, native_village, or ruins based on population band and
state allegiance. Hidden coves (count by density knob) are placed along
coastline rings with a hash-derived nudge. applyOverlay produces the
§9 Firestore settlement schema { id, name, type, position, parentFaction,
baseSize, hidden } and is the intended replacement for importer.toPreviewWorld.

Also: map-renderer.js accepts position (new schema) alongside pos (legacy),
index.html loads overlay.js before importer.js, and 33 Jest tests cover
all three public functions.

https://claude.ai/code/session_01JgGRUPu33mtnpkzg3rMUwP