### PR TITLE
feat(tortuga): sea graph + AP-based click-to-move on the game map (closes #201)

### DIFF
--- a/public/apps/tortuga/cartographer/pathfinder.js
+++ b/public/apps/tortuga/cartographer/pathfinder.js
@@ -260,9 +260,36 @@
     return _simplify(worldPath);
   }
 
+  // Full path result used by sea-graph.js for gameplay navigation.
+  // Returns { displayPath, gridPath, steps } or null.
+  //   displayPath — simplified polyline (collinear points dropped) for the map overlay
+  //   gridPath    — full unsimplified path in world coords, one entry per grid cell,
+  //                 used for step-by-step ship animation
+  //   steps       — gridPath.length - 1 (AP cost; each grid hop = 1 AP)
+  function findPathFull(meta, fromWorld, toWorld) {
+    var s = _worldToGrid(meta, fromWorld[0], fromWorld[1]);
+    var t = _worldToGrid(meta, toWorld[0], toWorld[1]);
+    var sw = _nearestWater(meta, s[0], s[1], 5);
+    var tw = _nearestWater(meta, t[0], t[1], 5);
+    if (!sw || !tw) return null;
+    var gridPath = _astar(meta, sw[0], sw[1], tw[0], tw[1]);
+    if (!gridPath || gridPath.length < 2) return null;
+    var worldPath = gridPath.map(function (g) {
+      return _gridToWorld(meta, g[0], g[1]);
+    });
+    worldPath[0] = fromWorld;
+    worldPath[worldPath.length - 1] = toWorld;
+    return {
+      displayPath: _simplify(worldPath),
+      gridPath: worldPath,
+      steps: gridPath.length - 1,
+    };
+  }
+
   var api = {
     buildLandMask: buildLandMask,
     findPath: findPath,
+    findPathFull: findPathFull,
     DEFAULT_GRID_SIZE: DEFAULT_GRID_SIZE,
   };
 

--- a/public/apps/tortuga/firestore.js
+++ b/public/apps/tortuga/firestore.js
@@ -130,6 +130,16 @@
         .update(Object.assign({}, data, { updatedAt: ts }));
     },
 
