### PR TITLE
feat(tortuga): world list UI — search, sort, preview, favorites

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -393,6 +393,10 @@ service cloud.firestore {
       }
     }
 
+    match /tortuga_user_prefs/{userId} {
+      allow read, write: if hasApp('tortuga') && request.auth.uid == userId;
+    }
+
     // ── Default deny ───────────────────────────────────────
 
     match /{document=**} {

--- a/public/apps/tortuga/app.js
+++ b/public/apps/tortuga/app.js
@@ -471,6 +471,7 @@
           polygon: _ptsToObjs(ft.polygon),
         };
       }),
+      createdByName: T.state.currentUser.displayName || T.state.currentUser.email || '',
     };
   }
 
@@ -523,10 +524,12 @@
       }
     }
 
-    var listId = mode === T.MODES.PLAY ? 'world-list-play' : 'world-list-world';
-    var listEl = document.getElementById(listId);
+    var suffix = mode === T.MODES.PLAY ? 'play' : 'world';
+    var listEl = document.getElementById('world-list-' + suffix);
     if (listEl) {
       T.worldList.render(listEl, {
+        toolbarEl: document.getElementById('world-list-toolbar-' + suffix),
+        previewEl: document.getElementById('world-preview-' + suffix),
         onSelect: function (worldId, worldData) {
           if (mode === T.MODES.PLAY) {
             T._startNewGame(worldId, worldData);

--- a/public/apps/tortuga/firestore.js
+++ b/public/apps/tortuga/firestore.js
@@ -112,5 +112,71 @@
     deleteGame: function (id) {
       return T.state.db.collection('tortuga_games').doc(id).delete();
     },
+
+    // ── User prefs / favorites ────────────────────────────
+
+    getFavorites: function (callback) {
+      var uid = T.state.currentUser.uid;
+      return T.state.db
+        .collection('tortuga_user_prefs')
+        .doc(uid)
+        .onSnapshot(
+          function (snap) {
+            var favorites = (snap.exists && snap.data().favorites) || [];
+            callback(favorites, null);
+          },
+          function (err) {
+            callback([], err);
+          }
+        );
+    },
+
+    toggleFavorite: function (worldId) {
+      var uid = T.state.currentUser.uid;
+      var ref = T.state.db.collection('tortuga_user_prefs').doc(uid);
+      return ref.get().then(function (snap) {
+        var favorites = (snap.exists && snap.data().favorites) || [];
+        var isFav = favorites.indexOf(worldId) !== -1;
+        var op = isFav
+          ? firebase.firestore.FieldValue.arrayRemove(worldId)
+          : firebase.firestore.FieldValue.arrayUnion(worldId);
+        return ref.set({ favorites: op }, { merge: true });
+      });
+    },
+
+    // ── Decode ────────────────────────────────────────────
+
+    decodeWorld: function (data) {
+      function objsToPts(arr) {
+        return (arr || []).map(function (o) {
+          return [o.y, o.x];
+        });
+      }
+      return Object.assign({}, data, {
+        coastlines: (data.coastlines || []).map(function (ring) {
+          return objsToPts(ring.pts || ring);
+        }),
+        settlements: (data.settlements || []).map(function (s) {
+          return Object.assign({}, s, {
+            position: s.position ? [s.position.y, s.position.x] : null,
+          });
+        }),
+        hazards: (data.hazards || []).map(function (h) {
+          return Object.assign({}, h, { polygon: objsToPts(h.polygon) });
+        }),
+        windCurrentZones: (data.windCurrentZones || []).map(function (wz) {
+          return Object.assign({}, wz, { bounds: objsToPts(wz.bounds) });
+        }),
+        factionTerritory: (data.factionTerritory || []).map(function (ft) {
+          return Object.assign({}, ft, { polygon: objsToPts(ft.polygon) });
+        }),
+        bounds: data.bounds
+          ? [
+              [data.bounds.minY, data.bounds.minX],
+              [data.bounds.maxY, data.bounds.maxX],
+            ]
+          : null,
+      });
+    },
   };
 })();

--- a/public/apps/tortuga/index.html
+++ b/public/apps/tortuga/index.html
@@ -60,7 +60,15 @@
         </div>
         <div id="cartographer-knobs" class="hidden"></div>
         <div id="cartographer-editor" class="hidden"></div>
-        <div id="world-list-world" class="world-list"></div>
+        <div class="world-list-section">
+          <div class="world-list-panel">
+            <div id="world-list-toolbar-world"></div>
+            <div id="world-list-world" class="world-list"></div>
+          </div>
+          <div id="world-preview-world" class="world-preview">
+            <p class="world-preview-placeholder">Select a world to preview</p>
+          </div>
+        </div>
         <div id="map-world" class="tortuga-map hidden"></div>
       </section>
 
@@ -69,7 +77,15 @@
         <h1 class="app-title">The Account</h1>
         <p class="app-subtitle">On the account, Captain.</p>
         <div class="app-divider"></div>
-        <div id="world-list-play" class="world-list"></div>
+        <div class="world-list-section">
+          <div class="world-list-panel">
+            <div id="world-list-toolbar-play"></div>
+            <div id="world-list-play" class="world-list"></div>
+          </div>
+          <div id="world-preview-play" class="world-preview">
+            <p class="world-preview-placeholder">Select a world to preview</p>
+          </div>
+        </div>
         <div id="map-play" class="tortuga-map hidden"></div>
       </section>
     </main>

--- a/public/apps/tortuga/tortuga.css
+++ b/public/apps/tortuga/tortuga.css
@@ -1,10 +1,76 @@
+/* ── World List section layout ─────────────────────────────── */
+
+.world-list-section {
+  display: flex;
+  gap: 1rem;
+  align-items: flex-start;
+  margin: 1rem 0;
+}
+
+.world-list-panel {
+  flex: 1 1 0;
+  min-width: 0;
+}
+
+.world-preview {
+  flex: 0 0 320px;
+  height: 260px;
+  border-radius: 8px;
+  border: 1px solid var(--color-border, #333);
+  background: var(--color-bg, #12121a);
+  position: sticky;
+  top: 1rem;
+  overflow: hidden;
+}
+
+.world-preview-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  margin: 0;
+  color: var(--color-text-muted, #888);
+  font-style: italic;
+  font-size: 0.85rem;
+}
+
+@media (max-width: 768px) {
+  .world-list-section {
+    flex-direction: column;
+  }
+
+  .world-preview {
+    flex: none;
+    width: 100%;
+    height: 200px;
+    position: static;
+  }
+}
+
+/* ── World list toolbar ────────────────────────────────────── */
+
+.world-list-toolbar {
+  display: flex;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.world-search-input {
+  flex: 1;
+  min-width: 0;
+}
+
+.world-sort-select {
+  flex: 0 0 auto;
+}
+
 /* ── World List ────────────────────────────────────────────── */
 
 .world-list {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
   gap: 1rem;
-  margin: 1rem 0;
+  margin: 0;
 }
 
 .world-card {
@@ -23,6 +89,14 @@
 .world-card:hover {
   border-color: var(--color-accent, #7c6aff);
   transform: translateY(-2px);
+}
+
+.world-card--selected {
+  border-color: #ffb74d;
+}
+
+.world-card--selected:hover {
+  border-color: #ffb74d;
 }
 
 .world-card-thumb {
@@ -72,6 +146,27 @@
   font-weight: 600;
   letter-spacing: 0.02em;
   align-self: flex-start;
+}
+
+.world-card-fav {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 1;
+  padding: 0;
+  margin-top: 0.35rem;
+  color: var(--color-text-muted, #888);
+  align-self: flex-start;
+  transition: color 0.15s;
+}
+
+.world-card-fav:hover {
+  color: #ffb74d;
+}
+
+.world-card-fav--active {
+  color: #ffb74d;
 }
 
 /* ── Skeleton ──────────────────────────────────────────────── */

--- a/public/apps/tortuga/world-list.js
+++ b/public/apps/tortuga/world-list.js
@@ -45,9 +45,11 @@
     container.appendChild(msg);
   }
 
-  function buildCard(world, onSelect) {
+  function buildCard(world, favorites, selectedId, onSelect, onFavToggle) {
     var card = document.createElement('div');
-    card.className = 'world-card';
+    var classes = 'world-card';
+    if (world.id === selectedId) classes += ' world-card--selected';
+    card.className = classes;
 
     var thumb;
     if (world.thumbnail) {
@@ -86,6 +88,18 @@
       body.appendChild(badge);
     }
 
+    var isFav = !!favorites[world.id];
+    var favBtn = document.createElement('button');
+    favBtn.className = 'world-card-fav' + (isFav ? ' world-card-fav--active' : '');
+    favBtn.setAttribute('aria-label', isFav ? 'Remove from favorites' : 'Add to favorites');
+    favBtn.setAttribute('type', 'button');
+    favBtn.textContent = isFav ? '★' : '☆';
+    favBtn.addEventListener('click', function (e) {
+      e.stopPropagation();
+      onFavToggle(world.id);
+    });
+    body.appendChild(favBtn);
+
     card.appendChild(body);
 
     card.addEventListener('click', function () {
@@ -95,63 +109,243 @@
     return card;
   }
 
-  function renderWorlds(container, sharedWorlds, ownedWorlds, onSelect) {
-    // Merge: owned worlds take precedence (covers owned-but-not-shared)
-    var merged = Object.assign({}, sharedWorlds, ownedWorlds);
-    var worlds = Object.keys(merged).map(function (id) {
-      return merged[id];
-    });
-
+  function renderWorlds(container, worlds, favorites, selectedId, onSelect, onFavToggle) {
     if (worlds.length === 0) {
       renderEmpty(container);
       return;
     }
 
+    container.innerHTML = '';
+    worlds.forEach(function (w) {
+      container.appendChild(buildCard(w, favorites, selectedId, onSelect, onFavToggle));
+    });
+  }
+
+  function _renderToolbar(toolbarEl, searchQuery, sortMode, onSearch, onSort) {
+    toolbarEl.innerHTML = '';
+
+    var toolbar = document.createElement('div');
+    toolbar.className = 'world-list-toolbar';
+
+    var searchInput = document.createElement('input');
+    searchInput.className = 'knobs-input world-search-input';
+    searchInput.setAttribute('type', 'search');
+    searchInput.setAttribute('placeholder', 'Search worlds…');
+    searchInput.setAttribute('aria-label', 'Search worlds');
+    searchInput.value = searchQuery;
+    searchInput.addEventListener('input', function () {
+      onSearch(searchInput.value);
+    });
+    toolbar.appendChild(searchInput);
+
+    var sortSelect = document.createElement('select');
+    sortSelect.className = 'knobs-select world-sort-select';
+    sortSelect.setAttribute('aria-label', 'Sort worlds');
+    [
+      { value: 'recent', label: 'Recent' },
+      { value: 'alpha', label: 'A–Z' },
+      { value: 'popular', label: 'Popular' },
+    ].forEach(function (opt) {
+      var option = document.createElement('option');
+      option.value = opt.value;
+      option.textContent = opt.label;
+      if (opt.value === sortMode) option.selected = true;
+      sortSelect.appendChild(option);
+    });
+    sortSelect.addEventListener('change', function () {
+      onSort(sortSelect.value);
+    });
+    toolbar.appendChild(sortSelect);
+
+    toolbarEl.appendChild(toolbar);
+  }
+
+  function _filterAndSort(sharedWorlds, ownedWorlds, searchQuery, sortMode) {
+    var merged = Object.assign({}, sharedWorlds, ownedWorlds);
+    var worlds = Object.keys(merged).map(function (id) {
+      return merged[id];
+    });
+
+    if (searchQuery) {
+      var q = searchQuery.toLowerCase();
+      worlds = worlds.filter(function (w) {
+        var nameMatch = (w.name || '').toLowerCase().indexOf(q) !== -1;
+        var creatorMatch = (w.createdByName || '').toLowerCase().indexOf(q) !== -1;
+        return nameMatch || creatorMatch;
+      });
+    }
+
     worlds.sort(function (a, b) {
+      if (sortMode === 'alpha') {
+        return (a.name || '').localeCompare(b.name || '');
+      }
+      if (sortMode === 'popular') {
+        var pa = a.playCount || 0;
+        var pb = b.playCount || 0;
+        if (pb !== pa) return pb - pa;
+        return (a.name || '').localeCompare(b.name || '');
+      }
+      // recent (default)
       var ta = a.updatedAt && a.updatedAt.toMillis ? a.updatedAt.toMillis() : 0;
       var tb = b.updatedAt && b.updatedAt.toMillis ? b.updatedAt.toMillis() : 0;
       return tb - ta;
     });
 
-    container.innerHTML = '';
-    worlds.forEach(function (w) {
-      container.appendChild(buildCard(w, onSelect));
+    return worlds;
+  }
+
+  function _initPreviewMap(previewEl, worldData) {
+    var decoded = T.firestore.decodeWorld(worldData);
+
+    var previewMap = L.map(previewEl, {
+      crs: L.CRS.Simple,
+      zoomControl: false,
+      dragging: false,
+      scrollWheelZoom: false,
+      doubleClickZoom: false,
+      boxZoom: false,
+      keyboard: false,
+      tap: false,
+      attributionControl: false,
     });
+
+    // Coastlines
+    (decoded.coastlines || []).forEach(function (ring) {
+      if (ring && ring.length > 2) {
+        L.polygon(ring, {
+          color: '#4a8c4a',
+          fillColor: '#3a7c3a',
+          fillOpacity: 0.55,
+          weight: 1,
+        }).addTo(previewMap);
+      }
+    });
+
+    // Settlements
+    (decoded.settlements || []).forEach(function (s) {
+      if (s.position && !s.hidden) {
+        L.circleMarker(s.position, {
+          radius: 3,
+          color: '#fff',
+          fillColor: '#ffb74d',
+          fillOpacity: 0.9,
+          weight: 1,
+        }).addTo(previewMap);
+      }
+    });
+
+    if (decoded.bounds) {
+      previewMap.fitBounds(decoded.bounds, { padding: [8, 8] });
+    }
+
+    return previewMap;
   }
 
   T.worldList = {
     _container: null,
+    _toolbarEl: null,
+    _previewEl: null,
     _onSelect: null,
     _unsubscribes: [],
+    _unsubFavs: null,
     _sharedWorlds: {},
     _ownedWorlds: {},
     _sharedLoaded: false,
     _ownedLoaded: false,
+    _favorites: {},
+    _selectedId: null,
+    _searchQuery: '',
+    _sortMode: 'recent',
+    _previewMap: null,
 
-    _mergeAndRender: function () {
+    _applyFiltersAndRender: function () {
       if (!this._sharedLoaded || !this._ownedLoaded) return;
-      renderWorlds(this._container, this._sharedWorlds, this._ownedWorlds, this._onSelect);
+      var self = this;
+      var worlds = _filterAndSort(
+        this._sharedWorlds,
+        this._ownedWorlds,
+        this._searchQuery,
+        this._sortMode
+      );
+      renderWorlds(
+        this._container,
+        worlds,
+        this._favorites,
+        this._selectedId,
+        function (worldId, worldData) {
+          self._selectedId = worldId;
+          self._applyFiltersAndRender();
+          self._updatePreview(worldData);
+          if (self._onSelect) self._onSelect(worldId, worldData);
+        },
+        function (worldId) {
+          T.firestore.toggleFavorite(worldId).catch(function (err) {
+            console.error('[world-list] toggleFavorite error', err);
+          });
+        }
+      );
+    },
+
+    _updatePreview: function (worldData) {
+      if (!this._previewEl) return;
+
+      // Clear placeholder text
+      this._previewEl.innerHTML = '';
+
+      if (this._previewMap) {
+        this._previewMap.remove();
+        this._previewMap = null;
+      }
+
+      try {
+        this._previewMap = _initPreviewMap(this._previewEl, worldData);
+      } catch (err) {
+        console.error('[world-list] preview error', err);
+        this._previewEl.innerHTML = '<p class="world-preview-placeholder">Preview unavailable</p>';
+      }
     },
 
     render: function (containerEl, opts) {
       this.destroy();
 
       this._container = containerEl;
-      this._onSelect = opts.onSelect || function () {};
+      this._toolbarEl = (opts && opts.toolbarEl) || null;
+      this._previewEl = (opts && opts.previewEl) || null;
+      this._onSelect = (opts && opts.onSelect) || null;
       this._sharedWorlds = {};
       this._ownedWorlds = {};
       this._sharedLoaded = false;
       this._ownedLoaded = false;
-
-      renderSkeleton(containerEl);
+      this._favorites = {};
+      this._selectedId = null;
+      this._searchQuery = '';
+      this._sortMode = 'recent';
 
       var self = this;
+
+      if (this._toolbarEl) {
+        _renderToolbar(
+          this._toolbarEl,
+          this._searchQuery,
+          this._sortMode,
+          function (q) {
+            self._searchQuery = q;
+            self._applyFiltersAndRender();
+          },
+          function (mode) {
+            self._sortMode = mode;
+            self._applyFiltersAndRender();
+          }
+        );
+      }
+
+      renderSkeleton(containerEl);
 
       var unsubShared = T.firestore.listWorlds(function (worlds, err) {
         if (err) {
           console.error('[world-list] shared worlds error', err);
           self._sharedLoaded = true;
-          self._mergeAndRender();
+          self._applyFiltersAndRender();
           return;
         }
         self._sharedWorlds = {};
@@ -159,14 +353,14 @@
           self._sharedWorlds[w.id] = w;
         });
         self._sharedLoaded = true;
-        self._mergeAndRender();
+        self._applyFiltersAndRender();
       });
 
       var unsubOwned = T.firestore.onOwnedWorlds(function (worlds, err) {
         if (err) {
           console.error('[world-list] owned worlds error', err);
           self._ownedLoaded = true;
-          self._mergeAndRender();
+          self._applyFiltersAndRender();
           return;
         }
         self._ownedWorlds = {};
@@ -174,10 +368,22 @@
           self._ownedWorlds[w.id] = w;
         });
         self._ownedLoaded = true;
-        self._mergeAndRender();
+        self._applyFiltersAndRender();
       });
 
       this._unsubscribes = [unsubShared, unsubOwned];
+
+      this._unsubFavs = T.firestore.getFavorites(function (favoriteIds, err) {
+        if (err) {
+          console.error('[world-list] favorites error', err);
+          return;
+        }
+        self._favorites = {};
+        favoriteIds.forEach(function (id) {
+          self._favorites[id] = true;
+        });
+        self._applyFiltersAndRender();
+      });
     },
 
     destroy: function () {
@@ -185,6 +391,16 @@
         if (typeof u === 'function') u();
       });
       this._unsubscribes = [];
+
+      if (typeof this._unsubFavs === 'function') {
+        this._unsubFavs();
+        this._unsubFavs = null;
+      }
+
+      if (this._previewMap) {
+        this._previewMap.remove();
+        this._previewMap = null;
+      }
     },
   };
 })();


### PR DESCRIPTION
## Summary

- **Search**: live-filter world cards by name or creator name (stored as `createdByName` on save)
- **Sort**: Recent (updatedAt desc) / A–Z / Popular (playCount desc) via a select in the toolbar
- **Preview pane**: clicking a card renders a read-only mini Leaflet map (coastlines + amber settlement dots) in a sticky side panel; decodes `{y,x}` Firestore objects back to arrays via new `T.firestore.decodeWorld()`
- **Favorites**: star button (☆/★) on each card; toggle persisted to `tortuga_user_prefs/{uid}.favorites` using `arrayUnion`/`arrayRemove`; rehydrated via real-time `onSnapshot` listener across sessions
- Two-pane flex layout (list left, preview right); stacks vertically on ≤768px
- New Firestore rule for `tortuga_user_prefs/{userId}` (read/write gated on `hasApp('tortuga') && uid match`)

Closes #196

## Test plan

- [ ] World list loads with skeleton → populated cards
- [ ] Typing in search box filters cards live by name and creator
- [ ] Changing sort reorders cards without reload
- [ ] Clicking a card highlights it (amber border) and renders coastlines + settlements in the preview pane
- [ ] Clicking ☆ on a card fills it amber; reloading the page shows it still filled
- [ ] Clicking ★ empties it; reload confirms it is gone
- [ ] Narrow viewport (≤768px): layout stacks vertically, preview full-width
- [ ] Worlds with no coastlines/settlements render an empty map without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)