### PR TITLE
fix(tortuga): blank Cartographer map and stuck "Generating…", plus hazard/route polish

### DIFF
--- a/public/apps/tortuga/cartographer/overlay.js
+++ b/public/apps/tortuga/cartographer/overlay.js
@@ -112,14 +112,17 @@
     'The Dark Passage',
   ];
 
-  // 4-point rectangle polygon centred at (cy, cx).
-  function _makeRect(cy, cx, halfH, halfW) {
-    return [
-      [cy - halfH, cx - halfW],
-      [cy - halfH, cx + halfW],
-      [cy + halfH, cx + halfW],
-      [cy + halfH, cx - halfW],
-    ];
+  // Irregular closed polygon with `sides` vertices around (cy, cx).
+  // Each vertex's radius is perturbed deterministically via `seed` so reefs
+  // and kraken zones read as organic shapes rather than blocks.
+  function _jaggedBlob(cy, cx, baseRadius, sides, seed) {
+    var pts = [];
+    for (var i = 0; i < sides; i++) {
+      var angle = (i / sides) * Math.PI * 2;
+      var r = baseRadius * (0.6 + 0.7 * _hash(seed + '_' + i));
+      pts.push([cy + Math.sin(angle) * r, cx + Math.cos(angle) * r]);
+    }
+    return pts;
   }
 
   // Deterministic djb2-style hash of a string → float in [0, 1).
@@ -305,8 +308,7 @@
 
     var mapH = bounds[1][0] - bounds[0][0];
     var mapW = bounds[1][1] - bounds[0][1];
-    var halfH = mapH * 0.025;
-    var halfW = mapW * 0.025;
+    var baseRadius = Math.min(mapH, mapW) * 0.018;
 
     var reefs = [];
     for (var i = 0; i < count; i++) {
@@ -322,7 +324,13 @@
       reefs.push({
         id: 'reef_' + i,
         type: 'reef',
-        polygon: _makeRect(basePos[0] + nudgeY, basePos[1] + nudgeX, halfH, halfW),
+        polygon: _jaggedBlob(
+          basePos[0] + nudgeY,
+          basePos[1] + nudgeX,
+          baseRadius,
+          7,
+          'reef_shape_' + i
+        ),
         severity: 'medium',
       });
     }
@@ -392,8 +400,7 @@
     var mapW = maxX - minX;
     var centerY = (minY + maxY) / 2;
     var centerX = (minX + maxX) / 2;
-    var halfH = mapH * 0.05;
-    var halfW = mapW * 0.05;
+    var baseRadius = Math.min(mapH, mapW) * 0.055;
 
     var zones = [];
     for (var i = 0; i < count; i++) {
@@ -402,7 +409,7 @@
       zones.push({
         id: 'kraken_' + i,
         type: 'kraken_zone',
-        polygon: _makeRect(cy, cx, halfH, halfW),
+        polygon: _jaggedBlob(cy, cx, baseRadius, 14, 'kzone_shape_' + i),
         severity: 'high',
       });
     }
@@ -488,6 +495,26 @@
       return { id: 'lake_' + i, name: l.name, type: 'lake', polygon: l.polygon, severity: 'low' };
     });
     var routes = generateTradeRoutes(classified, opts);
