### PR TITLE
feat(tortuga): Cartographer UI pipeline — upload → preview → knobs → save (closes #193)

### DIFF
--- a/public/apps/tortuga/app.js
+++ b/public/apps/tortuga/app.js
@@ -4,6 +4,15 @@
   window.Tortuga = window.Tortuga || {};
   var T = window.Tortuga;
 
+  // ── Module-local state ──────────────────────────────────────
+
+  var _parsedData = null; // intermediate shape from importer.parseAzgaarJson
+  var _generatedWorld = null; // last result of T.overlay.applyOverlay
+  var _generating = false; // guard against concurrent regenerations
+  var _mapInitialised = false; // track first T.mapRenderer.init call
+
+  // ── Mode routing ────────────────────────────────────────────
+
   function getMode() {
     var params = new URLSearchParams(window.location.search);
     var m = params.get('mode');
@@ -28,14 +37,6 @@
     }
   };
 
-  T._previewImportedWorld = function (previewWorld) {
-    var mapEl = document.getElementById('map-world');
-    if (!mapEl) return;
-    mapEl.classList.remove('hidden');
-    T.mapRenderer.destroy();
-    T.mapRenderer.init(mapEl, previewWorld);
-  };
-
   T._startNewGame = function () {
     var mapEl = document.getElementById('map-play');
     if (mapEl) {
@@ -43,6 +44,225 @@
       T.mapRenderer.init(mapEl, T.mapRenderer.PLACEHOLDER_WORLD);
     }
   };
