### PR TITLE
feat(tortuga): Cartographer world editor — rename, drag, factions, hazards, undo (closes #194)

### DIFF
--- a/public/apps/tortuga/app.js
+++ b/public/apps/tortuga/app.js
@@ -10,6 +10,7 @@
   var _generatedWorld = null; // last result of T.overlay.applyOverlay
   var _generating = false; // guard against concurrent regenerations
   var _mapInitialised = false; // track first T.mapRenderer.init call
+  var _keydownHandler = null; // Ctrl+Z / Ctrl+Y listener
 
   // ── Mode routing ────────────────────────────────────────────
 
@@ -209,7 +210,64 @@
         saveBtn.disabled = false;
         saveBtn.textContent = 'Save World';
       }
+
+      _initEditor();
     }, 0);
+  }
+
+  // ── Editor integration ───────────────────────────────────────
+
+  function _mapEditCallbacks() {
+    return {
+      onSettlementClick: function (id) {
+        if (T.editor) T.editor.selectSettlement(id);
+      },
+      onSettlementDrag: function (id, pos) {
+        if (T.editor) T.editor.updateSettlementPos(id, pos);
+      },
+    };
+  }
+
+  function _onWorldEdited(world) {
+    _generatedWorld = world;
+    T.mapRenderer.setWorld(world);
+    T.mapRenderer.setEditMode(world, _mapEditCallbacks());
+    var sel = T.editor && T.editor._selectedId;
+    if (sel) {
+      for (var i = 0; i < world.settlements.length; i++) {
+        if (world.settlements[i].id === sel) {
+          T.mapRenderer.highlightSettlement(
+            world.settlements[i].position || world.settlements[i].pos
+          );
+          break;
+        }
+      }
+    }
+  }
+
+  function _initEditor() {
+    var editorEl = document.getElementById('cartographer-editor');
+    if (!editorEl) return;
+    if (T.editor && T.editor._rendered) T.editor.destroy();
+    T.editor.render(editorEl, _generatedWorld, { onChanged: _onWorldEdited });
+    editorEl.classList.remove('hidden');
+    T.mapRenderer.setEditMode(_generatedWorld, _mapEditCallbacks());
+
+    if (!_keydownHandler) {
+      _keydownHandler = function (e) {
+        if (!T.editor || !T.editor._rendered) return;
+        if (e.ctrlKey || e.metaKey) {
+          if (!e.shiftKey && e.key === 'z') {
+            e.preventDefault();
+            T.editor.undo();
+          } else if (e.key === 'y' || (e.shiftKey && e.key === 'z')) {
+            e.preventDefault();
+            T.editor.redo();
+          }
+        }
+      };
+      document.addEventListener('keydown', _keydownHandler);
+    }
   }
 
   // ── Save handler ─────────────────────────────────────────────
@@ -278,6 +336,7 @@
             _parsedData = parsed;
             _generatedWorld = null;
             _mapInitialised = false;