+
+    // Route waypoints around landmasses if a pathfinder is registered.
+    // Browser-only — Node tests don't load pathfinder, routes keep fromId/toId
+    // and the renderer falls back to a straight line.
+    var pathfinder = typeof window !== 'undefined' && window.Tortuga && window.Tortuga.pathfinder;
+    if (pathfinder && routes.length > 0) {
+      var posById = {};
+      for (var pi = 0; pi < classified.length; pi++) {
+        posById[classified[pi].id] = classified[pi].position;
+      }
+      var mask = pathfinder.buildLandMask(parsed.bounds, parsed.coastlines);
+      for (var ri = 0; ri < routes.length; ri++) {
+        var r = routes[ri];
+        var from = posById[r.fromId];
+        var to = posById[r.toId];
+        if (!from || !to) continue;
+        var pts = pathfinder.findPath(mask, from, to);
+        if (pts && pts.length >= 2) r.points = pts;
+      }
+    }
 
     return {
       bounds: parsed.bounds,

--- a/public/apps/tortuga/cartographer/pathfinder.js
+++ b/public/apps/tortuga/cartographer/pathfinder.js
@@ -1,0 +1,279 @@
+(function () {
+  'use strict';
+
+  /*
+   * Tortuga water-pathfinder — used by overlay.applyOverlay to bend trade routes
+   * around landmasses instead of drawing straight lines through islands.
+   *
+   * Two-step pipeline:
+   *   buildLandMask(bounds, coastlines, gridSize)
+   *     Rasterises coastline polygons into a square land/water grid by bbox-
+   *     filtered ray-cast point-in-polygon on each cell centre.
+   *
+   *   findPath(meta, fromWorld, toWorld)
+   *     8-connected A* with octile-distance heuristic across the water cells,
+   *     then drops collinear intermediate points so the result is a polyline
+   *     of turn vertices in world coords (y, x).
+   *
+   * If start or end falls on land (ports sit on the coastline, so this is
+   * common), we BFS up to 5 cells outward to find the nearest water cell.
+   * If no path is found (e.g. ports on disconnected seas), returns null and
+   * the caller falls back to a straight line.
+   */
+
+  var DEFAULT_GRID_SIZE = 160;
+
+  function _bbox(poly) {
+    var minY = Infinity,
+      minX = Infinity,
+      maxY = -Infinity,
+      maxX = -Infinity;
+    for (var i = 0; i < poly.length; i++) {
+      var p = poly[i];
+      if (p[0] < minY) minY = p[0];
+      if (p[0] > maxY) maxY = p[0];
+      if (p[1] < minX) minX = p[1];
+      if (p[1] > maxX) maxX = p[1];
+    }
+    return [minY, minX, maxY, maxX];
+  }
+
+  function _pointInPolygon(y, x, poly) {
+    var inside = false;
+    var n = poly.length;
+    for (var i = 0, j = n - 1; i < n; j = i++) {
+      var yi = poly[i][0],
+        xi = poly[i][1];
+      var yj = poly[j][0],
+        xj = poly[j][1];
+      var intersect = yi > y !== yj > y && x < ((xj - xi) * (y - yi)) / (yj - yi) + xi;
+      if (intersect) inside = !inside;
+    }
+    return inside;
+  }
+
+  function buildLandMask(bounds, coastlines, gridSize) {
+    gridSize = gridSize || DEFAULT_GRID_SIZE;
+    var minY = bounds[0][0],
+      minX = bounds[0][1];
+    var maxY = bounds[1][0],
+      maxX = bounds[1][1];
+    var cellH = (maxY - minY) / gridSize;
+    var cellW = (maxX - minX) / gridSize;
+    var mask = new Uint8Array(gridSize * gridSize);
+
+    if (!coastlines) {
+      return { mask: mask, gridSize: gridSize, minY: minY, minX: minX, cellH: cellH, cellW: cellW };
+    }
+
+    for (var p = 0; p < coastlines.length; p++) {
+      var poly = coastlines[p];
+      if (!poly || poly.length < 3) continue;
+      var bb = _bbox(poly);
+      var iMin = Math.max(0, Math.floor((bb[0] - minY) / cellH));
+      var iMax = Math.min(gridSize - 1, Math.floor((bb[2] - minY) / cellH));
+      var jMin = Math.max(0, Math.floor((bb[1] - minX) / cellW));
+      var jMax = Math.min(gridSize - 1, Math.floor((bb[3] - minX) / cellW));
+      for (var i = iMin; i <= iMax; i++) {
+        var cy = minY + (i + 0.5) * cellH;
+        for (var j = jMin; j <= jMax; j++) {
+          var idx = i * gridSize + j;
+          if (mask[idx]) continue;
+          var cx = minX + (j + 0.5) * cellW;
+          if (_pointInPolygon(cy, cx, poly)) mask[idx] = 1;
+        }
+      }
+    }
+
+    return { mask: mask, gridSize: gridSize, minY: minY, minX: minX, cellH: cellH, cellW: cellW };
+  }
+
+  function _worldToGrid(meta, y, x) {
+    var i = Math.floor((y - meta.minY) / meta.cellH);
+    var j = Math.floor((x - meta.minX) / meta.cellW);
+    if (i < 0) i = 0;
+    if (i >= meta.gridSize) i = meta.gridSize - 1;
+    if (j < 0) j = 0;
+    if (j >= meta.gridSize) j = meta.gridSize - 1;
+    return [i, j];
+  }
+
+  function _gridToWorld(meta, i, j) {
+    return [meta.minY + (i + 0.5) * meta.cellH, meta.minX + (j + 0.5) * meta.cellW];
+  }
+
+  // BFS outward in square rings to find the nearest water cell within maxRadius.
+  function _nearestWater(meta, i, j, maxRadius) {
+    var n = meta.gridSize;
+    if (!meta.mask[i * n + j]) return [i, j];
+    for (var r = 1; r <= maxRadius; r++) {
+      for (var di = -r; di <= r; di++) {
+        for (var dj = -r; dj <= r; dj++) {
+          if (Math.abs(di) !== r && Math.abs(dj) !== r) continue;
+          var ni = i + di,
+            nj = j + dj;
+          if (ni < 0 || ni >= n || nj < 0 || nj >= n) continue;
+          if (!meta.mask[ni * n + nj]) return [ni, nj];
+        }
+      }
+    }
+    return null;
+  }
+
+  // Min-heap keyed on f-score. No decrease-key — stale entries are filtered
+  // in the A* main loop via the closed-set check.
+  function _Heap() {
+    this.data = [];
+  }
+  _Heap.prototype.push = function (node) {
+    this.data.push(node);
+    var i = this.data.length - 1;
+    while (i > 0) {
+      var pIdx = (i - 1) >> 1;
+      if (this.data[pIdx].f <= this.data[i].f) break;
+      var t = this.data[pIdx];
+      this.data[pIdx] = this.data[i];
+      this.data[i] = t;
+      i = pIdx;
+    }
+  };
+  _Heap.prototype.pop = function () {
+    if (this.data.length === 0) return null;
+    var top = this.data[0];
+    var last = this.data.pop();
+    if (this.data.length > 0) {
+      this.data[0] = last;
+      var i = 0,
+        n = this.data.length;
+      while (true) {
+        var l = 2 * i + 1,
+          r = 2 * i + 2,
+          s = i;
+        if (l < n && this.data[l].f < this.data[s].f) s = l;
+        if (r < n && this.data[r].f < this.data[s].f) s = r;
+        if (s === i) break;
+        var t = this.data[s];
+        this.data[s] = this.data[i];
+        this.data[i] = t;
+        i = s;
+      }
+    }
+    return top;
+  };
+  _Heap.prototype.size = function () {
+    return this.data.length;
+  };
+
+  var DIRS = [
+    [-1, 0, 1],
+    [1, 0, 1],
+    [0, -1, 1],
+    [0, 1, 1],
+    [-1, -1, Math.SQRT2],
+    [-1, 1, Math.SQRT2],
+    [1, -1, Math.SQRT2],
+    [1, 1, Math.SQRT2],
+  ];
+
+  function _octile(i, j, ti, tj) {
+    var di = Math.abs(i - ti),
+      dj = Math.abs(j - tj);
+    return di + dj + (Math.SQRT2 - 2) * Math.min(di, dj);
+  }
+
+  function _astar(meta, si, sj, ti, tj) {
+    var n = meta.gridSize;
+    var open = new _Heap();
+    var gScore = new Float32Array(n * n);
+    var came = new Int32Array(n * n);
+    var visited = new Uint8Array(n * n);
+    for (var k = 0; k < n * n; k++) {
+      gScore[k] = Infinity;
+      came[k] = -1;
+    }
+    var sIdx = si * n + sj;
+    gScore[sIdx] = 0;
+    open.push({ i: si, j: sj, f: _octile(si, sj, ti, tj) });
+
+    while (open.size() > 0) {
+      var cur = open.pop();
+      var cIdx = cur.i * n + cur.j;
+      if (visited[cIdx]) continue;
+      visited[cIdx] = 1;
+      if (cur.i === ti && cur.j === tj) {
+        var path = [];
+        var k2 = cIdx;
+        while (k2 !== -1) {
+          path.push([Math.floor(k2 / n), k2 % n]);
+          k2 = came[k2];
+        }
+        path.reverse();
+        return path;
+      }
+      for (var d = 0; d < DIRS.length; d++) {
+        var ni = cur.i + DIRS[d][0],
+          nj = cur.j + DIRS[d][1],
+          cost = DIRS[d][2];
+        if (ni < 0 || ni >= n || nj < 0 || nj >= n) continue;
+        var nIdx = ni * n + nj;
+        if (meta.mask[nIdx]) continue;
+        if (visited[nIdx]) continue;
+        var tentG = gScore[cIdx] + cost;
+        if (tentG >= gScore[nIdx]) continue;
+        gScore[nIdx] = tentG;
+        came[nIdx] = cIdx;
+        open.push({ i: ni, j: nj, f: tentG + _octile(ni, nj, ti, tj) });
+      }
+    }
+    return null;
+  }
+
+  // Drop collinear interior points via cross-product epsilon.
+  function _simplify(path) {
+    if (path.length <= 2) return path.slice();
+    var result = [path[0]];
+    for (var i = 1; i < path.length - 1; i++) {
+      var a = result[result.length - 1],
+        b = path[i],
+        c = path[i + 1];
+      var cross = (b[0] - a[0]) * (c[1] - a[1]) - (b[1] - a[1]) * (c[0] - a[0]);
+      if (Math.abs(cross) > 1e-6) result.push(b);
+    }
+    result.push(path[path.length - 1]);
+    return result;
+  }
+
+  function findPath(meta, fromWorld, toWorld) {
+    var s = _worldToGrid(meta, fromWorld[0], fromWorld[1]);
+    var t = _worldToGrid(meta, toWorld[0], toWorld[1]);
+    var sw = _nearestWater(meta, s[0], s[1], 5);
+    var tw = _nearestWater(meta, t[0], t[1], 5);
+    if (!sw || !tw) return null;
+    var gridPath = _astar(meta, sw[0], sw[1], tw[0], tw[1]);
+    if (!gridPath || gridPath.length < 2) return null;
+    var worldPath = gridPath.map(function (g) {
+      return _gridToWorld(meta, g[0], g[1]);
+    });
+    // Snap endpoints to the actual port positions so polylines visibly connect.
+    worldPath[0] = fromWorld;
+    worldPath[worldPath.length - 1] = toWorld;
+    return _simplify(worldPath);
+  }
+
+  var api = {
+    buildLandMask: buildLandMask,
+    findPath: findPath,
+    DEFAULT_GRID_SIZE: DEFAULT_GRID_SIZE,
+  };
+
+  if (typeof window !== 'undefined') {
+    window.Tortuga = window.Tortuga || {};
+    window.Tortuga.pathfinder = api;
+  }
+
+  // eslint-disable-next-line no-undef
+  if (typeof module !== 'undefined' && module.exports) {
+    // eslint-disable-next-line no-undef
+    module.exports = api;
+  }
+})();

--- a/public/apps/tortuga/index.html
+++ b/public/apps/tortuga/index.html
@@ -85,6 +85,7 @@
     <script src="/apps/tortuga/map-renderer.js"></script>
     <script src="/apps/tortuga/firestore.js"></script>
     <script src="/apps/tortuga/world-list.js"></script>
+    <script src="/apps/tortuga/cartographer/pathfinder.js"></script>
     <script src="/apps/tortuga/cartographer/overlay.js"></script>
     <script src="/apps/tortuga/cartographer/importer.js"></script>
     <script src="/apps/tortuga/app.js"></script>

--- a/public/apps/tortuga/map-renderer.js
+++ b/public/apps/tortuga/map-renderer.js
@@ -67,8 +67,21 @@
 
   function _renderTradeRoutes(world) {
     if (!world || !world.tradeRoutes) return;
+    var posById = {};
+    if (world.settlements) {
+      world.settlements.forEach(function (s) {
+        posById[s.id] = s.position || s.pos;
+      });
+    }
     world.tradeRoutes.forEach(function (r) {
-      L.polyline(r.points, {
+      var points = r.points;
+      if (!points && r.fromId && r.toId) {
+        var from = posById[r.fromId];
+        var to = posById[r.toId];
+        if (from && to) points = [from, to];
+      }
+      if (!points || points.length < 2) return;
+      L.polyline(points, {
         color: '#c8a84b',
         weight: 2,
         dashArray: '6 4',

--- a/public/apps/tortuga/map-renderer.js
+++ b/public/apps/tortuga/map-renderer.js
@@ -51,17 +51,49 @@
     });
   }
 
+  var HAZARD_STYLES = {
+    reef: { color: '#7a4a1c', fillColor: '#b07a3a', fillOpacity: 0.55, weight: 1 },
+    storm_band: {
+      color: '#506878',
+      fillColor: '#8aa8b8',
+      fillOpacity: 0.22,
+      weight: 1,
+      dashArray: '4 6',
+    },
+    kraken_zone: { color: '#2a1a3a', fillColor: '#4a2a5a', fillOpacity: 0.4, weight: 1 },
+    lake: { color: '#2a6a8a', fillColor: '#4a8aaa', fillOpacity: 0.55, weight: 1 },
+  };
+
+  var DEFAULT_HAZARD_STYLE = {
+    color: '#cc4444',
+    fillColor: '#ff0000',
+    fillOpacity: 0.25,
+    weight: 1,
+  };
+
+  var HAZARD_LABELS = {
+    reef: 'Reef',
+    storm_band: 'Storm Band',
+    kraken_zone: 'Kraken Waters',
+    lake: 'Lake',
+  };
+
   function _renderHazards(world) {
     if (!world || !world.hazards) return;
     world.hazards.forEach(function (h) {
-      L.polygon(h.polygon, {
-        color: '#cc4444',
-        fillColor: '#ff0000',
-        fillOpacity: 0.25,
-        weight: 1,
-      })
-        .bindPopup('<strong>' + (h.name || 'Hazard') + '</strong><br>' + (h.type || ''))
-        .addTo(_layers[LAYERS.HAZARDS]);
+      var style = HAZARD_STYLES[h.type] || DEFAULT_HAZARD_STYLE;
+      var label = h.name || HAZARD_LABELS[h.type] || 'Hazard';
+      var popup =
+        '<strong>' + label + '</strong>' + (h.severity ? '<br>Severity: ' + h.severity : '');
+      var polygon = L.polygon(h.polygon, style).bindPopup(popup);
+      if (h.type === 'kraken_zone') {
+        polygon.bindTooltip('Kraken Waters', {
+          permanent: true,
+          direction: 'center',
+          className: 'tortuga-hazard-label',
+        });
+      }
+      polygon.addTo(_layers[LAYERS.HAZARDS]);
     });
   }
 

--- a/public/apps/tortuga/tortuga.css
+++ b/public/apps/tortuga/tortuga.css
@@ -263,6 +263,31 @@
   border-radius: 6px;
 }
 
+/* ── Hazard center labels (Leaflet tooltip override) ──────── */
+
+.leaflet-tooltip.tortuga-hazard-label {
+  background: transparent;
+  border: none;
+  box-shadow: none;
+  padding: 0;
+  color: #d4b0e0;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  text-shadow:
+    -1px -1px 0 #1a0a2a,
+    1px -1px 0 #1a0a2a,
+    -1px 1px 0 #1a0a2a,
+    1px 1px 0 #1a0a2a;
+  white-space: nowrap;
+  pointer-events: none;
+}
+
+.leaflet-tooltip.tortuga-hazard-label::before {
+  display: none;
+}
+
 /* ── Cartographer knobs panel ──────────────────────────────── */
 
 .knobs-panel {


### PR DESCRIPTION
## Summary

Started as a bug report after #258 (Cartographer UI pipeline, closes #193):
real Azgaar imports rendered a blank map and the save button stuck on
"Generating…". Root cause was a renderer mismatch with the new §9 trade-route
schema. While in there, picked up two adjacent rough edges the user flagged:
all hazards looked like red blocks, and trade routes cut straight through
landmasses.

Two commits to keep review surface clear:

### `fix`: trade routes blank the map and freeze the save button
`applyOverlay` emits routes as `{ id, fromId, toId, faction }` (§9 schema)
with no `points` field. `_renderTradeRoutes` was calling
`L.polyline(undefined, …)`, which throws inside Leaflet's `_convertLatLngs`.
The throw aborted `setWorld` before `fitBounds` (→ blank map) and unwound
past the lines in `_generateAndPreview` that reset the save button text
(→ stuck on "Generating…"). Renderer now resolves `fromId`/`toId` against
`world.settlements` and keeps the `r.points` fallback so `PLACEHOLDER_WORLD`
still renders.

### `feat`: hazard styling + water-pathed trade routes
- **Hazards** — reefs and kraken zones now render as deterministic jagged
  blobs (7/14 sides, hash-perturbed radius) instead of rectangles. Storm
  bands stay rectangular but recolour cyan-grey dashed. Renderer dispatches
  per type via `HAZARD_STYLES`: reef brown, storm cyan-grey, kraken
  purple-black with a permanent centre "Kraken Waters" tooltip, lake blue.
- **Trade-route pathfinding** — new `cartographer/pathfinder.js` rasterises
  coastlines into a 160-cell land/water grid via bbox-filtered ray-cast
  point-in-polygon, runs 8-connected A* with octile heuristic, snaps
  endpoints to actual port coords, drops collinear interior points.
  When a port sits on land (the common case — ports are on the coastline),
  BFS up to 5 cells finds the nearest water cell. Disconnected seas →
  `null` → renderer falls back to a straight line. `applyOverlay` calls
  the pathfinder conditionally via `window.Tortuga.pathfinder` so the
  Node overlay tests stay decoupled.

## Test plan

- [x] `npm run lint` — clean (two pre-existing warnings in `app.js`).
- [x] `npm run format` — clean.
- [x] `cd tests && npx jest tortuga-overlay tortuga-importer` — 115/115 pass.
- [x] Manual: hosting emulator + Azgaar JSON import. Verified:
  - Map renders coastlines, settlements, hazards, routes.
  - Save button transitions "Generating…" → "Save World" and enables.
  - Reefs are small brown jagged blobs along the coast.
  - Storm bands are cyan-grey dashed.
  - Kraken zones are dark purple irregular blobs with "KRAKEN WATERS" label.
  - Lakes are blue.
  - Trade routes bend around islands instead of cutting through.
  - Knob changes regenerate the world and re-route trade lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)