### PR TITLE
feat(tortuga): ship class catalog and starter picker for new campaigns (closes #198)

### DIFF
--- a/public/apps/tortuga/firestore.js
+++ b/public/apps/tortuga/firestore.js
@@ -113,6 +113,23 @@
       return T.state.db.collection('tortuga_games').doc(id).delete();
     },
 
+    createFlagship: function (gameId, data) {
+      var ts = firebase.firestore.FieldValue.serverTimestamp();
+      return T.state.db
+        .collection('tortuga_games')
+        .doc(gameId)
+        .collection('ships')
+        .add(Object.assign({}, data, { createdAt: ts }));
+    },
+
+    updateGame: function (gameId, data) {
+      var ts = firebase.firestore.FieldValue.serverTimestamp();
+      return T.state.db
+        .collection('tortuga_games')
+        .doc(gameId)
+        .update(Object.assign({}, data, { updatedAt: ts }));
+    },
+
     // ── User prefs / favorites ────────────────────────────
 
     getFavorites: function (callback) {

--- a/public/apps/tortuga/index.html
+++ b/public/apps/tortuga/index.html
@@ -99,6 +99,7 @@
 
     <!-- App modules: state first, then helpers, app last -->
     <script src="/apps/tortuga/state.js"></script>
+    <script src="/apps/tortuga/play/ship-types.js"></script>
     <script src="/apps/tortuga/map-renderer.js"></script>
     <script src="/apps/tortuga/firestore.js"></script>
     <script src="/apps/tortuga/world-list.js"></script>

--- a/public/apps/tortuga/new-game.js
+++ b/public/apps/tortuga/new-game.js
@@ -35,9 +35,78 @@
       .replace(/"/g, '&quot;');
   }
 
+  function _escapeHtml(str) {
+    return String(str || '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
+  }
+
+  function _shipStatBar(label, value) {
+    var pct = Math.max(0, Math.min(100, value));
+    return (
+      '<div class="ship-stat-row">' +
+      '<span class="ship-stat-label">' +
+      _escapeHtml(label) +
+      '</span>' +
+      '<span class="ship-stat-bar"><span class="ship-stat-fill" style="width:' +
+      pct +
+      '%"></span></span>' +
+      '<span class="ship-stat-value">' +
+      value +
+      '</span>' +
+      '</div>'
+    );
+  }
+
+  function _buildShipCards(selectedClassId) {
+    return Object.keys(T.SHIP_TYPES)
+      .map(function (classId) {
+        var s = T.SHIP_TYPES[classId];
+        var bs = s.baseStats;
+        var isSelected = classId === selectedClassId;
+        return (
+          '<button class="ship-card' +
+          (isSelected ? ' ship-card--selected' : '') +
+          '" type="button"' +
+          ' data-class="' +
+          _escapeAttr(classId) +
+          '"' +
+          ' aria-pressed="' +
+          (isSelected ? 'true' : 'false') +
+          '">' +
+          '<div class="ship-card-header">' +
+          '<span class="ship-card-icon">' +
+          s.icon +
+          '</span>' +
+          '<span class="ship-card-name">' +
+          _escapeHtml(s.name) +
+          '</span>' +
+          '</div>' +
+          '<p class="ship-card-desc">' +
+          _escapeHtml(s.description) +
+          '</p>' +
+          '<div class="ship-card-stats">' +
+          _shipStatBar('Speed', bs.speed) +
+          _shipStatBar('Handle', bs.maneuverability) +
+          _shipStatBar('Hull', bs.hull.max) +
+          _shipStatBar('Cargo', bs.cargo.capacity) +
+          '</div>' +
+          '<div class="ship-card-guns">' +
+          bs.guns.count +
+          ' × ' +
+          bs.guns.weight +
+          'lb guns</div>' +
+          '</button>'
+        );
+      })
+      .join('');
+  }
+
   T.newGame = {
     _panelEl: null,
     _selectedPortrait: PORTRAITS[0].id,
+    _selectedShipClass: null,
     _worldId: null,
     _worldData: null,
 
@@ -45,6 +114,7 @@
       this._worldId = worldId;
       this._worldData = worldData;
       this._selectedPortrait = PORTRAITS[0].id;
+      this._selectedShipClass = Object.keys(T.SHIP_TYPES)[0];
 
       var panelEl = document.getElementById('new-game-panel');
       if (!panelEl) return;
@@ -94,6 +164,12 @@
         '<textarea class="knobs-input new-game-bio" id="ng-bio"' +
         ' rows="3" placeholder="Your captain\'s story…"></textarea>' +
         '</div>' +
+        '<div class="knobs-field">' +
+        '<label class="knobs-label">Flagship Class</label>' +
+        '<div class="ship-picker" id="ng-ship-picker">' +
+        _buildShipCards(this._selectedShipClass) +
+        '</div>' +
+        '</div>' +
         '<p class="new-game-error hidden" id="ng-error"></p>' +
         '<div class="new-game-actions">' +
         '<button class="btn-cancel" id="ng-cancel" type="button">Cancel</button>' +
@@ -117,6 +193,18 @@
         });
       });
 
