### PR TITLE
feat(tortuga): reachable-cell highlight movement (tap-to-move fix)

### DIFF
--- a/public/apps/tortuga/cartographer/pathfinder.js
+++ b/public/apps/tortuga/cartographer/pathfinder.js
@@ -286,10 +286,60 @@
     };
   }
 
+  // BFS flood-fill returning all water cells reachable within maxSteps hops.
+  // Each hop (cardinal or diagonal) counts as 1 step, matching the AP cost
+  // used by findPathFull (steps = gridPath.length - 1).
+  function reachableCells(meta, fromWorld, maxSteps) {
+    var n = meta.gridSize;
+    var s = _worldToGrid(meta, fromWorld[0], fromWorld[1]);
+    var sw = _nearestWater(meta, s[0], s[1], 5);
+    if (!sw) return [];
+
+    var DIRS8 = [
+      [-1, 0],
+      [1, 0],
+      [0, -1],
+      [0, 1],
+      [-1, -1],
+      [-1, 1],
+      [1, -1],
+      [1, 1],
+    ];
+    var dist = new Int16Array(n * n).fill(-1);
+    var queue = [];
+    var head = 0;
+    var startIdx = sw[0] * n + sw[1];
+    dist[startIdx] = 0;
+    queue.push(startIdx);
+    var result = [];
+
+    while (head < queue.length) {
+      var idx = queue[head++];
+      var ci = Math.floor(idx / n);
+      var cj = idx % n;
+      var cd = dist[idx];
+      if (cd > 0) {
+        result.push({ worldPos: _gridToWorld(meta, ci, cj), steps: cd });
+      }
+      if (cd >= maxSteps) continue;
+      for (var d = 0; d < 8; d++) {
+        var ni = ci + DIRS8[d][0];
+        var nj = cj + DIRS8[d][1];
+        if (ni < 0 || ni >= n || nj < 0 || nj >= n) continue;
+        var nIdx = ni * n + nj;
+        if (meta.mask[nIdx] || dist[nIdx] >= 0) continue;
+        dist[nIdx] = cd + 1;
+        queue.push(nIdx);
+      }
+    }
+    return result;
+  }
+
   var api = {
     buildLandMask: buildLandMask,
     findPath: findPath,
     findPathFull: findPathFull,
+    reachableCells: reachableCells,
     DEFAULT_GRID_SIZE: DEFAULT_GRID_SIZE,
   };
 

--- a/public/apps/tortuga/play/game-map.js
+++ b/public/apps/tortuga/play/game-map.js
@@ -25,7 +25,7 @@
   var _pendingMoveResult = null; // { displayPath, gridPath, steps }
   var _gameId = null;
   var _flagshipId = null;
-  var _mapClickHandler = null; // persistent Leaflet click listener
+  var _navCellLayer = null; // L.layerGroup of reachable-cell markers
 
   // ── Portrait symbols (mirrors new-game.js) ───────────────────
 
@@ -312,28 +312,43 @@
     }
   }
 
-  // ── Persistent map click handler ─────────────────────────────
+  // ── Reachable-cell markers ───────────────────────────────────
 
-  function _attachMapClick() {
-    var map = T.mapRenderer.getMap();
-    if (!map) return;
-    _mapClickHandler = function (e) {
-      _onMapClick([e.latlng.lat, e.latlng.lng]);
-    };
-    map.on('click', _mapClickHandler);
-  }
-
-  function _detachMapClick() {
-    var map = T.mapRenderer.getMap();
-    if (map && _mapClickHandler) {
-      map.off('click', _mapClickHandler);
+  function _clearNavCells() {
+    if (_navCellLayer) {
+      _navCellLayer.remove();
+      _navCellLayer = null;
     }
-    _mapClickHandler = null;
   }
 
-  function _onMapClick(pos) {
+  function _showReachableCells() {
+    _clearNavCells();
+    if (!_seaGraph || !_currentPosition || _movementAnimating || _apRemaining <= 0) return;
+    var cells = T.seaGraph.reachableCells(_seaGraph, _currentPosition, _apRemaining);
+    if (!cells.length) return;
+    var group = L.layerGroup();
+    cells.forEach(function (cell) {
+      var marker = L.circleMarker(cell.worldPos, {
+        radius: 6,
+        color: '#4caf50',
+        fillColor: '#4caf50',
+        fillOpacity: 0.25,
+        weight: 1,
+        opacity: 0.7,
+      });
+      marker.on('click', function (e) {
+        L.DomEvent.stopPropagation(e);
+        _onNavCellClick(cell.worldPos);
+      });
+      marker.addTo(group);
+    });
+    _navCellLayer = group;
+    T.mapRenderer.addExternalLayer('nav-cells', group);
+  }
+
+  function _onNavCellClick(pos) {
     if (_movementAnimating) return;
-    if (!_seaGraph || !_currentPosition) return;
+    _clearNavCells();
     _clearPathPreview();
     var result = T.seaGraph.findPath(_seaGraph, _currentPosition, pos);
     _showPathPreview(result);
@@ -343,6 +358,7 @@
 
   function _cancelMove() {
     _clearPathPreview();
+    _showReachableCells();
   }
 
   function _confirmMove() {
@@ -403,6 +419,7 @@
       });
 
     _renderHud(_lastGameDoc, Object.assign({}, _lastFlagshipDoc, { apRemaining: newAP }));
+    _showReachableCells();
   }
 
   // ── End Turn ─────────────────────────────────────────────────
@@ -425,6 +442,7 @@
       });
 
     _renderHud(_lastGameDoc, Object.assign({}, _lastFlagshipDoc, { apRemaining: _apMax }));