+            if (T.editor && T.editor._rendered) T.editor.destroy();
 
             var warningEl = document.getElementById('land-heavy-warning');
             if (parsed.landPercentage > T.LAND_HEAVY_THRESHOLD && warningEl) {

--- a/public/apps/tortuga/cartographer/editor.js
+++ b/public/apps/tortuga/cartographer/editor.js
@@ -1,0 +1,596 @@
+(function () {
+  'use strict';
+
+  /*
+   * Tortuga Cartographer world editor — issue #194.
+   *
+   * Renders three panels below the map preview:
+   *   Inspector  — per-settlement name / type / faction editor (shown on click)
+   *   Factions   — rename + recolor each faction
+   *   Hazards    — add reef / kraken zone, remove any non-lake hazard
+   *
+   * All mutations follow the same pattern:
+   *   1. Push snapshot to undo stack
+   *   2. Mutate _world in place
+   *   3. Call _callbacks.onChanged(_world)
+   *
+   * Undo/redo max depth: 20.
+   *
+   * app.js drives the map interactions via setEditMode/highlightSettlement
+   * callbacks; this module only concerns itself with the panel UI.
+   */
+
+  var MAX_HISTORY = 20;
+
+  var SETTLEMENT_TYPE_LABELS = {
+    colonial_port: 'Colonial Port',
+    free_port: 'Free Port',
+    fort: 'Fort',
+    hidden_cove: 'Hidden Cove',
+    native_village: 'Native Village',
+    ruins: 'Ruins',
+  };
+
+  var SETTLEMENT_TYPES = Object.keys(SETTLEMENT_TYPE_LABELS);
+
+  var PLACEABLE_HAZARD_TYPES = ['reef', 'kraken_zone'];
+
+  var HAZARD_TYPE_LABELS = {
+    reef: 'Reef',
+    storm_band: 'Storm Band',
+    kraken_zone: 'Kraken Zone',
+    lake: 'Lake',
+  };
+
+  // ── Internal state ──────────────────────────────────────────
+
+  var _world = null;
+  var _callbacks = {};
+  var _selectedId = null;
+  var _history = [];
+  var _historyPos = -1;
+  var _addingHazardType = null;
+  var _containerEl = null;
+  var _rendered = false;
+
+  // ── History ─────────────────────────────────────────────────
+
+  function _snapshot() {
+    return {
+      settlements: _world.settlements.map(function (s) {
+        return Object.assign({}, s);
+      }),
+      factions: _world.factions
+        ? _world.factions.map(function (f) {
+            return Object.assign({}, f);
+          })
+        : [],
+      hazards: _world.hazards.map(function (h) {
+        return Object.assign({}, h);
+      }),
+    };
+  }
+
+  function _pushHistory() {
+    // Drop any forward history beyond current position
+    _history = _history.slice(0, _historyPos + 1);
+    _history.push(_snapshot());
+    if (_history.length > MAX_HISTORY) _history.shift();
+    _historyPos = _history.length - 1;
+    _updateUndoRedoBtns();
+  }
+
+  function _restoreSnapshot(snap) {
+    _world.settlements = snap.settlements.map(function (s) {
+      return Object.assign({}, s);
+    });
+    _world.factions = snap.factions.map(function (f) {
+      return Object.assign({}, f);
+    });
+    _world.hazards = snap.hazards.map(function (h) {
+      return Object.assign({}, h);
+    });
+  }
+
+  function _updateUndoRedoBtns() {
+    var undoBtn = _containerEl && _containerEl.querySelector('#editor-undo-btn');
+    var redoBtn = _containerEl && _containerEl.querySelector('#editor-redo-btn');
+    if (undoBtn) undoBtn.disabled = _historyPos <= 0;
+    if (redoBtn) redoBtn.disabled = _historyPos >= _history.length - 1;
+  }
+
+  // ── Mutation helpers ────────────────────────────────────────
+
+  function _mutate(fn) {
+    _pushHistory();
+    fn();
+    if (_callbacks.onChanged) _callbacks.onChanged(_world);
+    _renderInspector();
+    _renderFactions();
+    _renderHazardList();
+  }
+
+  // ── Inspector panel ─────────────────────────────────────────
+
+  function _renderInspector() {
+    var panel = _containerEl && _containerEl.querySelector('#editor-inspector');
+    if (!panel) return;
+    var s = null;
+    if (_selectedId && _world) {
+      for (var i = 0; i < _world.settlements.length; i++) {
+        if (_world.settlements[i].id === _selectedId) {
+          s = _world.settlements[i];
+          break;
+        }
+      }
+    }
+
+    if (!s) {
+      panel.innerHTML = '<p class="inspector-empty">Click a settlement on the map to edit it.</p>';
+      return;
+    }
+
+    var factionOptions = '<option value="">— None —</option>';
+    (_world.factions || []).forEach(function (f) {
+      factionOptions +=
+        '<option value="' +
+        _escAttr(f.id) +
+        '"' +
+        (s.parentFaction === f.id ? ' selected' : '') +
+        '>' +
+        _escText(f.name) +
+        '</option>';
+    });
+
+    var typeOptions = SETTLEMENT_TYPES.map(function (t) {
+      return (
+        '<option value="' +
+        t +
+        '"' +
+        (s.type === t ? ' selected' : '') +
+        '>' +
+        SETTLEMENT_TYPE_LABELS[t] +
+        '</option>'
+      );
+    }).join('');
+
+    var pos = s.position || s.pos || [0, 0];
+
+    panel.innerHTML =
+      '<div class="inspector-header">' +
+      '<span class="inspector-title">' +
+      _escText(s.name) +
+      '</span>' +
+      '<button class="inspector-deselect" id="inspector-deselect" type="button" ' +
+      'aria-label="Deselect">&times;</button>' +
+      '</div>' +
+      '<div class="knobs-field">' +
+      '<label class="knobs-label" for="inspector-name">Name</label>' +
+      '<input class="knobs-input" id="inspector-name" type="text" value="' +
+      _escAttr(s.name) +
+      '">' +
+      '</div>' +
+      '<div class="knobs-field">' +
+      '<label class="knobs-label" for="inspector-type">Type</label>' +
+      '<select class="knobs-select" id="inspector-type">' +
+      typeOptions +
+      '</select>' +
+      '</div>' +
+      '<div class="knobs-field">' +
+      '<label class="knobs-label" for="inspector-faction">Faction</label>' +
+      '<select class="knobs-select" id="inspector-faction">' +
+      factionOptions +
+      '</select>' +
+      '</div>' +
+      '<p class="inspector-pos" id="inspector-pos">' +
+      _formatPos(pos) +
+      '</p>';
+
+    var nameInput = panel.querySelector('#inspector-name');
+    var typeSelect = panel.querySelector('#inspector-type');
+    var factionSelect = panel.querySelector('#inspector-faction');
+    var deselectBtn = panel.querySelector('#inspector-deselect');
+
+    nameInput.addEventListener('change', function () {
+      var val = nameInput.value.trim() || s.name;
+      _mutate(function () {
+        s.name = val;
+      });
+    });
+
+    typeSelect.addEventListener('change', function () {
+      _mutate(function () {
+        s.type = typeSelect.value;
+      });
+    });
+
+    factionSelect.addEventListener('change', function () {
+      _mutate(function () {
+        s.parentFaction = factionSelect.value || null;
+      });
+    });
+
+    deselectBtn.addEventListener('click', function () {
+      _selectedId = null;
+      if (window.Tortuga && window.Tortuga.mapRenderer) {
+        window.Tortuga.mapRenderer.clearHighlight();
+      }
+      _renderInspector();
+    });
+  }
+
+  // ── Factions panel ──────────────────────────────────────────
+
+  function _renderFactions() {
+    var panel = _containerEl && _containerEl.querySelector('#editor-factions');
+    if (!panel) return;
+    var factions = (_world && _world.factions) || [];
+    if (factions.length === 0) {
+      panel.innerHTML = '<p class="inspector-empty">No factions.</p>';
+      return;
+    }
+
+    var rows = factions
+      .map(function (f, idx) {
+        return (
+          '<div class="faction-list-row" data-faction-idx="' +
+          idx +
+          '">' +
+          '<input type="color" class="faction-color-input" ' +
+          'id="faction-color-' +
+          idx +
+          '" value="' +
+          _escAttr(f.color || '#888888') +
+          '" title="Faction color">' +
+          '<input class="knobs-input faction-name-input" ' +
+          'id="faction-name-' +
+          idx +
+          '" type="text" value="' +
+          _escAttr(f.name) +
+          '">' +
+          '<span class="faction-archetype-chip">' +
+          _escText(f.archetype || '') +
+          '</span>' +
+          '</div>'
+        );
+      })
+      .join('');
+
+    panel.innerHTML = rows;
+
+    factions.forEach(function (f, idx) {
+      var nameInput = panel.querySelector('#faction-name-' + idx);
+      var colorInput = panel.querySelector('#faction-color-' + idx);
+
+      nameInput.addEventListener('change', function () {
+        var val = nameInput.value.trim() || f.name;
+        _mutate(function () {
+          f.name = val;
+        });
+      });
+
+      colorInput.addEventListener('input', function () {
+        _mutate(function () {
+          f.color = colorInput.value;
+        });
+      });
+    });
+  }
+
+  // ── Hazards panel ───────────────────────────────────────────
+
+  function _renderHazardList() {
+    var listEl = _containerEl && _containerEl.querySelector('#editor-hazard-list');
+    if (!listEl) return;
+    var hazards = (_world && _world.hazards) || [];
+    var editable = hazards.filter(function (h) {
+      return h.type !== 'lake';
+    });
+    if (editable.length === 0) {
+      listEl.innerHTML = '<p class="inspector-empty">No hazards yet.</p>';
+      return;
+    }
+
+    listEl.innerHTML = editable
+      .map(function (h) {
+        return (
+          '<div class="hazard-list-row" data-hazard-id="' +
+          _escAttr(h.id) +
+          '">' +
+          '<span class="hazard-list-name">' +
+          _escText(HAZARD_TYPE_LABELS[h.type] || h.type) +
+          (h.name ? ' — ' + _escText(h.name) : '') +
+          '</span>' +
+          '<button class="hazard-delete-btn" type="button" ' +
+          'data-hazard-id="' +
+          _escAttr(h.id) +
+          '" aria-label="Remove hazard">&times;</button>' +
+          '</div>'
+        );
+      })
+      .join('');
+
+    listEl.querySelectorAll('.hazard-delete-btn').forEach(function (btn) {
+      btn.addEventListener('click', function () {
+        var id = btn.getAttribute('data-hazard-id');
+        _mutate(function () {
+          _world.hazards = _world.hazards.filter(function (h) {
+            return h.id !== id;
+          });
+        });
+      });
+    });
+  }
+
+  function _setAddHazardMode(type) {
+    _addingHazardType = type;
+    var addBtn = _containerEl && _containerEl.querySelector('#editor-add-hazard-btn');
+    var mapEl = document.getElementById('map-world');
+
+    if (!type) {
+      if (addBtn) {
+        addBtn.textContent = 'Add Hazard';
+        addBtn.classList.remove('app-btn--active');
+      }
+      if (mapEl) mapEl.classList.remove('tortuga-map--crosshair');
+      if (window.Tortuga && window.Tortuga.mapRenderer) {
+        window.Tortuga.mapRenderer.cancelMapClick();
+      }
+      return;
+    }
+
+    if (addBtn) {
+      addBtn.textContent = 'Cancel Add';
+      addBtn.classList.add('app-btn--active');
+    }
+    if (mapEl) mapEl.classList.add('tortuga-map--crosshair');
+
+    if (window.Tortuga && window.Tortuga.mapRenderer) {
+      window.Tortuga.mapRenderer.awaitMapClick(function (pos) {
+        _addingHazardType = null;
+        if (addBtn) {
+          addBtn.textContent = 'Add Hazard';
+          addBtn.classList.remove('app-btn--active');
+        }
+        if (mapEl) mapEl.classList.remove('tortuga-map--crosshair');
+        _placeHazard(type, pos);
+      });
+    }
+  }
+
+  // ── Public API ───────────────────────────────────────────────
+
+  function render(containerEl, world, callbacks) {
+    destroy();
+    _containerEl = containerEl;
+    _world = world;
+    _callbacks = callbacks || {};
+    _selectedId = null;
+    _history = [];
+    _historyPos = -1;
+    _addingHazardType = null;
+    _rendered = true;
+
+    // Push initial snapshot so undo is disabled at start
+    _history.push(_snapshot());
+    _historyPos = 0;
+
+    containerEl.innerHTML =
+      '<div class="editor-undo-row">' +
+      '<button class="editor-undo-btn" id="editor-undo-btn" type="button" disabled>&#8592; Undo</button>' +
+      '<button class="editor-undo-btn" id="editor-redo-btn" type="button" disabled>Redo &#8594;</button>' +
+      '</div>' +
+      '<div class="editor-panels">' +
+      '<div class="inspector-panel knobs-panel">' +
+      '<h2 class="knobs-panel-title">Settlement</h2>' +
+      '<div id="editor-inspector"></div>' +
+      '</div>' +
+      '<div class="faction-panel knobs-panel">' +
+      '<h2 class="knobs-panel-title">Factions</h2>' +
+      '<div id="editor-factions"></div>' +
+      '</div>' +
+      '</div>' +
+      '<div class="hazard-panel knobs-panel">' +
+      '<h2 class="knobs-panel-title">Hazards</h2>' +
+      '<div class="hazard-tools-row">' +
+      '<div class="hazard-type-radios">' +
+      PLACEABLE_HAZARD_TYPES.map(function (t) {
+        return (
+          '<label class="hazard-type-radio-label">' +
+          '<input type="radio" name="hazard-type" value="' +
+          t +
+          '"' +
+          (t === 'reef' ? ' checked' : '') +
+          '> ' +
+          (HAZARD_TYPE_LABELS[t] || t) +
+          '</label>'
+        );
+      }).join('') +
+      '</div>' +
+      '<button class="app-btn app-btn--sm" id="editor-add-hazard-btn" type="button">Add Hazard</button>' +
+      '</div>' +
+      '<div id="editor-hazard-list"></div>' +
+      '</div>';
+
+    _renderInspector();
+    _renderFactions();
+    _renderHazardList();
+    _updateUndoRedoBtns();
+
+    containerEl.querySelector('#editor-undo-btn').addEventListener('click', undo);
+    containerEl.querySelector('#editor-redo-btn').addEventListener('click', redo);
+    containerEl.querySelector('#editor-add-hazard-btn').addEventListener('click', function () {
+      if (_addingHazardType) {
+        _setAddHazardMode(null);
+      } else {
+        var typeRadio = containerEl.querySelector('input[name="hazard-type"]:checked');
+        _setAddHazardMode(typeRadio ? typeRadio.value : 'reef');
+      }
+    });
+  }
+
+  function destroy() {
+    if (!_rendered) return;
+    _setAddHazardMode(null);
+    _rendered = false;
+    _world = null;
+    _selectedId = null;
+    _history = [];
+    _historyPos = -1;
+    _callbacks = {};
+    if (_containerEl) {
+      _containerEl.innerHTML = '';
+      _containerEl.classList.add('hidden');
+    }
+    _containerEl = null;
+  }
+
+  function selectSettlement(id) {
+    _selectedId = id;
+    var s = null;
+    if (_world) {
+      for (var i = 0; i < _world.settlements.length; i++) {
+        if (_world.settlements[i].id === id) {
+          s = _world.settlements[i];
+          break;
+        }
+      }
+    }
+    if (s && window.Tortuga && window.Tortuga.mapRenderer) {
+      window.Tortuga.mapRenderer.highlightSettlement(s.position || s.pos);
+    }
+    _renderInspector();
+  }
+
+  function updateSettlementPos(id, pos) {
+    if (!_world) return;
+    var s = null;
+    for (var i = 0; i < _world.settlements.length; i++) {
+      if (_world.settlements[i].id === id) {
+        s = _world.settlements[i];
+        break;
+      }
+    }
+    if (!s) return;
+    _mutate(function () {
+      s.position = pos;
+    });
+    // Update position display if this settlement is currently inspected
+    if (_selectedId === id) {
+      var posEl = _containerEl && _containerEl.querySelector('#inspector-pos');
+      if (posEl) posEl.textContent = _formatPos(pos);
+    }
+    // Update highlight ring to new position
+    if (window.Tortuga && window.Tortuga.mapRenderer) {
+      window.Tortuga.mapRenderer.highlightSettlement(pos);
+    }
+  }
+
+  function placeHazardAt(pos) {
+    _placeHazard(_addingHazardType, pos);
+  }
+
+  function undo() {
+    if (_historyPos <= 0) return;
+    _historyPos--;
+    _restoreSnapshot(_history[_historyPos]);
+    _selectedId = null;
+    if (_callbacks.onChanged) _callbacks.onChanged(_world);
+    _renderInspector();
+    _renderFactions();
+    _renderHazardList();
+    _updateUndoRedoBtns();
+  }
+
+  function redo() {
+    if (_historyPos >= _history.length - 1) return;
+    _historyPos++;
+    _restoreSnapshot(_history[_historyPos]);
+    _selectedId = null;
+    if (_callbacks.onChanged) _callbacks.onChanged(_world);
+    _renderInspector();
+    _renderFactions();
+    _renderHazardList();
+    _updateUndoRedoBtns();
+  }
+
+  // ── Private helpers ──────────────────────────────────────────
+
+  function _placeHazard(type, pos) {
+    if (!type || !pos || !_world) return;
+    var bounds = _world.bounds || [
+      [0, 0],
+      [800, 800],
+    ];
+    var mapH = bounds[1][0] - bounds[0][0];
+    var overlay = window.Tortuga && window.Tortuga.overlay;
+    var radius = type === 'kraken_zone' ? mapH * 0.055 : mapH * 0.018;
+    var sides = type === 'kraken_zone' ? 14 : 7;
+    var seed = type + '_placed_' + Date.now();
+    var polygon = overlay
+      ? overlay.jaggedBlob(pos[0], pos[1], radius, sides, seed)
+      : _simpleCircle(pos[0], pos[1], radius, sides);
+    var id = type + '_placed_' + Date.now();
+    var severity = type === 'kraken_zone' ? 'high' : 'medium';
+    _mutate(function () {
+      _world.hazards.push({ id: id, type: type, polygon: polygon, severity: severity });
+    });
+  }
+
+  // Fallback polygon if overlay isn't loaded.
+  function _simpleCircle(cy, cx, r, sides) {
+    var pts = [];
+    for (var i = 0; i < sides; i++) {
+      var a = (i / sides) * Math.PI * 2;
+      pts.push([cy + Math.sin(a) * r, cx + Math.cos(a) * r]);
+    }
+    return pts;
+  }
+
+  function _escAttr(str) {
+    return String(str || '')
+      .replace(/&/g, '&amp;')
+      .replace(/"/g, '&quot;');
+  }
+
+  function _escText(str) {
+    return String(str || '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
+  }
+
+  function _formatPos(pos) {
+    if (!pos) return '';
+    return '[' + Math.round(pos[0]) + ', ' + Math.round(pos[1]) + ']';
+  }
+
+  // ── Export ───────────────────────────────────────────────────
+
+  var api = {
+    render: render,
+    destroy: destroy,
+    selectSettlement: selectSettlement,
+    updateSettlementPos: updateSettlementPos,
+    placeHazardAt: placeHazardAt,
+    undo: undo,
+    redo: redo,
+    get _selectedId() {
+      return _selectedId;
+    },
+    get _rendered() {
+      return _rendered;
+    },
+  };
+
+  if (typeof window !== 'undefined') {
+    window.Tortuga = window.Tortuga || {};
+    window.Tortuga.editor = api;
+  }
+
+  // eslint-disable-next-line no-undef
+  if (typeof module !== 'undefined' && module.exports) {
+    // eslint-disable-next-line no-undef
+    module.exports = api;
+  }
+})();

--- a/public/apps/tortuga/cartographer/importer.js
+++ b/public/apps/tortuga/cartographer/importer.js
@@ -206,8 +206,11 @@
     errorEl.classList.add('hidden');
   }
 
-  function _processFile(file, dropZoneEl, errorEl, callbacks) {
+  function _processFile(file, containerEl, callbacks) {
     if (!file) return;
+
+    var dropZoneEl = containerEl.querySelector('#cartographer-drop-zone');
+    var errorEl = containerEl.querySelector('#cartographer-import-error');
 
     var lower = file.name.toLowerCase();
     if (!lower.endsWith('.json')) {
@@ -220,11 +223,11 @@
 
     var reader = new FileReader();
     reader.onload = function (e) {
-      dropZoneEl.classList.remove('drop-zone--loading');
       var json;
       try {
         json = JSON.parse(e.target.result);
       } catch (parseErr) {
+        dropZoneEl.classList.remove('drop-zone--loading');
         var msg = 'File is not valid JSON: ' + parseErr.message;
         _showError(dropZoneEl, errorEl, msg);
         if (callbacks.onError) callbacks.onError(msg);
@@ -235,12 +238,16 @@
       try {
         parsed = parseAzgaarJson(json);
       } catch (err) {
+        dropZoneEl.classList.remove('drop-zone--loading');
         _showError(dropZoneEl, errorEl, err.message);
         if (callbacks.onError) callbacks.onError(err.message);
         return;
       }
 
-      _clearError(errorEl);
+      // Replace drop zone with a locked "loaded" state so the user can't
+      // accidentally re-upload while the overlay/pathfinder pipeline runs.
+      _showLoadedState(containerEl, file.name, callbacks);
+
       if (callbacks.onParsed) callbacks.onParsed(parsed, _toPreviewWorld(parsed));
     };
     reader.onerror = function () {
@@ -252,6 +259,38 @@
     reader.readAsText(file);
   }
 
+  // Replace the drop zone with a success banner. A "Choose different file" link
+  // resets the panel back to the drop zone so a fresh import can be made.
+  function _showLoadedState(containerEl, filename, callbacks) {
+    var dropZoneEl = containerEl.querySelector('#cartographer-drop-zone');
+    if (!dropZoneEl) return;
+
+    dropZoneEl.outerHTML =
+      '<div class="drop-zone-loaded" id="cartographer-drop-zone-loaded">' +
+      '<span class="drop-zone-loaded-icon" aria-hidden="true">&#10003;</span>' +
+      '<span class="drop-zone-loaded-name">' +
+      _escText(filename) +
+      '</span>' +
+      '<button class="drop-zone-reload-btn" id="cartographer-reload-btn" type="button">' +
+      'Choose different file' +
+      '</button>' +
+      '</div>';
+
+    var reloadBtn = containerEl.querySelector('#cartographer-reload-btn');
+    if (reloadBtn) {
+      reloadBtn.addEventListener('click', function () {
+        render(containerEl, callbacks);
+      });
+    }
+  }
+
+  function _escText(str) {
+    return String(str || '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
+  }
+
   function render(containerEl, callbacks) {
     containerEl.innerHTML =
       '<div class="import-panel">' +
@@ -261,10 +300,10 @@
       'then drop the <code>.json</code> file here. ' +
       '(The partitioned GeoJSON exports — cells, routes, rivers, markers, zones — are not supported.)</p>' +
       '<div class="drop-zone" id="cartographer-drop-zone">' +
-      '<span class="drop-zone-label">Drop Azgaar .json here</span>' +
-      '<label class="drop-zone-pick">or <span class="drop-zone-pick-link">choose a file</span>' +
-      '<input type="file" accept=".json,application/json" id="cartographer-file-input" style="display:none">' +
-      '</label>' +
+      '<span class="drop-zone-label">Drop Azgaar .json here, or tap to browse</span>' +
+      '<input type="file" accept=".json,application/json" ' +
+      'id="cartographer-file-input" class="drop-zone-file-input" ' +
+      'aria-label="Choose Azgaar JSON file">' +
       '</div>' +
       '<div class="import-error hidden" id="cartographer-import-error"></div>' +
       '</div>';
@@ -286,18 +325,16 @@
       e.preventDefault();
       dropZoneEl.classList.remove('drop-zone--active');
       var file = e.dataTransfer.files && e.dataTransfer.files[0];
-      _processFile(file, dropZoneEl, errorEl, callbacks);
-    });
-
-    dropZoneEl.addEventListener('click', function (e) {
-      if (e.target !== fileInputEl) fileInputEl.click();
+      _processFile(file, containerEl, callbacks);
     });
 
     fileInputEl.addEventListener('change', function () {
       var file = fileInputEl.files && fileInputEl.files[0];
-      _processFile(file, dropZoneEl, errorEl, callbacks);
       fileInputEl.value = '';
+      _processFile(file, containerEl, callbacks);
     });
+
+    void errorEl; // referenced via containerEl.querySelector in _processFile
   }
 
   var api = {

--- a/public/apps/tortuga/cartographer/overlay.js
+++ b/public/apps/tortuga/cartographer/overlay.js
@@ -537,6 +537,7 @@
     generateKrakenZones: generateKrakenZones,
     generateTradeRoutes: generateTradeRoutes,
     applyOverlay: applyOverlay,
+    jaggedBlob: _jaggedBlob,
   };
 
   if (typeof window !== 'undefined') {

--- a/public/apps/tortuga/index.html
+++ b/public/apps/tortuga/index.html
@@ -59,6 +59,7 @@
           </div>
         </div>
         <div id="cartographer-knobs" class="hidden"></div>
+        <div id="cartographer-editor" class="hidden"></div>
         <div id="world-list-world" class="world-list"></div>
         <div id="map-world" class="tortuga-map hidden"></div>
       </section>
@@ -88,6 +89,7 @@
     <script src="/apps/tortuga/cartographer/pathfinder.js"></script>
     <script src="/apps/tortuga/cartographer/overlay.js"></script>
     <script src="/apps/tortuga/cartographer/importer.js"></script>
+    <script src="/apps/tortuga/cartographer/editor.js"></script>
     <script src="/apps/tortuga/app.js"></script>
 
     <script>

--- a/public/apps/tortuga/map-renderer.js
+++ b/public/apps/tortuga/map-renderer.js
@@ -11,11 +11,14 @@
     TRADE_ROUTES: 'tradeRoutes',
     FACTION_TERRITORY: 'factionTerritory',
     WIND_CURRENTS: 'windCurrents',
+    SELECTION: 'selection',
   };
 
   var _map = null;
   var _layers = {};
   var _visibility = {};
+  var _editMode = false;
+  var _pendingMapClick = null;
 
   function _clearLayers() {
     Object.keys(_layers).forEach(function (k) {
@@ -335,6 +338,7 @@
       _layers[LAYERS.TRADE_ROUTES] = L.layerGroup();
       _layers[LAYERS.FACTION_TERRITORY] = L.layerGroup();
       _layers[LAYERS.WIND_CURRENTS] = L.layerGroup();
+      _layers[LAYERS.SELECTION] = L.layerGroup();
 
       Object.keys(_layers).forEach(function (k) {
         _layers[k].addTo(_map);
@@ -355,6 +359,7 @@
 
     setWorld: function (world) {
       if (!_map) return;
+      this.clearEditMode();
       _clearLayers();
       _renderBase(world);
       _renderSettlements(world);
@@ -397,6 +402,81 @@
       _layers[name] = leafletLayer;
       _visibility[name] = true;
       leafletLayer.addTo(_map);
+    },
+
+    // ── Edit mode ───────────────────────────────────────────────
+
+    setEditMode: function (world, callbacks) {
+      if (!_map) return;
+      _editMode = true;
+      var cb = callbacks || {};
+      var settlementsLayer = _layers[LAYERS.SETTLEMENTS];
+      if (!settlementsLayer) return;
+      settlementsLayer.clearLayers();
+      if (!world || !world.settlements) return;
+      world.settlements.forEach(function (s) {
+        var pos = s.position || s.pos;
+        var factionLabel = s.parentFaction || s.faction || null;
+        var marker = L.marker(pos, { title: s.name, draggable: true });
+        marker.bindPopup(
+          '<strong>' +
+            s.name +
+            '</strong><br>' +
+            (s.type || '') +
+            (factionLabel ? '<br>' + factionLabel : '')
+        );
+        marker.on('click', function (e) {
+          L.DomEvent.stopPropagation(e);
+          if (cb.onSettlementClick) cb.onSettlementClick(s.id);
+        });
+        marker.on('dragend', function () {
+          var ll = marker.getLatLng();
+          if (cb.onSettlementDrag) cb.onSettlementDrag(s.id, [ll.lat, ll.lng]);
+        });
+        marker.addTo(settlementsLayer);
+      });
+    },
+
+    clearEditMode: function () {
+      _editMode = false;
+      this.cancelMapClick();
+    },
+
+    highlightSettlement: function (pos) {
+      if (!_map || !_layers[LAYERS.SELECTION]) return;
+      _layers[LAYERS.SELECTION].clearLayers();
+      if (!pos) return;
+      L.circleMarker(pos, {
+        radius: 14,
+        color: '#ffb74d',
+        fillOpacity: 0,
+        weight: 2,
+      }).addTo(_layers[LAYERS.SELECTION]);
+    },
+
+    clearHighlight: function () {
+      if (_layers[LAYERS.SELECTION]) _layers[LAYERS.SELECTION].clearLayers();
+    },
+
+    awaitMapClick: function (callback) {
+      if (!_map) return;
+      this.cancelMapClick();
+      _pendingMapClick = function (e) {
+        _pendingMapClick = null;
+        callback([e.latlng.lat, e.latlng.lng]);
+      };
+      _map.once('click', _pendingMapClick);
+    },
+
+    cancelMapClick: function () {
+      if (_map && _pendingMapClick) {
+        _map.off('click', _pendingMapClick);
+      }
+      _pendingMapClick = null;
+    },
+
+    isEditMode: function () {
+      return _editMode;
     },
   };
 })();

--- a/public/apps/tortuga/tortuga.css
+++ b/public/apps/tortuga/tortuga.css
@@ -149,6 +149,7 @@
 }
 
 .drop-zone {
+  position: relative;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -163,6 +164,16 @@
     border-color 0.15s,
     background 0.15s;
   text-align: center;
+}
+
+/* Transparent file input overlays the entire drop zone — reliable on iOS */
+.drop-zone-file-input {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  cursor: pointer;
 }
 
 .drop-zone:hover,
@@ -196,6 +207,46 @@
   margin-top: 0.5rem;
   font-size: 0.8rem;
   color: #e05555;
+}
+
+/* Loaded state — replaces drop zone after a successful parse */
+
+.drop-zone-loaded {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+  padding: 0.75rem 1rem;
+  border: 1px solid rgba(102, 187, 106, 0.3);
+  border-radius: 8px;
+  background: rgba(102, 187, 106, 0.06);
+}
+
+.drop-zone-loaded-icon {
+  color: #66bb6a;
+  font-size: 1rem;
+  flex-shrink: 0;
+}
+
+.drop-zone-loaded-name {
+  flex: 1;
+  min-width: 0;
+  font-size: 0.85rem;
+  color: var(--color-text, #e0e0e0);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.drop-zone-reload-btn {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  color: var(--color-accent, #7c6aff);
+  font-size: 0.8rem;
+  cursor: pointer;
+  text-decoration: underline;
+  padding: 0;
 }
 
 /* ── Buttons ───────────────────────────────────────────────── */
@@ -414,6 +465,226 @@
 
 @media (max-width: 600px) {
   .knobs-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ── World editor ──────────────────────────────────────────── */
+
+.editor-undo-row {
+  display: flex;
+  gap: 0.5rem;
+  margin: 0.75rem 0 0.25rem;
+}
+
+.editor-undo-btn {
+  padding: 0.3rem 0.7rem;
+  font-size: 0.75rem;
+  color: #90a4ae;
+  background: none;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  cursor: pointer;
+  transition:
+    color 0.2s,
+    border-color 0.2s;
+}
+
+.editor-undo-btn:hover:not(:disabled) {
+  color: #e0e0e0;
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+.editor-undo-btn:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+
+.editor-panels {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+  margin: 0.5rem 0;
+}
+
+/* Inspector */
+
+.inspector-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.75rem;
+}
+
+.inspector-title {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--color-text, #e0e0e0);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.inspector-deselect {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  color: #90a4ae;
+  font-size: 1.1rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 0.25rem;
+}
+
+.inspector-deselect:hover {
+  color: #e05555;
+}
+
+.inspector-empty {
+  font-size: 0.82rem;
+  color: var(--color-text-muted, #888);
+  font-style: italic;
+  margin: 0;
+}
+
+.inspector-pos {
+  font-size: 0.72rem;
+  font-family: monospace;
+  color: var(--color-text-muted, #888);
+  margin: 0.5rem 0 0;
+}
+
+/* Faction panel */
+
+.faction-list-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.faction-list-row:last-child {
+  border-bottom: none;
+}
+
+.faction-color-input {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  padding: 0;
+  flex-shrink: 0;
+  background: none;
+}
+
+.faction-color-input::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.faction-color-input::-webkit-color-swatch {
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 4px;
+}
+
+.faction-name-input {
+  flex: 1;
+  min-width: 0;
+}
+
+.faction-archetype-chip {
+  font-size: 0.65rem;
+  color: var(--color-text-muted, #888);
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 4px;
+  padding: 0.1rem 0.35rem;
+  flex-shrink: 0;
+  max-width: 90px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Hazard panel */
+
+.hazard-panel {
+  margin-top: 0.5rem;
+}
+
+.hazard-tools-row {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.75rem;
+}
+
+.hazard-type-radios {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.hazard-type-radio-label {
+  font-size: 0.82rem;
+  color: var(--color-text-muted, #90a4ae);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+.hazard-list-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.35rem 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.hazard-list-row:last-child {
+  border-bottom: none;
+}
+
+.hazard-list-name {
+  font-size: 0.82rem;
+  color: var(--color-text, #e0e0e0);
+}
+
+.hazard-delete-btn {
+  background: none;
+  border: none;
+  color: #90a4ae;
+  font-size: 1rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 0.25rem;
+  flex-shrink: 0;
+}
+
+.hazard-delete-btn:hover {
+  color: #e05555;
+}
+
+/* Active add-hazard button state */
+
+.app-btn--active {
+  background: rgba(255, 183, 77, 0.18);
+  border-color: rgba(255, 183, 77, 0.5);
+  color: #ffb74d;
+}
+
+/* Map crosshair when placing a hazard */
+
+.tortuga-map--crosshair {
+  cursor: crosshair;
+}
+
+@media (max-width: 600px) {
+  .editor-panels {
     grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
## Summary

Implements step 5 of the §3 Cartographer pipeline: after overlay generation, users can hand-edit the world before saving.

- **Settlement inspector** — click any marker to open a panel: rename, change type (colonial port / fort / hidden cove / etc.), reassign faction, live coordinate display
- **Drag to reposition** — settlement markers are draggable; position updates in the inspector in real time
- **Faction editor** — rename and recolor each faction with a native color picker; changes cascade immediately via map re-render
- **Hazard tools** — add reef or kraken zone by clicking the map in crosshair mode; remove any non-lake hazard via trash button
- **Undo/redo** — 20-level stack via Ctrl+Z / Ctrl+Y or panel buttons; every edit (name, type, faction, drag, add/remove hazard) is undoable
- **Knob changes reset the editor** cleanly — editor destroys and re-inits from the freshly generated world

Also fixes two pre-existing import reliability issues discovered during iPad testing:

- **iOS file picker** — the hidden `<input>` + programmatic `.click()` was unreliable on iOS Safari. Replaced with a transparent file input that physically overlays the entire drop zone, so any tap activates the native picker directly.
- **Re-upload race condition** — `drop-zone--loading` was cleared as soon as `reader.onload` fired, leaving a multi-second gap (during overlay + pathfinder generation) where a second upload would silently no-op due to the `_generating` guard. Now the drop zone is replaced by a locked success banner (✓ filename + "Choose different file") that stays in place for the full generation window.

## Files changed

| File | Change |
|------|--------|
| `cartographer/editor.js` | New — inspector, faction, hazard panels + undo stack |
| `map-renderer.js` | `setEditMode`, `clearEditMode`, `highlightSettlement`, `awaitMapClick`, SELECTION layer |
| `overlay.js` | Expose `jaggedBlob` for hand-placed hazard shaping |
| `app.js` | `_initEditor`, `_onWorldEdited`, Ctrl+Z/Y listener |
| `importer.js` | iOS file input fix + success banner replacing drop zone |
| `index.html` | `#cartographer-editor` div + `editor.js` script tag |
| `tortuga.css` | All editor panel styles + drop zone loaded state |

## Test plan

- [x] `npm run lint:fix && npm run format` — clean
- [x] `cd tests && npx jest tortuga-overlay tortuga-importer` — 115/115 pass
- [x] Manual: hosting emulator + Azgaar JSON
  - Import → success banner shows filename, map + editor panels appear
  - Click settlement → inspector opens with name/type/faction
  - Rename → header + popup update
  - Drag → coordinates update live
  - Faction color → map re-renders
  - Add reef → crosshair → click → blob appears
  - Delete hazard → removed from map and list
  - Ctrl+Z → undo across all edit types
  - Knob change → editor resets to new generation
  - "Choose different file" → drop zone resets
  - Save → edited data persists to Firestore

🤖 Generated with [Claude Code](https://claude.com/claude-code)