### PR TITLE
feat(tortuga): new game creation with captain setup and world snapshot (closes #197)

### DIFF
--- a/public/apps/tortuga/app.js
+++ b/public/apps/tortuga/app.js
@@ -47,12 +47,8 @@
     _initEditor();
   };
 
-  T._startNewGame = function () {
-    var mapEl = document.getElementById('map-play');
-    if (mapEl) {
-      mapEl.classList.remove('hidden');
-      T.mapRenderer.init(mapEl, T.mapRenderer.PLACEHOLDER_WORLD);
-    }
+  T._startNewGame = function (worldId, worldData) {
+    T.newGame.show(worldId, worldData);
   };
 
   // ── Knobs helpers ────────────────────────────────────────────

--- a/public/apps/tortuga/index.html
+++ b/public/apps/tortuga/index.html
@@ -86,7 +86,7 @@
             <p class="world-preview-placeholder">Select a world to preview</p>
           </div>
         </div>
-        <div id="map-play" class="tortuga-map hidden"></div>
+        <div id="new-game-panel" class="hidden"></div>
       </section>
     </main>
 
@@ -106,6 +106,7 @@
     <script src="/apps/tortuga/cartographer/overlay.js"></script>
     <script src="/apps/tortuga/cartographer/importer.js"></script>
     <script src="/apps/tortuga/cartographer/editor.js"></script>
+    <script src="/apps/tortuga/new-game.js"></script>
     <script src="/apps/tortuga/app.js"></script>
 
     <script>

--- a/public/apps/tortuga/new-game.js
+++ b/public/apps/tortuga/new-game.js
@@ -1,0 +1,212 @@
+(function () {
+  'use strict';
+
+  window.Tortuga = window.Tortuga || {};
+  var T = window.Tortuga;
+
+  var PORTRAITS = [
+    { id: 'anchor', symbol: '⚓', label: 'Anchor' },
+    { id: 'skull', symbol: '💀', label: 'Skull' },
+    { id: 'compass', symbol: '🧭', label: 'Compass' },
+    { id: 'wheel', symbol: '⚙️', label: "Ship's Wheel" },
+    { id: 'telescope', symbol: '🔭', label: 'Telescope' },
+    { id: 'map', symbol: '🗺️', label: 'Map' },
+  ];
+
+  function _buildWorldSnapshot(worldData) {
+    return {
+      geography: {
+        coastlines: worldData.coastlines || [],
+        bounds: worldData.bounds || null,
+        dimensions: worldData.dimensions || {},
+        windCurrentZones: worldData.windCurrentZones || [],
+        factionTerritory: worldData.factionTerritory || [],
+      },
+      settlements: (worldData.settlements || []).slice(),
+      hazards: (worldData.hazards || []).slice(),
+      factions: (worldData.factions || []).slice(),
+      tradeRoutes: (worldData.tradeRoutes || []).slice(),
+    };
+  }
+
+  function _escapeAttr(str) {
+    return String(str || '')
+      .replace(/&/g, '&amp;')
+      .replace(/"/g, '&quot;');
+  }
+
+  T.newGame = {
+    _panelEl: null,
+    _selectedPortrait: PORTRAITS[0].id,
+    _worldId: null,
+    _worldData: null,
+
+    show: function (worldId, worldData) {
+      this._worldId = worldId;
+      this._worldData = worldData;
+      this._selectedPortrait = PORTRAITS[0].id;
+
+      var panelEl = document.getElementById('new-game-panel');
+      if (!panelEl) return;
+      this._panelEl = panelEl;
+
+      var worldName = (worldData && worldData.name) || 'Unknown World';
+
+      var portraitButtons = PORTRAITS.map(function (p, i) {
+        var selectedClass = i === 0 ? ' portrait-btn--selected' : '';
+        return (
+          '<button class="portrait-btn' +
+          selectedClass +
+          '" type="button"' +
+          ' data-portrait="' +
+          _escapeAttr(p.id) +
+          '"' +
+          ' aria-label="' +
+          _escapeAttr(p.label) +
+          '"' +
+          ' aria-pressed="' +
+          (i === 0 ? 'true' : 'false') +
+          '">' +
+          p.symbol +
+          '</button>'
+        );
+      }).join('');
+
+      panelEl.innerHTML =
+        '<div class="new-game-panel">' +
+        '<div class="new-game-world-badge">World: ' +
+        _escapeAttr(worldName) +
+        '</div>' +
+        '<h2 class="new-game-title">New Campaign</h2>' +
+        '<div class="knobs-field">' +
+        '<label class="knobs-label" for="ng-captain-name">Captain\'s Name</label>' +
+        '<input class="knobs-input" id="ng-captain-name" type="text"' +
+        ' maxlength="50" placeholder="Enter your captain\'s name">' +
+        '</div>' +
+        '<div class="knobs-field">' +
+        '<label class="knobs-label">Portrait</label>' +
+        '<div class="portrait-picker">' +
+        portraitButtons +
+        '</div>' +
+        '</div>' +
+        '<div class="knobs-field">' +
+        '<label class="knobs-label" for="ng-bio">Bio <span class="knobs-label-optional">(optional)</span></label>' +
+        '<textarea class="knobs-input new-game-bio" id="ng-bio"' +
+        ' rows="3" placeholder="Your captain\'s story…"></textarea>' +
+        '</div>' +
+        '<p class="new-game-error hidden" id="ng-error"></p>' +
+        '<div class="new-game-actions">' +
+        '<button class="btn-cancel" id="ng-cancel" type="button">Cancel</button>' +
+        '<button class="app-btn app-btn--sm" id="ng-confirm" type="button">Begin Campaign</button>' +
+        '</div>' +
+        '</div>';
+
+      panelEl.classList.remove('hidden');
+
+      var self = this;
+
+      panelEl.querySelectorAll('.portrait-btn').forEach(function (btn) {
+        btn.addEventListener('click', function () {
+          self._selectedPortrait = btn.getAttribute('data-portrait');
+          panelEl.querySelectorAll('.portrait-btn').forEach(function (b) {
+            b.classList.remove('portrait-btn--selected');
+            b.setAttribute('aria-pressed', 'false');
+          });
+          btn.classList.add('portrait-btn--selected');
+          btn.setAttribute('aria-pressed', 'true');
+        });
+      });
+
+      document.getElementById('ng-cancel').addEventListener('click', function () {
+        self._hide();
+      });
+
+      document.getElementById('ng-confirm').addEventListener('click', function () {
+        self._onConfirm();
+      });
+    },
+
+    _hide: function () {
+      if (this._panelEl) {
+        this._panelEl.classList.add('hidden');
+        this._panelEl.innerHTML = '';
+      }
+      this._worldId = null;
+      this._worldData = null;
+    },
+
+    _onConfirm: function () {
+      var nameEl = document.getElementById('ng-captain-name');
+      var bioEl = document.getElementById('ng-bio');
+      var errorEl = document.getElementById('ng-error');
+      var confirmBtn = document.getElementById('ng-confirm');
+      var cancelBtn = document.getElementById('ng-cancel');
+
+      var captainName = (nameEl && nameEl.value.trim()) || '';
+      if (!captainName) {
+        if (errorEl) {
+          errorEl.textContent = 'A captain needs a name.';
+          errorEl.classList.remove('hidden');
+        }
+        if (nameEl) nameEl.focus();
+        return;
+      }
+
+      if (errorEl) errorEl.classList.add('hidden');
+      if (confirmBtn) {
+        confirmBtn.disabled = true;
+        confirmBtn.textContent = 'Creating…';
+      }
+      if (cancelBtn) cancelBtn.disabled = true;
+
+      var bio = (bioEl && bioEl.value.trim()) || '';
+
+      var gameDoc = {
+        worldId: this._worldId,
+        worldSnapshot: _buildWorldSnapshot(this._worldData),
+        phase: 'exploration',
+        turnNumber: 0,
+        captain: {
+          name: captainName,
+          portrait: this._selectedPortrait,
+          bio: bio,
+          reputation: 0,
+          gold: 0,
+          stats: { command: 50, navigation: 50, cunning: 50, charisma: 50 },
+        },
+        flagshipId: null,
+        fog: [],
+        settings: { difficulty: 'normal', mythicEnabled: true, pacing: 'async' },
+      };
+
+      var self = this;
+      T.firestore
+        .createGame(gameDoc)
+        .then(function (docRef) {
+          if (self._panelEl) {
+            self._panelEl.innerHTML =
+              '<div class="new-game-success">' +
+              '<p class="new-game-success-title">Campaign created!</p>' +
+              '<p class="new-game-success-meta">Captain ' +
+              _escapeAttr(captainName) +
+              ' is ready to sail.</p>' +
+              '<p class="new-game-success-id">Game ID: ' +
+              _escapeAttr(docRef.id) +
+              '</p>' +
+              '</div>';
+          }
+        })
+        .catch(function (err) {
+          if (confirmBtn) {
+            confirmBtn.disabled = false;
+            confirmBtn.textContent = 'Begin Campaign';
+          }
+          if (cancelBtn) cancelBtn.disabled = false;
+          if (errorEl) {
+            errorEl.textContent = 'Failed to create campaign: ' + err.message;
+            errorEl.classList.remove('hidden');
+          }
+        });
+    },
+  };
+})();

--- a/public/apps/tortuga/tortuga.css
+++ b/public/apps/tortuga/tortuga.css
@@ -853,3 +853,114 @@
   gap: 0.75rem;
   margin-top: 1.25rem;
 }
+
+/* ── New Game panel ────────────────────────────────────────── */
+
+.new-game-panel {
+  max-width: 560px;
+  margin: 1.5rem 0;
+  padding: 1.5rem;
+  background: var(--color-surface, #1a1a2a);
+  border: 1px solid var(--color-border, #333);
+  border-radius: 8px;
+}
+
+.new-game-world-badge {
+  display: inline-block;
+  padding: 0.2rem 0.6rem;
+  border-radius: 4px;
+  background: var(--color-bg, #12121a);
+  color: var(--color-text-muted, #888);
+  font-size: 0.8rem;
+  margin-bottom: 0.75rem;
+}
+
+.new-game-title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin: 0 0 1.25rem;
+  color: var(--color-text, #e8e8f0);
+}
+
+.new-game-bio {
+  resize: vertical;
+}
+
+.portrait-picker {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.25rem;
+}
+
+.portrait-btn {
+  width: 60px;
+  height: 60px;
+  font-size: 1.6rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--color-bg, #12121a);
+  border: 2px solid var(--color-border, #333);
+  border-radius: 6px;
+  cursor: pointer;
+  transition:
+    border-color 0.15s,
+    background 0.15s;
+}
+
+.portrait-btn:hover {
+  border-color: var(--color-accent, #7b61ff);
+}
+
+.portrait-btn--selected {
+  border-color: var(--color-accent, #7b61ff);
+  background: rgba(123, 97, 255, 0.15);
+}
+
+.knobs-label-optional {
+  font-size: 0.75rem;
+  color: var(--color-text-muted, #888);
+  font-weight: 400;
+}
+
+.new-game-error {
+  font-size: 0.8rem;
+  color: #e05555;
+  margin: 0 0 0.75rem;
+}
+
+.new-game-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  margin-top: 1.25rem;
+}
+
+.new-game-success {
+  max-width: 560px;
+  margin: 1.5rem 0;
+  padding: 1.5rem;
+  background: rgba(74, 124, 89, 0.15);
+  border: 1px solid #4a7c59;
+  border-radius: 8px;
+}
+
+.new-game-success-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin: 0 0 0.5rem;
+  color: #7dc98a;
+}
+
+.new-game-success-meta {
+  margin: 0 0 0.4rem;
+  color: var(--color-text, #e8e8f0);
+}
+
+.new-game-success-id {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--color-text-muted, #888);
+  font-family: monospace;
+}


### PR DESCRIPTION
Add The Account's "New Game" flow: selecting a world in play mode now opens
a captain-creation panel (name, portrait, optional bio). On confirm, writes
tortuga_games/{gameId} with phase:'exploration', turnNumber:0, all captain
stats at 50, and a deep worldSnapshot of the source world's geography,
settlements, hazards, factions, and tradeRoutes — so future edits to the
source world cannot affect active games.

https://claude.ai/code/session_01RCHnS7i8Jqhxx7bMn88236