+    updateFlagship: function (gameId, flagshipId, data) {
+      var ts = firebase.firestore.FieldValue.serverTimestamp();
+      return T.state.db
+        .collection('tortuga_games')
+        .doc(gameId)
+        .collection('ships')
+        .doc(flagshipId)
+        .update(Object.assign({}, data, { updatedAt: ts }));
+    },
+
     // ── User prefs / favorites ────────────────────────────
 
     getFavorites: function (callback) {

--- a/public/apps/tortuga/index.html
+++ b/public/apps/tortuga/index.html
@@ -111,6 +111,7 @@
     <script src="/apps/tortuga/cartographer/overlay.js"></script>
     <script src="/apps/tortuga/cartographer/importer.js"></script>
     <script src="/apps/tortuga/cartographer/editor.js"></script>
+    <script src="/apps/tortuga/play/sea-graph.js"></script>
     <script src="/apps/tortuga/play/game-map.js"></script>
     <script src="/apps/tortuga/new-game.js"></script>
     <script src="/apps/tortuga/app.js"></script>

--- a/public/apps/tortuga/new-game.js
+++ b/public/apps/tortuga/new-game.js
@@ -481,6 +481,9 @@
       var selectedShipClass = this._selectedShipClass;
       var shipType = T.SHIP_TYPES[selectedShipClass];
       var startingPortId = this._selectedPortId;
+      var startingPort = (this._worldData.settlements || []).find(function (s) {
+        return s.id === startingPortId;
+      });
 
       var gameDoc = {
         worldId: this._worldId,
@@ -520,6 +523,11 @@
         draft: shipType.baseStats.draft,
         damage: { hull: 0, sails: 0, guns: 0, hold: 0 },
         location: startingPortId,
+        position:
+          startingPort && startingPort.position
+            ? { y: startingPort.position[0], x: startingPort.position[1] }
+            : null,
+        apRemaining: T.seaGraph.speedToAP(shipType.baseStats.speed),
         squadId: null,
       };
 

--- a/public/apps/tortuga/play/game-map.js
+++ b/public/apps/tortuga/play/game-map.js
@@ -15,6 +15,17 @@
   var _fogLayerRef = null;
   var _shipLayerRef = null;
 
+  // Movement state
+  var _seaGraph = null;
+  var _apMax = 0;
+  var _apRemaining = 0;
+  var _currentPosition = null; // [y, x] in world coords
+  var _pathPreviewLayer = null;
+  var _movementAnimating = false;
+  var _pendingMoveResult = null; // { displayPath, gridPath, steps }
+  var _gameId = null;
+  var _flagshipId = null;
+
   // ── Portrait symbols (mirrors new-game.js) ───────────────────
 
   var PORTRAIT_SYMBOLS = {
@@ -95,11 +106,21 @@
 
   // ── Ship layer ───────────────────────────────────────────────
 
-  function _buildShipLayer(locationId) {
+  function _resolveShipPos(flagshipDoc) {
+    if (flagshipDoc && flagshipDoc.position) {
+      return [flagshipDoc.position.y, flagshipDoc.position.x];
+    }
+    // Fallback for pre-migration documents that have only a settlement location.
+    if (flagshipDoc && flagshipDoc.location) {
+      var s = _settlementIndex[flagshipDoc.location];
+      if (s && s.position) return s.position;
+    }
+    return null;
+  }
+
+  function _buildShipLayer(flagshipDoc) {
     var group = L.layerGroup();
-    if (!locationId) return group;
-    var s = _settlementIndex[locationId];
-    var pos = s && s.position ? s.position : null;
+    var pos = _resolveShipPos(flagshipDoc);
     if (!pos) return group;
     L.circleMarker(pos, {
       radius: 9,
@@ -135,11 +156,15 @@
       cargoStr = flagshipDoc.cargo.used + ' / ' + flagshipDoc.cargo.capacity;
     }
 
-    var locationName = '—';
+    var locationName = 'At Sea';
     if (flagshipDoc && flagshipDoc.location) {
       var s = _settlementIndex[flagshipDoc.location];
       if (s && s.name) locationName = s.name;
     }
+
+    var apRemaining =
+      flagshipDoc && flagshipDoc.apRemaining != null ? flagshipDoc.apRemaining : _apRemaining;
+    var apLowClass = apRemaining <= 2 ? ' game-hud-ap--low' : '';
 
     hudEl.innerHTML =
       '<div class="game-hud-portrait">' +
@@ -174,7 +199,222 @@
       '<span class="game-hud-value">' +
       _escapeHtml(locationName) +
       '</span>' +
+      '</div>' +
+      '<div class="game-hud-item">' +
+      '<span class="game-hud-label">AP</span>' +
+      '<span class="game-hud-value game-hud-ap' +
+      apLowClass +
+      '">' +
+      apRemaining +
+      ' / ' +
+      _apMax +
+      '</span>' +
+      '</div>' +
+      '<div class="game-hud-move-info" id="game-hud-move-info"></div>' +
+      '<div class="game-hud-actions">' +
+      '<button class="game-hud-end-turn" id="game-hud-end-turn" type="button">End Turn</button>' +
       '</div>';
+
+    var endTurnBtn = document.getElementById('game-hud-end-turn');
+    if (endTurnBtn) {
+      endTurnBtn.addEventListener('click', _endTurn);
+    }
+  }
+
+  // ── Move info area ───────────────────────────────────────────
+
+  function _setMoveInfo(html) {
+    var el = document.getElementById('game-hud-move-info');
+    if (el) el.innerHTML = html || '';
+  }
+
+  // ── Path preview ─────────────────────────────────────────────
+
+  function _clearPathPreview() {
+    if (_pathPreviewLayer) {
+      _pathPreviewLayer.remove();
+      _pathPreviewLayer = null;
+    }
+    _pendingMoveResult = null;
+    _setMoveInfo('');
+  }
+
+  function _showPathPreview(result) {
+    _clearPathPreview();
+
+    if (!result) {
+      // No water path to this point — re-register click immediately.
+      _registerMapClick();
+      return;
+    }
+
+    var withinAP = result.steps <= _apRemaining;
+    var color = withinAP ? '#4caf50' : '#f44336';
+    var dashArray = withinAP ? null : '8 5';
+
+    _pathPreviewLayer = L.polyline(result.displayPath, {
+      color: color,
+      weight: 3,
+      dashArray: dashArray,
+      opacity: 0.85,
+      interactive: false,
+    });
+    T.mapRenderer.addExternalLayer('path-preview', _pathPreviewLayer);
+
+    if (withinAP) {
+      _pendingMoveResult = result;
+      _setMoveInfo(
+        '<div class="game-hud-move-prompt">' +
+          '<span class="game-hud-move-cost">Move: ' +
+          result.steps +
+          ' AP</span>' +
+          '<button class="game-hud-move-confirm" id="game-hud-move-confirm" type="button">Move</button>' +
+          '<button class="game-hud-move-cancel" id="game-hud-move-cancel" type="button">Cancel</button>' +
+          '</div>'
+      );
+      var confirmBtn = document.getElementById('game-hud-move-confirm');
+      var cancelBtn = document.getElementById('game-hud-move-cancel');
+      if (confirmBtn) confirmBtn.addEventListener('click', _confirmMove);
+      if (cancelBtn) cancelBtn.addEventListener('click', _cancelMove);
+    } else {
+      _setMoveInfo(
+        '<div class="game-hud-move-prompt game-hud-move-prompt--blocked">' +
+          '<span class="game-hud-move-cost game-hud-move-cost--over">Not enough AP (' +
+          result.steps +
+          ' needed)</span>' +
+          '<button class="game-hud-move-cancel" id="game-hud-move-cancel" type="button">Cancel</button>' +
+          '</div>'
+      );
+      var cancelBtn2 = document.getElementById('game-hud-move-cancel');
+      if (cancelBtn2) cancelBtn2.addEventListener('click', _cancelMove);
+      // Allow clicking a different destination.
+      _registerMapClick();
+    }
+  }
+
+  // ── Click registration ───────────────────────────────────────
+
+  function _registerMapClick() {
+    if (_movementAnimating) return;
+    T.mapRenderer.awaitMapClick(function (pos) {
+      _onMapClick(pos);
+    });
+  }
+
+  function _onMapClick(pos) {
+    if (_movementAnimating || !_seaGraph || !_currentPosition) {
+      _registerMapClick();
+      return;
+    }
+    _clearPathPreview();
+    var result = T.seaGraph.findPath(_seaGraph, _currentPosition, pos);
+    _showPathPreview(result);
+  }
+
+  // ── Movement ─────────────────────────────────────────────────
+
+  function _cancelMove() {
+    _clearPathPreview();
+    _registerMapClick();
+  }
+
+  function _confirmMove() {
+    if (!_pendingMoveResult || _movementAnimating) return;
+    var result = _pendingMoveResult;
+    _pendingMoveResult = null;
+    _setMoveInfo('');
+
+    _movementAnimating = true;
+    var gridPath = result.gridPath;
+    var stepIndex = 0;
+
+    function _step() {
+      stepIndex++;
+      if (stepIndex >= gridPath.length) {
+        _finishMove(gridPath[gridPath.length - 1], result.steps);
+        return;
+      }
+      var pos = gridPath[stepIndex];
+      _currentPosition = pos;
+      _setShipLayer(_buildShipLayerAtPos(pos));
+      setTimeout(_step, 150);
+    }
+
+    setTimeout(_step, 150);
+  }
+
+  function _buildShipLayerAtPos(pos) {
+    var group = L.layerGroup();
+    if (!pos) return group;
+    L.circleMarker(pos, {
+      radius: 9,
+      color: '#ffb74d',
+      fillColor: '#ffb74d',
+      fillOpacity: 0.9,
+      weight: 2,
+      interactive: false,
+    }).addTo(group);
+    return group;
+  }
+
+  function _finishMove(finalPos, stepsUsed) {
+    _movementAnimating = false;
+    _clearPathPreview();
+
+    var newAP = Math.max(0, _apRemaining - stepsUsed);
+    _apRemaining = newAP;
+    _currentPosition = finalPos;
+
+    // Determine if final position is at a settlement.
+    var arrivedAtSettlement = null;
+    Object.keys(_settlementIndex).forEach(function (id) {
+      var s = _settlementIndex[id];
+      if (!s || !s.position) return;
+      var dy = s.position[0] - finalPos[0];
+      var dx = s.position[1] - finalPos[1];
+      // Snap threshold: within half a nav cell (approx)
+      var cellSize =
+        _seaGraph && _seaGraph.cellH ? Math.max(_seaGraph.cellH, _seaGraph.cellW) / 2 : 8;
+      if (Math.sqrt(dy * dy + dx * dx) < cellSize) {
+        arrivedAtSettlement = id;
+      }
+    });
+
+    T.firestore
+      .updateFlagship(_gameId, _flagshipId, {
+        position: { y: finalPos[0], x: finalPos[1] },
+        location: arrivedAtSettlement,
+        apRemaining: newAP,
+      })
+      .catch(function (err) {
+        console.error('[game-map] updateFlagship failed', err);
+      });
+
+    _renderHud(_lastGameDoc, Object.assign({}, _lastFlagshipDoc, { apRemaining: newAP }));
+    _registerMapClick();
+  }
+
+  // ── End Turn ─────────────────────────────────────────────────
+
+  function _endTurn() {
+    if (_movementAnimating) return;
+    _clearPathPreview();
+    _apRemaining = _apMax;
+
+    T.firestore.updateFlagship(_gameId, _flagshipId, { apRemaining: _apMax }).catch(function (err) {
+      console.error('[game-map] updateFlagship (endTurn) failed', err);
+    });
+
+    T.firestore
+      .updateGame(_gameId, {
+        turnNumber: firebase.firestore.FieldValue.increment(1),
+      })
+      .catch(function (err) {
+        console.error('[game-map] updateGame (endTurn) failed', err);
+      });
+
+    _renderHud(_lastGameDoc, Object.assign({}, _lastFlagshipDoc, { apRemaining: _apMax }));
+    _registerMapClick();
   }
 
   // ── Live update handlers ─────────────────────────────────────
@@ -198,28 +438,52 @@
       return;
     }
     _lastFlagshipDoc = flagshipDoc;
+
+    // Sync AP and position from Firestore (covers resume-from-save).
+    if (flagshipDoc.apRemaining != null) {
+      _apRemaining = flagshipDoc.apRemaining;
+    }
+    if (flagshipDoc.position) {
+      _currentPosition = [flagshipDoc.position.y, flagshipDoc.position.x];
+    }
+
     _renderHud(_lastGameDoc, flagshipDoc);
 
     var mapPanel = document.getElementById('game-map-panel');
     if (!mapPanel || mapPanel.classList.contains('hidden')) return;
-    _setShipLayer(_buildShipLayer(flagshipDoc.location));
+    if (!_movementAnimating) {
+      _setShipLayer(_buildShipLayer(flagshipDoc));
+    }
   }
 
   // ── Public API ───────────────────────────────────────────────
 
   T.gameMap = {
     open: function (gameId, gameDoc, flagshipId, flagshipDoc, worldData) {
+      _gameId = gameId;
+      _flagshipId = flagshipId;
       _worldData = worldData;
       _lastGameDoc = gameDoc;
       _lastFlagshipDoc = flagshipDoc;
 
-      // Build settlement index
+      // Build settlement index.
       _settlementIndex = {};
       (worldData.settlements || []).forEach(function (s) {
         _settlementIndex[s.id] = s;
       });
 
-      // Show/hide panels
+      // Movement state from flagship doc.
+      _apMax = T.seaGraph.speedToAP((flagshipDoc && flagshipDoc.speed) || 0);
+      _apRemaining =
+        flagshipDoc && flagshipDoc.apRemaining != null ? flagshipDoc.apRemaining : _apMax;
+      _currentPosition = _resolveShipPos(flagshipDoc);
+      _movementAnimating = false;
+      _pendingMoveResult = null;
+
+      // Build sea graph from world coastlines.
+      _seaGraph = T.seaGraph.buildGraph(worldData);
+
+      // Show/hide panels.
       var shellPlayEl = document.getElementById('shell-play');
       var worldListSection = shellPlayEl && shellPlayEl.querySelector('.world-list-section');
       var newGamePanel = document.getElementById('new-game-panel');
@@ -232,18 +496,21 @@
       }
       if (gameMapPanel) gameMapPanel.classList.remove('hidden');
 
-      // Render initial HUD
+      // Render initial HUD.
       _renderHud(gameDoc, flagshipDoc);
 
-      // Init map renderer
+      // Init map renderer.
       var mapEl = document.getElementById('map-play');
       T.mapRenderer.init(mapEl, worldData);
 
-      // Add fog and ship layers
+      // Add fog and ship layers.
       _setFogLayer(_buildFogLayer(gameDoc.fog, worldData));
-      _setShipLayer(_buildShipLayer(flagshipDoc.location));
+      _setShipLayer(_buildShipLayer(flagshipDoc));
 
-      // Subscribe to live Firestore updates
+      // Start click-to-move loop.
+      _registerMapClick();
+
+      // Subscribe to live Firestore updates.
       _unsubGame = T.firestore.onGame(gameId, _onGameUpdate);
       _unsubFlagship = T.firestore.onFlagship(gameId, flagshipId, _onFlagshipUpdate);
     },
@@ -258,14 +525,23 @@
         _unsubFlagship = null;
       }
 
+      T.mapRenderer.cancelMapClick();
+      _clearPathPreview();
       T.mapRenderer.destroy();
 
       _fogLayerRef = null;
       _shipLayerRef = null;
+      _pathPreviewLayer = null;
       _worldData = null;
       _settlementIndex = {};
       _lastGameDoc = null;
       _lastFlagshipDoc = null;
+      _seaGraph = null;
+      _currentPosition = null;
+      _movementAnimating = false;
+      _pendingMoveResult = null;
+      _gameId = null;
+      _flagshipId = null;
 
       var gameMapPanel = document.getElementById('game-map-panel');
       if (gameMapPanel) gameMapPanel.classList.add('hidden');

--- a/public/apps/tortuga/play/sea-graph.js
+++ b/public/apps/tortuga/play/sea-graph.js
@@ -1,0 +1,48 @@
+(function () {
+  'use strict';
+
+  window.Tortuga = window.Tortuga || {};
+  var T = window.Tortuga;
+
+  // Coarser grid than pathfinder's trade-route default (160) — each nav cell is a
+  // meaningful movement step (~12×16 world units on a typical 600×800 map).
+  var NAV_GRID_SIZE = 50;
+
+  // AP budget per turn derived from ship speed (1–100 scale, per §5 ship stats).
+  var SPEED_AP_BRACKETS = [
+    { min: 80, ap: 10 },
+    { min: 70, ap: 8 },
+    { min: 60, ap: 7 },
+    { min: 50, ap: 6 },
+    { min: 35, ap: 4 },
+    { min: 0, ap: 3 },
+  ];
+
+  function speedToAP(speed) {
+    for (var i = 0; i < SPEED_AP_BRACKETS.length; i++) {
+      if (speed >= SPEED_AP_BRACKETS[i].min) return SPEED_AP_BRACKETS[i].ap;
+    }
+    return 3;
+  }
+
+  // Build the navigation land mask from world coastlines at NAV_GRID_SIZE resolution.
+  // Returns the meta object expected by findPath / findPathFull in pathfinder.js.
+  function buildGraph(worldData) {
+    return T.pathfinder.buildLandMask(worldData.bounds, worldData.coastlines, NAV_GRID_SIZE);
+  }
+
+  // Returns { displayPath, gridPath, steps } or null when no water path exists.
+  // displayPath — simplified polyline for the map overlay
+  // gridPath    — full cell-by-cell path in world coords for step animation
+  // steps       — AP cost (each grid hop = 1 AP)
+  function findPath(graph, fromPos, toPos) {
+    return T.pathfinder.findPathFull(graph, fromPos, toPos);
+  }
+
+  T.seaGraph = {
+    buildGraph: buildGraph,
+    findPath: findPath,
+    speedToAP: speedToAP,
+    NAV_GRID_SIZE: NAV_GRID_SIZE,
+  };
+})();

--- a/public/apps/tortuga/tortuga.css
+++ b/public/apps/tortuga/tortuga.css
@@ -1233,6 +1233,97 @@
   font-weight: 700;
 }
 