+
+  // ── Knobs helpers ────────────────────────────────────────────
+
+  function _escapeAttr(str) {
+    return String(str || '')
+      .replace(/&/g, '&amp;')
+      .replace(/"/g, '&quot;');
+  }
+
+  function _showKnobs(defaultName) {
+    var el = document.getElementById('cartographer-knobs');
+    if (!el) return;
+
+    el.innerHTML =
+      '<div class="knobs-panel">' +
+      '<h2 class="knobs-panel-title">Configure World</h2>' +
+      '<div class="knobs-field world-name-field">' +
+      '<label class="knobs-label" for="knob-name">World Name</label>' +
+      '<input class="knobs-input world-name-input" id="knob-name" type="text"' +
+      ' value="' +
+      _escapeAttr(defaultName) +
+      '" placeholder="Unnamed World">' +
+      '</div>' +
+      '<div class="knobs-grid">' +
+      '<div class="knobs-field">' +
+      '<label class="knobs-label" for="knob-era">Era Preset</label>' +
+      '<select class="knobs-select" id="knob-era">' +
+      '<option value="caribbean_golden_age" selected>Caribbean Golden Age</option>' +
+      '<option value="mediterranean_corsair">Mediterranean Corsair</option>' +
+      '<option value="indian_ocean">Indian Ocean</option>' +
+      '<option value="freeform">Freeform</option>' +
+      '</select>' +
+      '</div>' +
+      '<div class="knobs-field">' +
+      '<label class="knobs-label" for="knob-factions">Faction Count</label>' +
+      '<select class="knobs-select" id="knob-factions">' +
+      '<option value="2">2</option>' +
+      '<option value="3">3</option>' +
+      '<option value="4">4</option>' +
+      '<option value="5">5</option>' +
+      '<option value="6">6</option>' +
+      '<option value="7">7</option>' +
+      '<option value="8" selected>8</option>' +
+      '</select>' +
+      '</div>' +
+      '<div class="knobs-field">' +
+      '<label class="knobs-label" for="knob-settlement-density">Settlement Density</label>' +
+      '<select class="knobs-select" id="knob-settlement-density">' +
+      '<option value="sparse">Sparse</option>' +
+      '<option value="standard" selected>Standard</option>' +
+      '<option value="dense">Dense</option>' +
+      '</select>' +
+      '</div>' +
+      '<div class="knobs-field">' +
+      '<label class="knobs-label" for="knob-hazard-density">Hazard Density</label>' +
+      '<select class="knobs-select" id="knob-hazard-density">' +
+      '<option value="sparse">Sparse</option>' +
+      '<option value="standard" selected>Standard</option>' +
+      '<option value="dense">Dense</option>' +
+      '</select>' +
+      '</div>' +
+      '<div class="knobs-field">' +
+      '<label class="knobs-label" id="knob-mythic-label">Mythic Creatures</label>' +
+      '<div class="knobs-checkbox-row">' +
+      '<input class="knobs-checkbox" id="knob-mythic" type="checkbox" checked' +
+      ' aria-labelledby="knob-mythic-label">' +
+      '<label class="knobs-checkbox-label" for="knob-mythic">Enable krakens &amp; sea monsters</label>' +
+      '</div>' +
+      '</div>' +
+      '</div>' +
+      '<div class="knobs-save-row">' +
+      '<button class="app-btn app-btn--sm" id="knobs-save-btn" type="button" disabled>' +
+      'Save World' +
+      '</button>' +
+      '<span class="save-status" id="knobs-save-status"></span>' +
+      '</div>' +
+      '</div>';
+
+    el.classList.remove('hidden');
+
+    var knobIds = [
+      'knob-era',
+      'knob-factions',
+      'knob-settlement-density',
+      'knob-hazard-density',
+      'knob-mythic',
+    ];
+    knobIds.forEach(function (id) {
+      var ctrl = document.getElementById(id);
+      if (ctrl) ctrl.addEventListener('change', _generateAndPreview);
+    });
+  }
+
+  function _readKnobs() {
+    var era = (document.getElementById('knob-era') || {}).value || 'caribbean_golden_age';
+    var factionCount = parseInt((document.getElementById('knob-factions') || {}).value, 10) || 8;
+    var settlementDensity =
+      (document.getElementById('knob-settlement-density') || {}).value || 'standard';
+    var hazardDensity = (document.getElementById('knob-hazard-density') || {}).value || 'standard';
+    var mythicEl = document.getElementById('knob-mythic');
+    var mythic = mythicEl ? mythicEl.checked : true;
+    return {
+      era: era,
+      factionCount: factionCount,
+      settlementDensity: settlementDensity,
+      hazardDensity: hazardDensity,
+      mythic: mythic,
+    };
+  }
+
+  // ── Generation ───────────────────────────────────────────────
+
+  function _generateAndPreview() {
+    if (!_parsedData || _generating) return;
+    _generating = true;
+
+    var saveBtn = document.getElementById('knobs-save-btn');
+    var statusEl = document.getElementById('knobs-save-status');
+
+    if (saveBtn) {
+      saveBtn.disabled = true;
+      saveBtn.textContent = 'Generating…';
+    }
+    if (statusEl) {
+      statusEl.textContent = '';
+      statusEl.className = 'save-status';
+    }
+
+    var opts = _readKnobs();
+
+    // Yield to the browser so the "Generating…" state paints before the
+    // synchronous applyOverlay call blocks the thread.
+    setTimeout(function () {
+      try {
+        _generatedWorld = T.overlay.applyOverlay(_parsedData, opts);
+      } catch (err) {
+        _generating = false;
+        if (saveBtn) {
+          saveBtn.disabled = true;
+          saveBtn.textContent = 'Save World';
+        }
+        if (statusEl) {
+          statusEl.textContent = 'Generation error: ' + err.message;
+          statusEl.className = 'save-status save-status--error';
+        }
+        return;
+      }
+
+      _generating = false;
+
+      var mapEl = document.getElementById('map-world');
+      if (mapEl) {
+        mapEl.classList.remove('hidden');
+        if (!_mapInitialised) {
+          T.mapRenderer.init(mapEl, _generatedWorld);
+          _mapInitialised = true;
+        } else {
+          T.mapRenderer.setWorld(_generatedWorld);
+        }
+      }
+
+      if (saveBtn) {
+        saveBtn.disabled = false;
+        saveBtn.textContent = 'Save World';
+      }
+    }, 0);
+  }
+
+  // ── Save handler ─────────────────────────────────────────────
+
+  function _onSaveClick() {
+    if (!_generatedWorld) return;
+
+    var saveBtn = document.getElementById('knobs-save-btn');
+    var statusEl = document.getElementById('knobs-save-status');
+    var nameInput = document.getElementById('knob-name');
+    var eraEl = document.getElementById('knob-era');
+    var worldName = (nameInput && nameInput.value.trim()) || 'Unnamed World';
+
+    if (saveBtn) {
+      saveBtn.disabled = true;
+      saveBtn.textContent = 'Saving…';
+    }
+    if (statusEl) {
+      statusEl.textContent = '';
+      statusEl.className = 'save-status';
+    }
+
+    var payload = Object.assign({}, _generatedWorld, {
+      name: worldName,
+      era: (eraEl && eraEl.value) || 'caribbean_golden_age',
+      shared: false,
+    });
+
+    T.firestore
+      .createWorld(payload)
+      .then(function () {
+        if (saveBtn) {
+          saveBtn.disabled = false;
+          saveBtn.textContent = 'Save World';
+        }
+        if (statusEl) {
+          statusEl.textContent = 'World saved!';
+          statusEl.className = 'save-status save-status--success';
+        }
+      })
+      .catch(function (err) {
+        if (saveBtn) {
+          saveBtn.disabled = false;
+          saveBtn.textContent = 'Save World';
+        }
+        if (statusEl) {
+          statusEl.textContent = 'Save failed: ' + err.message;
+          statusEl.className = 'save-status save-status--error';
+        }
+      });
+  }
+
+  // ── Init ─────────────────────────────────────────────────────
 
   T.init = function (user) {
     T.state.currentUser = user;
@@ -54,21 +274,38 @@
       var importEl = document.getElementById('cartographer-import');
       if (importEl) {
         T.importer.render(importEl, {
-          onParsed: function (parsed, previewWorld) {
+          onParsed: function (parsed) {
+            _parsedData = parsed;
+            _generatedWorld = null;
+            _mapInitialised = false;
+
             var warningEl = document.getElementById('land-heavy-warning');
             if (parsed.landPercentage > T.LAND_HEAVY_THRESHOLD && warningEl) {
               warningEl.classList.remove('hidden');
               document.getElementById('land-heavy-continue').onclick = function () {
                 warningEl.classList.add('hidden');
-                T._previewImportedWorld(previewWorld);
+                _showKnobs(parsed.info.name);
+                _generateAndPreview();
               };
               document.getElementById('land-heavy-cancel').onclick = function () {
                 warningEl.classList.add('hidden');
+                _parsedData = null;
               };
             } else {
-              T._previewImportedWorld(previewWorld);
+              _showKnobs(parsed.info.name);
+              _generateAndPreview();
             }
           },
+        });
+      }
+
+      // Delegated save handler — #knobs-save-btn is injected dynamically by _showKnobs
+      var shellEl = document.getElementById('shell-world');
+      if (shellEl) {
+        shellEl.addEventListener('click', function (e) {
+          if (e.target && e.target.id === 'knobs-save-btn') {
+            _onSaveClick();
+          }
         });
       }
     }

--- a/public/apps/tortuga/cartographer/overlay.js
+++ b/public/apps/tortuga/cartographer/overlay.js
@@ -465,17 +465,25 @@
    * the cartographer UI, callers should use applyOverlay instead of toPreviewWorld.
    *
    * @param {Object} parsed  - result of importer.parseAzgaarJson
-   * @param {Object} options - { density: 'sparse'|'standard'|'dense', era: string }
+   * @param {Object} options - { era, settlementDensity, hazardDensity, mythic, factionCount, density (fallback) }
    * @returns {Object}       - renderer-compatible world
    */
   function applyOverlay(parsed, options) {
     var opts = options || {};
+    // settlementDensity drives hidden coves; hazardDensity drives reefs/storms/krakens.
+    // Both fall back to opts.density for backward compatibility with single-density callers.
+    var settlementOpts = Object.assign({}, opts, {
+      density: opts.settlementDensity || opts.density || 'standard',
+    });
+    var hazardOpts = Object.assign({}, opts, {
+      density: opts.hazardDensity || opts.density || 'standard',
+    });
     var classified = classifySettlements(parsed.burgs, parsed.stateBorders, opts);
     var factions = generateFactions(parsed.stateBorders, opts);
-    var coves = generateHiddenCoves(parsed.bounds, parsed.coastlines, opts);
-    var reefs = generateReefs(parsed.bounds, parsed.coastlines, opts);
-    var storms = generateStormBands(parsed.bounds, opts);
-    var krakens = generateKrakenZones(parsed.bounds, parsed.coastlines, opts);
+    var coves = generateHiddenCoves(parsed.bounds, parsed.coastlines, settlementOpts);
+    var reefs = generateReefs(parsed.bounds, parsed.coastlines, hazardOpts);
+    var storms = generateStormBands(parsed.bounds, hazardOpts);
+    var krakens = generateKrakenZones(parsed.bounds, parsed.coastlines, hazardOpts);
     var lakeHazards = parsed.lakes.map(function (l, i) {
       return { id: 'lake_' + i, name: l.name, type: 'lake', polygon: l.polygon, severity: 'low' };
     });

--- a/public/apps/tortuga/index.html
+++ b/public/apps/tortuga/index.html
@@ -58,6 +58,7 @@
             </button>
           </div>
         </div>
+        <div id="cartographer-knobs" class="hidden"></div>
         <div id="world-list-world" class="world-list"></div>
         <div id="map-world" class="tortuga-map hidden"></div>
       </section>

--- a/public/apps/tortuga/tortuga.css
+++ b/public/apps/tortuga/tortuga.css
@@ -262,3 +262,133 @@
   width: 100%;
   border-radius: 6px;
 }
+
+/* ── Cartographer knobs panel ──────────────────────────────── */
+
+.knobs-panel {
+  margin: 1rem 0;
+  padding: 1rem 1.25rem;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 8px;
+}
+
+.knobs-panel-title {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--color-text, #e0e0e0);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin: 0 0 0.75rem;
+}
+
+.knobs-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.75rem 1.25rem;
+  margin-bottom: 0.75rem;
+}
+
+.knobs-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.knobs-label {
+  font-size: 0.75rem;
+  color: var(--color-text-muted, #90a4ae);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.knobs-select,
+.knobs-input {
+  padding: 0.5rem 0.75rem;
+  font-size: 0.85rem;
+  font-family: inherit;
+  color: #e0e0e0;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  outline: none;
+  transition:
+    border-color 0.2s,
+    box-shadow 0.2s;
+}
+
+.knobs-select {
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%2390a4ae' d='M6 8L1 3h10z'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 0.75rem center;
+  background-color: rgba(255, 255, 255, 0.05);
+  padding-right: 2rem;
+}
+
+.knobs-select option {
+  background: #111827;
+  color: #e0e0e0;
+}
+
+.knobs-select:focus,
+.knobs-input:focus {
+  border-color: rgba(255, 183, 77, 0.5);
+  box-shadow: 0 0 0 3px rgba(255, 183, 77, 0.1);
+}
+
+.knobs-checkbox-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding-top: 0.6rem;
+}
+
+.knobs-checkbox {
+  accent-color: #ffb74d;
+  width: 16px;
+  height: 16px;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.knobs-checkbox-label {
+  font-size: 0.85rem;
+  color: #e0e0e0;
+  cursor: pointer;
+}
+
+.world-name-field {
+  margin-bottom: 0.75rem;
+}
+
+.world-name-input {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.knobs-save-row {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-top: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.save-status {
+  font-size: 0.8rem;
+}
+
+.save-status--success {
+  color: #66bb6a;
+}
+
+.save-status--error {
+  color: #e05555;
+}
+
+@media (max-width: 600px) {
+  .knobs-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/tests/tortuga-overlay.test.js
+++ b/tests/tortuga-overlay.test.js
@@ -846,3 +846,42 @@ describe('Tortuga overlay — generateFactions', () => {
     expect(factions.find((f) => f.archetype === 'pirate_brethren')).toBeDefined();
   });
 });
+
+describe('applyOverlay — split density keys', () => {
+  let parsed;
+
+  beforeEach(() => {
+    parsed = importer.parseAzgaarJson(azgaarJsonSample());
+  });
+
+  test('settlementDensity controls hidden cove count independently of hazardDensity', () => {
+    const sparse = overlay.applyOverlay(parsed, { settlementDensity: 'sparse', hazardDensity: 'dense' });
+    const dense = overlay.applyOverlay(parsed, { settlementDensity: 'dense', hazardDensity: 'dense' });
+    const sparseCoves = sparse.settlements.filter((s) => s.type === 'hidden_cove').length;
+    const denseCoves = dense.settlements.filter((s) => s.type === 'hidden_cove').length;
+    expect(sparseCoves).toBeLessThan(denseCoves);
+  });
+
+  test('hazardDensity controls reef count independently of settlementDensity', () => {
+    const sparse = overlay.applyOverlay(parsed, { settlementDensity: 'dense', hazardDensity: 'sparse' });
+    const dense = overlay.applyOverlay(parsed, { settlementDensity: 'dense', hazardDensity: 'dense' });
+    const sparseReefs = sparse.hazards.filter((h) => h.type === 'reef').length;
+    const denseReefs = dense.hazards.filter((h) => h.type === 'reef').length;
+    expect(sparseReefs).toBeLessThan(denseReefs);
+  });
+
+  test('dense settlementDensity + sparse hazardDensity gives more coves than reefs', () => {
+    const world = overlay.applyOverlay(parsed, { settlementDensity: 'dense', hazardDensity: 'sparse' });
+    const coves = world.settlements.filter((s) => s.type === 'hidden_cove').length;
+    const reefs = world.hazards.filter((h) => h.type === 'reef').length;
+    expect(coves).toBeGreaterThan(reefs);
+  });
+
+  test('falls back to opts.density when split keys are absent', () => {
+    const sparse = overlay.applyOverlay(parsed, { density: 'sparse' });
+    const dense = overlay.applyOverlay(parsed, { density: 'dense' });
+    const sparseCoves = sparse.settlements.filter((s) => s.type === 'hidden_cove').length;
+    const denseCoves = dense.settlements.filter((s) => s.type === 'hidden_cove').length;
+    expect(sparseCoves).toBeLessThan(denseCoves);
+  });
+});


### PR DESCRIPTION
Wire the full Cartographer flow: file upload dispatches to the Azgaar
parser, overlay generation runs automatically with default knob values,
a configure-world panel lets users tweak era preset, faction count,
settlement density, hazard density, and mythic creatures toggle with
live map re-generation on each change, and a Save World button (gated
until generation completes) writes the world payload to Firestore.

Also splits applyOverlay density into settlementDensity (hidden coves)
and hazardDensity (reefs/storms/krakens) with backward-compatible
fallback to the single opts.density key.

https://claude.ai/code/session_01RhH146CVUKZN3SPetQE4LD