+      panelEl.querySelectorAll('.ship-card').forEach(function (card) {
+        card.addEventListener('click', function () {
+          self._selectedShipClass = card.getAttribute('data-class');
+          panelEl.querySelectorAll('.ship-card').forEach(function (c) {
+            c.classList.remove('ship-card--selected');
+            c.setAttribute('aria-pressed', 'false');
+          });
+          card.classList.add('ship-card--selected');
+          card.setAttribute('aria-pressed', 'true');
+        });
+      });
+
       document.getElementById('ng-cancel').addEventListener('click', function () {
         self._hide();
       });
@@ -133,6 +221,7 @@
       }
       this._worldId = null;
       this._worldData = null;
+      this._selectedShipClass = null;
     },
 
     _onConfirm: function () {
@@ -160,6 +249,8 @@
       if (cancelBtn) cancelBtn.disabled = true;
 
       var bio = (bioEl && bioEl.value.trim()) || '';
+      var selectedShipClass = this._selectedShipClass;
+      var shipType = T.SHIP_TYPES[selectedShipClass];
 
       var gameDoc = {
         worldId: this._worldId,
@@ -179,19 +270,52 @@
         settings: { difficulty: 'normal', mythicEnabled: true, pacing: 'async' },
       };
 
+      var flagshipDoc = {
+        classId: selectedShipClass,
+        name: captainName + "'s " + shipType.name,
+        customFlag: null,
+        hull: { current: shipType.baseStats.hull.max, max: shipType.baseStats.hull.max },
+        sails: { current: shipType.baseStats.sails.max, max: shipType.baseStats.sails.max },
+        guns: { count: shipType.baseStats.guns.count, weight: shipType.baseStats.guns.weight },
+        crew: {
+          current: shipType.baseStats.crew.max,
+          min: shipType.baseStats.crew.min,
+          max: shipType.baseStats.crew.max,
+        },
+        morale: shipType.baseStats.morale,
+        cargo: { used: 0, capacity: shipType.baseStats.cargo.capacity, manifest: [] },
+        upgrades: [],
+        speed: shipType.baseStats.speed,
+        maneuverability: shipType.baseStats.maneuverability,
+        draft: shipType.baseStats.draft,
+        damage: { hull: 0, sails: 0, guns: 0, hold: 0 },
+        location: null,
+        squadId: null,
+      };
+
       var self = this;
+      var gameDocRef;
       T.firestore
         .createGame(gameDoc)
         .then(function (docRef) {
+          gameDocRef = docRef;
+          return T.firestore.createFlagship(docRef.id, flagshipDoc);
+        })
+        .then(function (shipDocRef) {
+          return T.firestore.updateGame(gameDocRef.id, { flagshipId: shipDocRef.id });
+        })
+        .then(function () {
           if (self._panelEl) {
             self._panelEl.innerHTML =
               '<div class="new-game-success">' +
               '<p class="new-game-success-title">Campaign created!</p>' +
               '<p class="new-game-success-meta">Captain ' +
               _escapeAttr(captainName) +
-              ' is ready to sail.</p>' +
+              ' sails aboard the ' +
+              _escapeAttr(captainName + "'s " + shipType.name) +
+              '.</p>' +
               '<p class="new-game-success-id">Game ID: ' +
-              _escapeAttr(docRef.id) +
+              _escapeAttr(gameDocRef.id) +
               '</p>' +
               '</div>';
           }

--- a/public/apps/tortuga/play/ship-types.js
+++ b/public/apps/tortuga/play/ship-types.js
@@ -1,0 +1,106 @@
+(function () {
+  'use strict';
+
+  window.Tortuga = window.Tortuga || {};
+  var T = window.Tortuga;
+
+  // Static ship class catalog. All stat values are on the T.STAT_SCALE (1–100) scale.
+  // Base stats are denormalized onto flagship instances at new-game creation time.
+  T.SHIP_TYPES = {
+    sloop: {
+      classId: 'sloop',
+      name: 'Sloop',
+      icon: '⛵',
+      description:
+        'A nimble single-masted raider. Fast enough to close, agile enough to disengage, ' +
+        'and small enough to hide in coves no patrol dares follow.',
+      baseStats: {
+        hull: { current: 40, max: 40 },
+        sails: { current: 35, max: 35 },
+        guns: { count: 6, weight: 4 },
+        crew: { current: 25, min: 8, max: 30 },
+        morale: 60,
+        cargo: { used: 0, capacity: 25, manifest: [] },
+        upgrades: [],
+        speed: 75,
+        maneuverability: 80,
+        draft: 20,
+        damage: { hull: 0, sails: 0, guns: 0, hold: 0 },
+        location: null,
+        squadId: null,
+      },
+    },
+
+    schooner: {
+      classId: 'schooner',
+      name: 'Schooner',
+      icon: '🚢',
+      description:
+        'A two-masted workhorse that earns her keep on trade runs. Generous hold, ' +
+        'good speed, and enough guns to discourage casual trouble.',
+      baseStats: {
+        hull: { current: 50, max: 50 },
+        sails: { current: 45, max: 45 },
+        guns: { count: 8, weight: 6 },
+        crew: { current: 35, min: 12, max: 40 },
+        morale: 60,
+        cargo: { used: 0, capacity: 50, manifest: [] },
+        upgrades: [],
+        speed: 65,
+        maneuverability: 65,
+        draft: 30,
+        damage: { hull: 0, sails: 0, guns: 0, hold: 0 },
+        location: null,
+        squadId: null,
+      },
+    },
+
+    cutter: {
+      classId: 'cutter',
+      name: 'Cutter',
+      icon: '⚔️',
+      description:
+        'A stout fore-and-aft rigged warship favored by privateers. She takes a punch ' +
+        'better than anything her size, and her broadside makes escorts think twice.',
+      baseStats: {
+        hull: { current: 60, max: 60 },
+        sails: { current: 40, max: 40 },
+        guns: { count: 10, weight: 6 },
+        crew: { current: 45, min: 15, max: 50 },
+        morale: 65,
+        cargo: { used: 0, capacity: 20, manifest: [] },
+        upgrades: [],
+        speed: 55,
+        maneuverability: 60,
+        draft: 35,
+        damage: { hull: 0, sails: 0, guns: 0, hold: 0 },
+        location: null,
+        squadId: null,
+      },
+    },
+
+    pinnace: {
+      classId: 'pinnace',
+      name: 'Pinnace',
+      icon: '🛶',
+      description:
+        'A tiny open-decked scout. No ship in the archipelago is faster or harder to ' +
+        'spot. She slips through shallows that strand heavier vessels.',
+      baseStats: {
+        hull: { current: 20, max: 20 },
+        sails: { current: 20, max: 20 },
+        guns: { count: 2, weight: 4 },
+        crew: { current: 10, min: 4, max: 12 },
+        morale: 70,
+        cargo: { used: 0, capacity: 10, manifest: [] },
+        upgrades: [],
+        speed: 85,
+        maneuverability: 90,
+        draft: 10,
+        damage: { hull: 0, sails: 0, guns: 0, hold: 0 },
+        location: null,
+        squadId: null,
+      },
+    },
+  };
+})();

--- a/public/apps/tortuga/state.js
+++ b/public/apps/tortuga/state.js
@@ -7,6 +7,7 @@
   T.MODES = { WORLD: 'world', PLAY: 'play' };
   T.DEFAULT_MODE = 'world';
   T.LAND_HEAVY_THRESHOLD = 60;
+  T.STAT_SCALE = 100;
 
   T.state = {
     db: null,

--- a/public/apps/tortuga/tortuga.css
+++ b/public/apps/tortuga/tortuga.css
@@ -964,3 +964,119 @@
   color: var(--color-text-muted, #888);
   font-family: monospace;
 }
+
+/* ── Ship class picker (new-game flow) ──────────────────────── */
+
+.ship-picker {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.5rem;
+  margin-top: 0.25rem;
+}
+
+.ship-card {
+  padding: 0.75rem;
+  background: var(--color-bg, #12121a);
+  border: 2px solid var(--color-border, #333);
+  border-radius: 6px;
+  cursor: pointer;
+  text-align: left;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  transition:
+    border-color 0.15s,
+    background 0.15s;
+  font-family: inherit;
+  font-size: inherit;
+  color: var(--color-text, #e8e8f0);
+}
+
+.ship-card:hover {
+  border-color: var(--color-accent, #7b61ff);
+}
+
+.ship-card--selected {
+  border-color: var(--color-accent, #7b61ff);
+  background: rgba(123, 97, 255, 0.15);
+}
+
+.ship-card-header {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.ship-card-icon {
+  font-size: 1.25rem;
+  line-height: 1;
+}
+
+.ship-card-name {
+  font-weight: 700;
+  font-size: 0.9rem;
+  color: var(--color-text, #e8e8f0);
+}
+
+.ship-card-desc {
+  font-size: 0.75rem;
+  color: var(--color-text-muted, #888);
+  line-height: 1.35;
+  margin: 0;
+}
+
+.ship-card-stats {
+  display: flex;
+  flex-direction: column;
+  gap: 0.18rem;
+  margin-top: 0.1rem;
+}
+
+.ship-stat-row {
+  display: grid;
+  grid-template-columns: 3.5rem 1fr 2rem;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.68rem;
+}
+
+.ship-stat-label {
+  color: var(--color-text-muted, #888);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.ship-stat-bar {
+  display: block;
+  height: 4px;
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.ship-stat-fill {
+  display: block;
+  height: 100%;
+  background: var(--color-accent, #7b61ff);
+  border-radius: 2px;
+}
+
+.ship-stat-value {
+  color: var(--color-text-muted, #888);
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+}
+
+.ship-card-guns {
+  font-size: 0.72rem;
+  color: var(--color-text-muted, #888);
+  margin-top: 0.05rem;
+}
+
+@media (max-width: 480px) {
+  .ship-picker {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
Adds play/ship-types.js with 4 starter classes (Sloop, Schooner, Cutter,
Pinnace) on the 1–100 stat scale. New-game creation now shows a ship class
picker with stat bars; on confirm, a flagship document is created in the
ships subcollection and the game's flagshipId is set. Adds STAT_SCALE = 100
to state.js per §11 design doc resolution.

https://claude.ai/code/session_014z2qk76y7cM1EHEPAzV8Xf