### PR TITLE
fix(tortuga): load real world into editor and preview on card select

### DIFF
--- a/public/apps/tortuga/app.js
+++ b/public/apps/tortuga/app.js
@@ -29,13 +29,19 @@
     T.state.currentMode = mode;
   };
 
-  T._openWorldEditor = function (_worldId, _worldData) {
-    // TODO (T-110): load worldData from Firestore and render it.
+  T._openWorldEditor = function (_worldId, worldData) {
     var mapEl = document.getElementById('map-world');
-    if (mapEl) {
-      mapEl.classList.remove('hidden');
-      T.mapRenderer.init(mapEl, T.mapRenderer.PLACEHOLDER_WORLD);
-    }
+    if (!mapEl) return;
+
+    var decoded = T.firestore.decodeWorld(worldData);
+    _generatedWorld = decoded;
+    _mapInitialised = false;
+
+    mapEl.classList.remove('hidden');
+    T.mapRenderer.init(mapEl, decoded);
+    _mapInitialised = true;
+
+    _initEditor();
   };
 
   T._startNewGame = function () {

--- a/public/apps/tortuga/world-list.js
+++ b/public/apps/tortuga/world-list.js
@@ -213,15 +213,65 @@
     (decoded.coastlines || []).forEach(function (ring) {
       if (ring && ring.length > 2) {
         L.polygon(ring, {
-          color: '#4a8c4a',
-          fillColor: '#3a7c3a',
-          fillOpacity: 0.55,
+          color: '#4a7c59',
+          fillColor: '#2d5a3d',
+          fillOpacity: 0.6,
           weight: 1,
         }).addTo(previewMap);
       }
     });
 
-    // Settlements
+    // Faction territory (below settlements)
+    (decoded.factionTerritory || []).forEach(function (ft) {
+      if (ft.polygon && ft.polygon.length > 2) {
+        L.polygon(ft.polygon, {
+          color: ft.color || '#888',
+          fillColor: ft.color || '#888',
+          fillOpacity: 0.18,
+          weight: 1,
+        }).addTo(previewMap);
+      }
+    });
+
+    // Hazards
+    var HAZARD_COLORS = {
+      reef: '#b07a3a',
+      storm_band: '#8aa8b8',
+      kraken_zone: '#4a2a5a',
+      lake: '#4a8aaa',
+    };
+    (decoded.hazards || []).forEach(function (h) {
+      if (h.polygon && h.polygon.length > 2) {
+        var col = HAZARD_COLORS[h.type] || '#cc4444';
+        L.polygon(h.polygon, {
+          color: col,
+          fillColor: col,
+          fillOpacity: 0.4,
+          weight: 1,
+        }).addTo(previewMap);
+      }
+    });
+
+    // Trade routes
+    var posById = {};
+    (decoded.settlements || []).forEach(function (s) {
+      if (s.id && s.position) posById[s.id] = s.position;
+    });
+    (decoded.tradeRoutes || []).forEach(function (r) {
+      var pts = r.points;
+      if (!pts && r.fromId && r.toId) {
+        var from = posById[r.fromId];
+        var to = posById[r.toId];
+        if (from && to) pts = [from, to];
+      }
+      if (pts && pts.length >= 2) {
+        L.polyline(pts, { color: '#c8a84b', weight: 1, dashArray: '4 3', opacity: 0.7 }).addTo(
+          previewMap
+        );
+      }
+    });
+
+    // Settlements (on top)
     (decoded.settlements || []).forEach(function (s) {
       if (s.position && !s.hidden) {
         L.circleMarker(s.position, {


### PR DESCRIPTION
## Root cause

`T._openWorldEditor` in `app.js` had a `// TODO (T-110)` stub that ignored the `worldData` argument entirely and always rendered `PLACEHOLDER_WORLD`. Selecting any saved world from the list showed the same placeholder map instead of the actual world — the symptom that looked like saves weren't working.

## Changes

**`app.js` — `T._openWorldEditor`**
- Decodes the Firestore payload using `T.firestore.decodeWorld(worldData)` (converts `{y,x}` objects back to `[y,x]` arrays)
- Sets `_generatedWorld` to the decoded world so the editor and save button work against the right data
- Calls `T.mapRenderer.init()` on `#map-world` with the real world, then `_initEditor()` to wire up the settlement/hazard editor

**`world-list.js` — preview mini-map**
- Added faction territories, hazards, and trade routes to the preview so it matches the full map renderer (previously only showed coastlines + settlements)

## Test plan

- [ ] Save a world via the Cartographer
- [ ] Select it from the world list → full map renders with coastlines, settlements, hazards, faction territories, and trade routes — **not** the placeholder
- [ ] Editor panel appears; settlements are draggable; undo/redo works
- [ ] Preview mini-map in the world list also shows hazards and faction colour overlays
- [ ] A world with no hazards/factions renders without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)