+.game-hud-ap {
+  color: #66bb6a;
+  font-weight: 700;
+}
+
+.game-hud-ap--low {
+  color: #ef5350;
+}
+
+.game-hud-move-info {
+  flex-basis: 100%;
+  order: 99;
+}
+
+.game-hud-move-prompt {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.35rem 0.6rem;
+  background: rgba(255, 183, 77, 0.08);
+  border: 1px solid rgba(255, 183, 77, 0.25);
+  border-radius: 4px;
+  font-size: 0.78rem;
+}
+
+.game-hud-move-prompt--blocked {
+  background: rgba(239, 83, 80, 0.08);
+  border-color: rgba(239, 83, 80, 0.3);
+}
+
+.game-hud-move-cost {
+  flex: 1;
+  color: var(--color-text, #e0e0e0);
+}
+
+.game-hud-move-cost--over {
+  color: #ef5350;
+}
+
+.game-hud-move-confirm {
+  padding: 0.2rem 0.6rem;
+  background: #2e7d32;
+  color: #fff;
+  border: none;
+  border-radius: 3px;
+  cursor: pointer;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.game-hud-move-confirm:hover {
+  background: #388e3c;
+}
+
+.game-hud-move-cancel {
+  padding: 0.2rem 0.6rem;
+  background: transparent;
+  color: var(--color-text-muted, #888);
+  border: 1px solid rgba(136, 136, 136, 0.4);
+  border-radius: 3px;
+  cursor: pointer;
+  font-size: 0.75rem;
+}
+
+.game-hud-move-cancel:hover {
+  color: var(--color-text, #e0e0e0);
+  border-color: rgba(224, 224, 224, 0.4);
+}
+
+.game-hud-actions {
+  margin-left: auto;
+  flex-shrink: 0;
+}
+
+.game-hud-end-turn {
+  padding: 0.25rem 0.75rem;
+  background: rgba(255, 183, 77, 0.12);
+  color: #ffb74d;
+  border: 1px solid rgba(255, 183, 77, 0.4);
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+}
+
+.game-hud-end-turn:hover {
+  background: rgba(255, 183, 77, 0.22);
+}
+
 #game-map-panel .tortuga-map {
   border-radius: 0 0 6px 6px;
 }


### PR DESCRIPTION
Implements T-205: generates a navigable water graph from world coastlines at
a coarser 50×50 grid resolution (each nav cell ~12×16 world units), then wires
click-to-move on that graph with an AP budget derived from the flagship's speed.

- play/sea-graph.js (new): buildGraph wraps pathfinder.buildLandMask at
  NAV_GRID_SIZE=50; findPath delegates to pathfinder.findPathFull; speedToAP
  converts ship speed (1–100) to per-turn AP via a step table

- cartographer/pathfinder.js: add findPathFull returning { displayPath,
  gridPath, steps } — simplified polyline for overlay, full cell-by-cell path
  for step animation, and AP cost

- play/game-map.js: sea graph built on open(); click-to-move via
  awaitMapClick loop; green/red path preview with Move/Cancel prompt in HUD;
  step-by-step ship animation at 150ms per cell; AP deducted on move with
  Firestore write; End Turn button resets AP and increments turnNumber;
  flagship.position {y,x} used for rendering with settlement fallback

- firestore.js: add updateFlagship for writing position/apRemaining

- new-game.js: populate flagship position + apRemaining at game creation

- tortuga.css: AP display (green/red), move-info prompt strip, End Turn button

https://claude.ai/code/session_01XR3Uq1b4Wy1L2QfR513QkG