### PR TITLE
fix(tortuga): save changes to loaded world instead of always creating new

### DIFF
--- a/public/apps/tortuga/app.js
+++ b/public/apps/tortuga/app.js
@@ -11,6 +11,7 @@
   var _generating = false; // guard against concurrent regenerations
   var _mapInitialised = false; // track first T.mapRenderer.init call
   var _keydownHandler = null; // Ctrl+Z / Ctrl+Y listener
+  var _loadedWorldId = null; // Firestore id when editing a saved world; null for new generations
 
   // ── Mode routing ────────────────────────────────────────────
 
@@ -29,18 +30,20 @@
     T.state.currentMode = mode;
   };
 
-  T._openWorldEditor = function (_worldId, worldData) {
+  T._openWorldEditor = function (worldId, worldData) {
     var mapEl = document.getElementById('map-world');
     if (!mapEl) return;
 
     var decoded = T.firestore.decodeWorld(worldData);
     _generatedWorld = decoded;
     _mapInitialised = false;
+    _loadedWorldId = worldData.createdBy === T.state.currentUser.uid ? worldId : null;
 
     mapEl.classList.remove('hidden');
     T.mapRenderer.init(mapEl, decoded);
     _mapInitialised = true;
 
+    _showSaveRow(worldData);
     _initEditor();
   };
 
@@ -166,6 +169,7 @@
   function _generateAndPreview() {
     if (!_parsedData || _generating) return;
     _generating = true;
+    _loadedWorldId = null;
 
     var saveBtn = document.getElementById('knobs-save-btn');
     var statusEl = document.getElementById('knobs-save-status');
@@ -278,6 +282,21 @@
 
   // ── Save handler ─────────────────────────────────────────────
 
+  function _showSaveRow(worldData) {
+    var knobsEl = document.getElementById('cartographer-knobs');
+    if (!knobsEl) return;
+    var isOwner = worldData.createdBy === T.state.currentUser.uid;
+    knobsEl.innerHTML =
+      '<div class="knobs-panel">' +
+      '<div class="knobs-save-row">' +
+      '<button class="app-btn app-btn--sm" id="knobs-save-btn" type="button">' +
+      (isOwner ? 'Save Changes' : 'Save as New World') +
+      '</button>' +
+      '<span class="save-status" id="knobs-save-status"></span>' +
+      '</div></div>';
+    knobsEl.classList.remove('hidden');
+  }
+
   function _onSaveClick() {
     if (!_generatedWorld) return;
     _showSaveDialog();
@@ -288,7 +307,13 @@
       (document.getElementById('knob-name') || {}).value ||
       (_generatedWorld && _generatedWorld.name) ||
       'Unnamed World';
-    var currentEra = (document.getElementById('knob-era') || {}).value || 'caribbean_golden_age';
+    var currentEra =
+      (document.getElementById('knob-era') || {}).value ||
+      (_generatedWorld && _generatedWorld.era) ||
+      'caribbean_golden_age';
+    var currentDescription = (_generatedWorld && _generatedWorld.description) || '';
+    var currentShared = _generatedWorld ? _generatedWorld.shared !== false : true;
+    var dialogTitle = _loadedWorldId ? 'Save Changes' : 'Save World';
 
     var overlay = document.createElement('div');
     overlay.className = 'save-dialog-overlay';
@@ -296,7 +321,9 @@
 
     overlay.innerHTML =
       '<div class="save-dialog" role="dialog" aria-modal="true" aria-labelledby="save-dialog-heading">' +
-      '<h2 class="save-dialog-title" id="save-dialog-heading">Save World</h2>' +
+      '<h2 class="save-dialog-title" id="save-dialog-heading">' +
+      dialogTitle +
+      '</h2>' +
       '<div class="save-dialog-field">' +
       '<label class="save-dialog-label" for="save-dialog-name">World Name</label>' +
       '<input class="knobs-input" id="save-dialog-name" type="text" value="' +
@@ -327,7 +354,7 @@
       '</div>' +
       '<div class="save-dialog-field">' +
       '<div class="save-dialog-shared-row">' +
-      '<input class="knobs-checkbox" id="save-dialog-shared" type="checkbox" checked>' +
+      '<input class="knobs-checkbox" id="save-dialog-shared" type="checkbox">' +
       '<label class="knobs-checkbox-label" for="save-dialog-shared">' +
       'Share — other players can use this world for campaigns' +
       '</label>' +
@@ -341,6 +368,10 @@
       '</div>';
 
     document.body.appendChild(overlay);
+
+    // Set values that can't be set via HTML attribute
+    overlay.querySelector('#save-dialog-description').value = currentDescription;
+    overlay.querySelector('#save-dialog-shared').checked = currentShared;
 
     overlay.addEventListener('click', function (e) {
       if (e.target === overlay) _closeSaveDialog();
@@ -372,14 +403,16 @@
     if (errorEl) errorEl.classList.add('hidden');
 
     var payload = _buildWorldPayload(name, description, era, shared);
+    var saveOp = _loadedWorldId
+      ? T.firestore.updateWorld(_loadedWorldId, payload)
+      : T.firestore.createWorld(payload);
 
-    T.firestore
-      .createWorld(payload)
+    saveOp
       .then(function () {
         _closeSaveDialog();
         var statusEl = document.getElementById('knobs-save-status');
         if (statusEl) {
-          statusEl.textContent = 'World saved!';
+          statusEl.textContent = _loadedWorldId ? 'Changes saved!' : 'World saved!';
           statusEl.className = 'save-status save-status--success';
         }
       })


### PR DESCRIPTION
## Root cause

After loading a saved world from the world list, two things were missing:

1. **No save button** — `_openWorldEditor` didn't show the knobs panel or any save UI, so there was no way to persist edits
2. **Wrong Firestore operation** — `_doSave` always called `createWorld`, which would have created a duplicate instead of updating the existing document

## Changes

**`app.js`**

- Added `_loadedWorldId` module-level variable — tracks the Firestore doc id of the currently loaded world; `null` for freshly generated worlds
- `_openWorldEditor` now sets `_loadedWorldId` (only for the world's owner; non-owners get `null` so Save As New is used) and calls `_showSaveRow(worldData)` before `_initEditor()`
- New `_showSaveRow(worldData)` injects a minimal knobs panel with a "Save Changes" (owner) or "Save as New World" (non-owner) button — same delegated click handler wires it up
- `_generateAndPreview` resets `_loadedWorldId = null` so a fresh import always creates a new document
- `_showSaveDialog` now pre-fills description and shared state from `_generatedWorld`, and sets the dialog title to "Save Changes" vs "Save World"
- `_doSave` branches on `_loadedWorldId`: calls `updateWorld(id, payload)` for existing worlds, `createWorld(payload)` for new ones; success message also reflects which path was taken

## Test plan

- [ ] Load a saved world from the world list → "Save Changes" button appears above the editor
- [ ] Edit a settlement (drag, rename) → click "Save Changes" → dialog pre-filled with world's name, description, era, and shared state
- [ ] Confirm → Firestore document updates (`updatedAt` changes), no duplicate created
- [ ] Load a shared world you don't own → button reads "Save as New World" → saves as a separate document with your uid as `createdBy`
- [ ] Import a fresh Azgaar map → knobs panel shows normally, save creates a new document

🤖 Generated with [Claude Code](https://claude.com/claude-code)