### PR TITLE
feat(tortuga): overlay generator — faction mapping from source states (closes #191)

### DIFF
--- a/public/apps/tortuga/cartographer/overlay.js
+++ b/public/apps/tortuga/cartographer/overlay.js
@@ -2,22 +2,26 @@
   'use strict';
 
   /*
-   * Tortuga overlay generator — T-104 / T-105 (hidden coves).
+   * Tortuga overlay generator — T-104 / T-105 (hidden coves) / T-106 (faction mapping).
    *
    * Transforms the intermediate shape produced by importer.parseAzgaarJson into
    * a pirate-themed world whose settlements match the tortuga_worlds.settlements[]
    * schema from §9 of the design doc:
    *   { id, name, type, position, parentFaction, baseSize, hidden }
    *
+   * Factions match the tortuga_worlds.factions[] schema from §9:
+   *   { id, name, archetype, color, homeSettlementId }
+   *
    * Settlement types: colonial_port, free_port, fort, hidden_cove, native_village, ruins
    *
-   * Classification is deterministic: same parsed input + same options → same output.
-   * Branching decisions use a lightweight hash of the burg ID rather than Math.random().
+   * Classification and faction mapping are deterministic: same parsed input + same options
+   * → same output. Branching decisions use a lightweight hash of the burg ID rather than
+   * Math.random().
    *
    * applyOverlay(parsed, options) is the top-level entry point. It returns a
    * renderer-compatible world shape (same keys as importer._toPreviewWorld) but
-   * with fully classified settlements. Callers should prefer applyOverlay over
-   * importer.toPreviewWorld once this module is loaded.
+   * with fully classified settlements and faction list. Callers should prefer applyOverlay
+   * over importer.toPreviewWorld once this module is loaded.
    */
 
   var SETTLEMENT_TYPES = {
@@ -51,6 +55,43 @@
     sparse: 1,
     standard: 2,
     dense: 3,
+  };
+
+  var ERA_FACTION_CATALOG = {
+    caribbean_golden_age: [
+      { archetype: 'spanish_crown', name: 'Spanish Crown', color: '#c8a000' },
+      { archetype: 'british_crown', name: 'British Crown', color: '#8b0000' },
+      { archetype: 'french_crown', name: 'French Crown', color: '#00408b' },
+      { archetype: 'dutch_trading_co', name: 'Dutch Trading Co.', color: '#005e00' },
+      { archetype: 'indigenous_confederacy', name: 'Indigenous Confederacy', color: '#7a5200' },
+      { archetype: 'free_city', name: 'Free City', color: '#555555' },
+    ],
+    mediterranean_corsair: [
+      { archetype: 'ottoman_regency', name: 'Ottoman Regency', color: '#8b0000' },
+      { archetype: 'venetian_republic', name: 'Venetian Republic', color: '#9b6000' },
+      { archetype: 'papal_states', name: 'Papal States', color: '#c8c800' },
+      { archetype: 'corsair_republic', name: 'Corsair Republic', color: '#003060' },
+      { archetype: 'free_city', name: 'Free City', color: '#555555' },
+    ],
+    indian_ocean: [
+      { archetype: 'mughal_empire', name: 'Mughal Empire', color: '#8b3a00' },
+      { archetype: 'portuguese_estado', name: 'Portuguese Estado', color: '#005e00' },
+      { archetype: 'arab_sultanate', name: 'Arab Sultanate', color: '#c8a000' },
+      { archetype: 'east_india_company', name: 'East India Company', color: '#8b0000' },
+      { archetype: 'free_city', name: 'Free City', color: '#555555' },
+    ],
+    freeform: [
+      { archetype: 'realm', name: 'Realm', color: '#556070' },
+      { archetype: 'confederacy', name: 'Confederacy', color: '#705560' },
+      { archetype: 'guild', name: 'Guild', color: '#607055' },
+      { archetype: 'free_city', name: 'Free City', color: '#555555' },
+    ],
+  };
+
+  var PIRATE_BRETHREN_ENTRY = {
+    archetype: 'pirate_brethren',
+    name: 'Pirate Brethren',
+    color: '#222222',
   };
 
   var COVE_NAMES = [
@@ -159,6 +200,47 @@
       if (s !== null) settlements.push(s);
     }
     return settlements;
+  }
+
+  /*
+   * Map source states to faction archetypes for the era preset.
+   * Pirate Brethren is always appended as a synthetic faction (no Azgaar state).
+   *
+   * @param {Array} stateBorders - from parseAzgaarJson result: [{ id, name, color, capitalBurgId }]
+   * @param {Object} options     - { era: string, factionCount: number (2–8) }
+   * @returns {Array}            - faction objects matching §9 schema: { id, name, archetype, color, homeSettlementId }
+   */
+  function generateFactions(stateBorders, options) {
+    var opts = options || {};
+    var era = opts.era || 'caribbean_golden_age';
+    var rawCount = typeof opts.factionCount === 'number' ? opts.factionCount : 8;
+    var factionCount = Math.max(2, Math.min(8, rawCount));
+
+    var catalog = ERA_FACTION_CATALOG[era] || ERA_FACTION_CATALOG['caribbean_golden_age'];
+    var stateSlots = Math.min(stateBorders.length, factionCount - 1);
+
+    var factions = [];
+    for (var i = 0; i < stateSlots; i++) {
+      var state = stateBorders[i];
+      var entry = catalog[i % catalog.length];
+      factions.push({
+        id: state.id,
+        name: entry.name,
+        archetype: entry.archetype,
+        color: state.color || entry.color,
+        homeSettlementId: state.capitalBurgId || null,
+      });
+    }
+
+    factions.push({
+      id: 'faction_pirate',
+      name: PIRATE_BRETHREN_ENTRY.name,
+      archetype: PIRATE_BRETHREN_ENTRY.archetype,
+      color: PIRATE_BRETHREN_ENTRY.color,
+      homeSettlementId: null,
+    });
+
+    return factions;
   }
 
   /*
@@ -338,6 +420,7 @@
   function applyOverlay(parsed, options) {
     var opts = options || {};
     var classified = classifySettlements(parsed.burgs, parsed.stateBorders, opts);
+    var factions = generateFactions(parsed.stateBorders, opts);
     var coves = generateHiddenCoves(parsed.bounds, parsed.coastlines, opts);
     var reefs = generateReefs(parsed.bounds, parsed.coastlines, opts);
     var storms = generateStormBands(parsed.bounds, opts);
@@ -351,6 +434,7 @@
       coastlines: parsed.coastlines,
       settlements: classified.concat(coves),
       hazards: lakeHazards.concat(reefs, storms, krakens),
+      factions: factions,
       tradeRoutes: [],
       factionTerritory: [],
       windCurrentZones: [],
@@ -359,6 +443,7 @@
 
   var api = {
     classifySettlements: classifySettlements,
+    generateFactions: generateFactions,
     generateHiddenCoves: generateHiddenCoves,
     generateReefs: generateReefs,
     generateStormBands: generateStormBands,

--- a/tests/tortuga-overlay.test.js
+++ b/tests/tortuga-overlay.test.js
@@ -245,9 +245,16 @@ describe('Tortuga overlay — applyOverlay', () => {
     expect(world).toHaveProperty('coastlines');
     expect(world).toHaveProperty('settlements');
     expect(world).toHaveProperty('hazards');
+    expect(world).toHaveProperty('factions');
     expect(world).toHaveProperty('tradeRoutes');
     expect(world).toHaveProperty('factionTerritory');
     expect(world).toHaveProperty('windCurrentZones');
+  });
+
+  test('factions is a non-empty array', () => {
+    const world = overlay.applyOverlay(parsed, {});
+    expect(Array.isArray(world.factions)).toBe(true);
+    expect(world.factions.length).toBeGreaterThan(0);
   });
 
   test('settlements combines classified burgs and hidden coves', () => {
@@ -566,5 +573,102 @@ describe('Tortuga overlay — generateKrakenZones', () => {
       density: 'standard',
     });
     expect(a).toEqual(b);
+  });
+});
+
+describe('Tortuga overlay — generateFactions', () => {
+  // Fixture states from azgaarJsonSample:
+  //   state_1 — Albion:  color '#cc4400', capitalBurgId 'burg_1'
+  //   state_2 — Castile: color '#ddaa00', capitalBurgId null
+  let parsed;
+
+  beforeEach(() => {
+    parsed = importer.parseAzgaarJson(azgaarJsonSample());
+  });
+
+  test('every faction has all required §9 schema fields', () => {
+    const factions = overlay.generateFactions(parsed.stateBorders, {});
+    factions.forEach((f) => {
+      expect(f).toHaveProperty('id');
+      expect(f).toHaveProperty('name');
+      expect(f).toHaveProperty('archetype');
+      expect(f).toHaveProperty('color');
+      expect(f).toHaveProperty('homeSettlementId');
+    });
+  });
+
+  test('archetype is a non-empty string on every faction', () => {
+    const factions = overlay.generateFactions(parsed.stateBorders, {});
+    factions.forEach((f) => {
+      expect(typeof f.archetype).toBe('string');
+      expect(f.archetype.length).toBeGreaterThan(0);
+    });
+  });
+
+  test('era preset influences faction archetypes — caribbean_golden_age vs mediterranean_corsair', () => {
+    const caribbean = overlay.generateFactions(parsed.stateBorders, {
+      era: 'caribbean_golden_age',
+    });
+    const mediterranean = overlay.generateFactions(parsed.stateBorders, {
+      era: 'mediterranean_corsair',
+    });
+    const firstCaribbean = caribbean.find((f) => f.id === 'state_1');
+    const firstMediterranean = mediterranean.find((f) => f.id === 'state_1');
+    expect(firstCaribbean.archetype).not.toBe(firstMediterranean.archetype);
+  });
+
+  test('factionCount: 2 limits output to at most 2 factions', () => {
+    const factions = overlay.generateFactions(parsed.stateBorders, { factionCount: 2 });
+    expect(factions.length).toBeLessThanOrEqual(2);
+  });
+
+  test('output never exceeds factionCount', () => {
+    [2, 3, 8].forEach((count) => {
+      const factions = overlay.generateFactions(parsed.stateBorders, { factionCount: count });
+      expect(factions.length).toBeLessThanOrEqual(count);
+    });
+  });
+
+  test('Pirate Brethren faction is always present', () => {
+    const factions = overlay.generateFactions(parsed.stateBorders, {});
+    const pirate = factions.find((f) => f.archetype === 'pirate_brethren');
+    expect(pirate).toBeDefined();
+  });
+
+  test('homeSettlementId for state_1 is burg_1 (capitalBurgId from fixture)', () => {
+    const factions = overlay.generateFactions(parsed.stateBorders, {});
+    const state1 = factions.find((f) => f.id === 'state_1');
+    expect(state1.homeSettlementId).toBe('burg_1');
+  });
+
+  test('homeSettlementId for state_2 is null (no capital in fixture)', () => {
+    const factions = overlay.generateFactions(parsed.stateBorders, {});
+    const state2 = factions.find((f) => f.id === 'state_2');
+    expect(state2.homeSettlementId).toBeNull();
+  });
+
+  test('state faction id matches parentFaction on classified settlements', () => {
+    const factions = overlay.generateFactions(parsed.stateBorders, {});
+    const settlements = overlay.classifySettlements(parsed.burgs, parsed.stateBorders, {});
+    const factionIds = factions.map((f) => f.id);
+    settlements
+      .filter((s) => s.parentFaction !== null)
+      .forEach((s) => {
+        expect(factionIds).toContain(s.parentFaction);
+      });
+  });
+
+  test('is deterministic — same input produces same output', () => {
+    const a = overlay.generateFactions(parsed.stateBorders, { era: 'caribbean_golden_age' });
+    const b = overlay.generateFactions(parsed.stateBorders, { era: 'caribbean_golden_age' });
+    expect(a).toEqual(b);
+  });
+
+  test('unknown era slug falls back gracefully — no throw, pirate brethren present', () => {
+    let factions;
+    expect(() => {
+      factions = overlay.generateFactions(parsed.stateBorders, { era: 'totally_unknown_era' });
+    }).not.toThrow();
+    expect(factions.find((f) => f.archetype === 'pirate_brethren')).toBeDefined();
   });
 });


### PR DESCRIPTION
Implements T-106: adds generateFactions() to the overlay module, mapping
Azgaar source states to era-flavoured faction archetypes. Includes a
per-era catalog (caribbean_golden_age, mediterranean_corsair, indian_ocean,
freeform) and always appends a synthetic Pirate Brethren faction. Faction
ids match the parentFaction values already emitted by classifySettlements,
satisfying the §9 cross-reference requirement. applyOverlay now returns
factions[] alongside settlements and hazards. 11 new Jest tests added.

https://claude.ai/code/session_0139SPATK4kTtY4rsrASkYjZ