### PR TITLE
feat(tortuga): reveal settlements on approach within discovery range

### DIFF
--- a/public/apps/tortuga/play/game-map.js
+++ b/public/apps/tortuga/play/game-map.js
@@ -56,6 +56,18 @@
     return pts;
   }
 
+  // ── Discovery toast ──────────────────────────────────────────
+
+  function _showDiscoveryToast(settlementIds) {
+    var names = settlementIds.map(function (id) {
+      return _escapeHtml((_settlementIndex[id] && _settlementIndex[id].name) || 'Unknown');
+    });
+    _setMoveInfo('<div class="game-hud-discovery">Discovered: ' + names.join(', ') + '</div>');
+    setTimeout(function () {
+      _setMoveInfo('');
+    }, 3000);
+  }
+
   // ── Fog layer ────────────────────────────────────────────────
 
   function _buildFogLayer(fog, worldData) {
@@ -407,6 +419,36 @@
         arrivedAtSettlement = id;
       }
     });
+
+    // Scan for newly discovered settlements within discovery range.
+    var currentFog = (_lastGameDoc && _lastGameDoc.fog) || [];
+    var fogSet = {};
+    currentFog.forEach(function (id) {
+      fogSet[id] = true;
+    });
+    var newlyDiscovered = [];
+    Object.keys(_settlementIndex).forEach(function (id) {
+      if (fogSet[id]) return;
+      var s = _settlementIndex[id];
+      if (!s || !s.position) return;
+      var dy = s.position[0] - finalPos[0];
+      var dx = s.position[1] - finalPos[1];
+      var dist = Math.sqrt(dy * dy + dx * dx);
+      var radius = s.hidden || s.type === 'hidden_cove' ? T.HIDDEN_COVE_RADIUS : T.DISCOVERY_RADIUS;
+      if (dist < radius) {
+        newlyDiscovered.push(id);
+      }
+    });
+    if (newlyDiscovered.length > 0) {
+      T.firestore
+        .updateGame(_gameId, {
+          fog: firebase.firestore.FieldValue.arrayUnion.apply(null, newlyDiscovered),
+        })
+        .catch(function (err) {
+          console.error('[game-map] fog discovery update failed', err);
+        });
+      _showDiscoveryToast(newlyDiscovered);
+    }
 
     T.firestore
       .updateFlagship(_gameId, _flagshipId, {

--- a/public/apps/tortuga/state.js
+++ b/public/apps/tortuga/state.js
@@ -8,6 +8,8 @@
   T.DEFAULT_MODE = 'world';
   T.LAND_HEAVY_THRESHOLD = 60;
   T.STAT_SCALE = 100;
+  T.DISCOVERY_RADIUS = 30;
+  T.HIDDEN_COVE_RADIUS = 12;
 
   T.state = {
     db: null,

--- a/public/apps/tortuga/tortuga.css
+++ b/public/apps/tortuga/tortuga.css
@@ -1247,6 +1247,12 @@
   order: 99;
 }
 
+.game-hud-discovery {
+  color: #80cbc4;
+  font-size: 0.85rem;
+  padding: 4px 0;
+}
+
 .game-hud-move-prompt {
   display: flex;
   align-items: center;


### PR DESCRIPTION
Implements issue #202. On each confirmed move, _finishMove scans all
settlements and appends any within DISCOVERY_RADIUS (30 wu) — or
HIDDEN_COVE_RADIUS (12 wu) for hidden coves — to game.fog via
arrayUnion, triggering the live fog overlay update. A 3-second teal
toast names each newly discovered settlement.

https://claude.ai/code/session_01VzAP3E8tM9suzmJ81Lbg3A