+    _showReachableCells();
   }
 
   // ── Live update handlers ─────────────────────────────────────
@@ -517,8 +535,8 @@
       _setFogLayer(_buildFogLayer(gameDoc.fog, worldData));
       _setShipLayer(_buildShipLayer(flagshipDoc));
 
-      // Attach persistent click-to-move handler.
-      _attachMapClick();
+      // Show reachable-cell markers for tap-to-move.
+      _showReachableCells();
 
       // Subscribe to live Firestore updates.
       _unsubGame = T.firestore.onGame(gameId, _onGameUpdate);
@@ -535,12 +553,13 @@
         _unsubFlagship = null;
       }
 
-      _detachMapClick();
+      _clearNavCells();
       _clearPathPreview();
       T.mapRenderer.destroy();
 
       _fogLayerRef = null;
       _shipLayerRef = null;
+      _navCellLayer = null;
       _pathPreviewLayer = null;
       _worldData = null;
       _settlementIndex = {};

--- a/public/apps/tortuga/play/sea-graph.js
+++ b/public/apps/tortuga/play/sea-graph.js
@@ -39,9 +39,16 @@
     return T.pathfinder.findPathFull(graph, fromPos, toPos);
   }
 
+  // Returns all water cells reachable within apBudget AP from fromPos.
+  // Each element: { worldPos: [y,x], steps: number }
+  function reachableCells(graph, fromPos, apBudget) {
+    return T.pathfinder.reachableCells(graph, fromPos, apBudget);
+  }
+
   T.seaGraph = {
     buildGraph: buildGraph,
     findPath: findPath,
+    reachableCells: reachableCells,
     speedToAP: speedToAP,
     NAV_GRID_SIZE: NAV_GRID_SIZE,
   };


### PR DESCRIPTION
## Summary

- Replaces the persistent `map.on('click')` listener with BFS flood-fill reachable-cell markers (XCOM/Civ-style). The map-click approach was unreliable on mobile/touch because Leaflet's pixel-origin mapping can be stale when the map panel transitions from hidden → visible just before `init()`.
- All water cells reachable within the ship's remaining AP are rendered as tappable `L.circleMarker` dots. Tapping a dot uses a marker-level click handler (immune to the pixel-origin issue) to trigger the existing path-preview → confirm flow.
- `pathfinder.js`: new `reachableCells(meta, fromWorld, maxSteps)` — BFS flood-fill counting each 8-connected hop as 1 step, consistent with `findPathFull` AP cost (`steps = gridPath.length - 1`)
- `sea-graph.js`: exposes `T.seaGraph.reachableCells` delegating to pathfinder
- `game-map.js`: removes `_attachMapClick`/`_detachMapClick`/`_onMapClick`; adds `_showReachableCells`/`_clearNavCells`/`_onNavCellClick`; dots refresh after each move, cancel, and end-turn

## Test plan

- [ ] Start a new game, open the map — green dots appear on water cells around the ship
- [ ] Tap a nearby dot — path preview polyline and "Move (X AP)" confirm/cancel appear in HUD
- [ ] Confirm move — ship animates cell-by-cell; dots refresh at new position with reduced AP
- [ ] Cancel move — dots reappear at original position
- [ ] Tap a land area (no dot there) — nothing happens
- [ ] Use all AP — dots disappear (AP = 0)
- [ ] Tap "End Turn" — AP resets, full dot cloud reappears
- [ ] Reload game — ship restored at last Firestore position, correct dots shown
- [ ] Test on mobile/touch — dots register taps correctly

https://claude.ai/code/session_01XR3Uq1b4Wy1L2QfR513QkG

---
_Generated by [Claude Code](https://claude.ai/code/session_01XR3Uq1b4Wy1L2QfR513QkG)_