### PR TITLE
feat(tortuga): random event engine + non-combat event pack (T-208)

### DIFF
--- a/public/apps/tortuga/index.html
+++ b/public/apps/tortuga/index.html
@@ -114,6 +114,8 @@
     <script src="/apps/tortuga/play/sea-graph.js"></script>
     <script src="/apps/tortuga/play/game-map.js"></script>
     <script src="/apps/tortuga/play/port-visit.js"></script>
+    <script src="/apps/tortuga/play/event-packs.js"></script>
+    <script src="/apps/tortuga/play/events.js"></script>
     <script src="/apps/tortuga/new-game.js"></script>
     <script src="/apps/tortuga/app.js"></script>
 

--- a/public/apps/tortuga/play/event-packs.js
+++ b/public/apps/tortuga/play/event-packs.js
@@ -1,0 +1,200 @@
+(function () {
+  'use strict';
+
+  window.Tortuga = window.Tortuga || {};
+  var T = window.Tortuga;
+
+  // ── Event catalog ────────────────────────────────────────────
+  //
+  // Each event object:
+  //   id         {string}    unique identifier
+  //   type       {string}    'storm' | 'wreckage' | 'sighting'
+  //   title      {string}    modal header text
+  //   weight     {number}    relative draw weight
+  //   narratives {string[]}  one is picked at random for flavour
+  //   choices    {Array<{
+  //                id:      string,
+  //                label:   string,
+  //                primary: bool,
+  //                outcome: {
+  //                  hullDmg?:  [min, max],
+  //                  sailsDmg?: [min, max],
+  //                  supplies?: { key: [min, max] },
+  //                }
+  //              }>}
+  //
+  // Damage values are dealt amounts (positive = damage). Supply values are gains
+  // (positive = gain). Ranges are inclusive. The engine resolves them at fire-time.
+
+  T.EVENT_PACKS = [
+    // ── Storms ────────────────────────────────────────────────
+
+    {
+      id: 'storm_squall',
+      type: 'storm',
+      title: 'Sudden Squall',
+      weight: 3,
+      narratives: [
+        'Black clouds pile on the horizon with frightening speed. The lookout shouts "All hands!" ' +
+          'before the first wave crashes over the bow.',
+        'A wall of rain sweeps in from the east. Lightning splits the sky as the wind tears at the rigging.',
+        'Without warning the sea turns from grey to green. The crew scramble to furl sail before the gust hits.',
+      ],
+      choices: [
+        {
+          id: 'understood',
+          label: 'Ride it out',
+          primary: true,
+          outcome: { hullDmg: [1, 2], sailsDmg: [1, 3] },
+        },
+      ],
+    },
+
+    {
+      id: 'storm_typhoon',
+      type: 'storm',
+      title: 'Tropical Typhoon',
+      weight: 1,
+      narratives: [
+        'A full typhoon closes from the south-west. For three hours the ship is at the mercy of the sea.',
+        'The barometer drops like a stone. By nightfall the flagship is fighting for her life in mountainous swells.',
+      ],
+      choices: [
+        {
+          id: 'understood',
+          label: 'Hold fast',
+          primary: true,
+          outcome: { hullDmg: [2, 3], sailsDmg: [1, 2] },
+        },
+      ],
+    },
+
+    // ── Wreckage ──────────────────────────────────────────────
+
+    {
+      id: 'wreckage_merchant',
+      type: 'wreckage',
+      title: 'Merchant Wreck',
+      weight: 3,
+      narratives: [
+        'A shattered hull bobs in the swell — a merchant brig, recently broken apart. ' +
+          'Barrels and bales drift around her.',
+        'Smoke still rises from a beached wreck on a reef ahead. The crew spot cargo floating free.',
+        'Half-submerged crates mark the grave of an unlucky merchantman. ' +
+          'No survivors, but her cargo endures.',
+      ],
+      choices: [
+        {
+          id: 'salvage',
+          label: 'Salvage',
+          primary: true,
+          outcome: {
+            supplies: {
+              food: [1, 3],
+              water: [0, 2],
+              rum: [0, 2],
+              repairMaterials: [0, 2],
+            },
+          },
+        },
+        {
+          id: 'sail_on',
+          label: 'Sail On',
+          primary: false,
+          outcome: {},
+        },
+      ],
+    },
+
+    {
+      id: 'wreckage_warship',
+      type: 'wreckage',
+      title: 'Sunken Warship',
+      weight: 1,
+      narratives: [
+        'The cannon-pocked hull of a naval sloop lies on a sandbar. ' +
+          'Powder and shot litter the shallows.',
+        'A patrol frigate, caught by some terrible broadside, rests half-submerged. ' +
+          'Her gun-ports are still open.',
+      ],
+      choices: [
+        {
+          id: 'salvage',
+          label: 'Salvage',
+          primary: true,
+          outcome: {
+            supplies: {
+              powder: [1, 3],
+              shot: [1, 3],
+              repairMaterials: [0, 1],
+            },
+          },
+        },
+        {
+          id: 'sail_on',
+          label: 'Sail On',
+          primary: false,
+          outcome: {},
+        },
+      ],
+    },
+
+    // ── Sightings ─────────────────────────────────────────────
+
+    {
+      id: 'sighting_sea_turtle',
+      type: 'sighting',
+      title: 'Giant Sea Turtle',
+      weight: 2,
+      narratives: [
+        'A leatherback the size of a jolly-boat surfaces alongside the flagship, ' +
+          'regarding the crew with an ancient eye before diving.',
+        'The helmsman nearly puts the wheel hard over when a great shell breaks the surface ahead. ' +
+          'The old hands assure the young ones it is a good omen.',
+      ],
+      choices: [{ id: 'dismiss', label: 'Remarkable', primary: true, outcome: {} }],
+    },
+
+    {
+      id: 'sighting_ghost_ship',
+      type: 'sighting',
+      title: 'Ghost Ship',
+      weight: 1,
+      narratives: [
+        'A full-rigged ship glides through the fog under all sail — no crew visible, ' +
+          'no flag at her masthead. She rounds a headland and vanishes.',
+        'The night watch wakes the captain: a dark vessel with no running lights crosses ' +
+          "the flagship's bows without a sound.",
+      ],
+      choices: [{ id: 'dismiss', label: 'Unsettling', primary: true, outcome: {} }],
+    },
+
+    {
+      id: 'sighting_whale_pod',
+      type: 'sighting',
+      title: 'Pod of Whales',
+      weight: 2,
+      narratives: [
+        'A pod of sperm whales breaches off the starboard bow, soaking the watch with spray ' +
+          'and drawing a cheer from the crew.',
+        'Fins cut the water all around. The flagship picks her way through a gathering of ' +
+          'giants, close enough to touch.',
+      ],
+      choices: [{ id: 'dismiss', label: 'Magnificent', primary: true, outcome: {} }],
+    },
+
+    {
+      id: 'sighting_distant_fleet',
+      type: 'sighting',
+      title: 'Distant Fleet',
+      weight: 2,
+      narratives: [
+        'A dozen sails are counted on the horizon before they disappear into haze. ' +
+          'Their flag is impossible to make out.',
+        'The lookout reports a column of smoke, then topgallants — a fleet, moving fast. ' +
+          'They pass without incident.',
+      ],
+      choices: [{ id: 'dismiss', label: 'Noted', primary: true, outcome: {} }],
+    },
+  ];
+})();

--- a/public/apps/tortuga/play/events.js
+++ b/public/apps/tortuga/play/events.js
@@ -1,0 +1,214 @@
+(function () {
+  'use strict';
+
+  window.Tortuga = window.Tortuga || {};
+  var T = window.Tortuga;
+
+  // ── Module-local state ───────────────────────────────────────
+
+  var _lastEventTurn = -1;
+  var _overlayEl = null;
+
+  // ── Helpers ──────────────────────────────────────────────────
+
+  function _rng(min, max) {
+    return Math.floor(Math.random() * (max - min + 1)) + min;
+  }
+
+  function _esc(str) {
+    return String(str == null ? '' : str)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+  }
+
+  function _pickWeighted(pack) {
+    var totalWeight = pack.reduce(function (sum, ev) {
+      return sum + (ev.weight || 1);
+    }, 0);
+    var roll = Math.random() * totalWeight;
+    var cumulative = 0;
+    for (var i = 0; i < pack.length; i++) {
+      cumulative += pack[i].weight || 1;
+      if (roll < cumulative) return pack[i];
+    }
+    return pack[pack.length - 1];
+  }
+
+  function _typeLabel(type) {
+    if (type === 'storm') return 'Storm';
+    if (type === 'wreckage') return 'Wreckage';
+    return 'Sighting';
+  }
+
+  // ── Outcome resolution ───────────────────────────────────────
+
+  function _applyOutcome(outcome, ctx, doneCb) {
+    _closeModal();
+
+    var patch = {};
+    var hasUpdate = false;
+
+    if (outcome.hullDmg) {
+      var dmg = _rng(outcome.hullDmg[0], outcome.hullDmg[1]);
+      if (dmg > 0) {
+        var currentHull = (ctx.flagship.hull && ctx.flagship.hull.current) || 0;
+        patch['hull.current'] = Math.max(0, currentHull - dmg);
+        hasUpdate = true;
+      }
+    }
+
+    if (outcome.sailsDmg) {
+      var sdmg = _rng(outcome.sailsDmg[0], outcome.sailsDmg[1]);
+      if (sdmg > 0) {
+        var currentSails = (ctx.flagship.sails && ctx.flagship.sails.current) || 0;
+        patch['sails.current'] = Math.max(0, currentSails - sdmg);
+        hasUpdate = true;
+      }
+    }
+
+    if (outcome.supplies) {
+      var supplyKeys = Object.keys(outcome.supplies);
+      for (var si = 0; si < supplyKeys.length; si++) {
+        var key = supplyKeys[si];
+        var range = outcome.supplies[key];
+        var gain = _rng(range[0], range[1]);
+        if (gain > 0) {
+          patch['supplies.' + key] = firebase.firestore.FieldValue.increment(gain);
+          hasUpdate = true;
+        }
+      }
+    }
+
+    var currentTurn = (ctx.gameDoc && ctx.gameDoc.turnNumber) || 0;
+
+    var promises = [];
+
+    if (hasUpdate) {
+      promises.push(
+        T.firestore.updateFlagship(ctx.gameId, ctx.flagshipId, patch).catch(function (err) {
+          console.error('[events] updateFlagship failed', err);
+        })
+      );
+    }
+
+    promises.push(
+      T.firestore.updateGame(ctx.gameId, { lastEventTurn: currentTurn }).catch(function (err) {
+        console.error('[events] updateGame (lastEventTurn) failed', err);
+      })
+    );
+
+    Promise.all(promises).then(doneCb).catch(doneCb);
+  }
+
+  // ── Modal ────────────────────────────────────────────────────
+
+  function _closeModal() {
+    if (_overlayEl && _overlayEl.parentNode) {
+      _overlayEl.parentNode.removeChild(_overlayEl);
+    }
+    _overlayEl = null;
+  }
+
+  function _openModal(event, narrative, ctx, doneCb) {
+    if (_overlayEl) _closeModal();
+
+    var choicesHtml = event.choices
+      .map(function (choice) {
+        var cls =
+          'event-choice-btn' +
+          (choice.primary ? ' event-choice-btn--primary' : ' event-choice-btn--secondary');
+        return (
+          '<button class="' +
+          cls +
+          '" type="button" data-choice-id="' +
+          _esc(choice.id) +
+          '">' +
+          _esc(choice.label) +
+          '</button>'
+        );
+      })
+      .join('');
+
+    var html =
+      '<div class="event-modal-root">' +
+      '<div class="port-dialog">' +
+      '<div class="port-modal-header">' +
+      '<span class="port-modal-title">' +
+      _esc(event.title) +
+      '</span>' +
+      '</div>' +
+      '<span class="event-type-badge event-type-badge--' +
+      _esc(event.type) +
+      '">' +
+      _esc(_typeLabel(event.type)) +
+      '</span>' +
+      '<p class="event-narrative">' +
+      _esc(narrative) +
+      '</p>' +
+      '<div class="event-choices">' +
+      choicesHtml +
+      '</div>' +
+      '</div>' +
+      '</div>';
+
+    _overlayEl = document.createElement('div');
+    _overlayEl.innerHTML = html;
+    document.body.appendChild(_overlayEl);
+
+    var choiceMap = {};
+    event.choices.forEach(function (c) {
+      choiceMap[c.id] = c;
+    });
+
+    _overlayEl.querySelectorAll('.event-choice-btn').forEach(function (btn) {
+      btn.addEventListener('click', function () {
+        var choiceId = btn.getAttribute('data-choice-id');
+        var choice = choiceMap[choiceId];
+        _applyOutcome(choice ? choice.outcome : {}, ctx, doneCb);
+      });
+    });
+  }
+
+  // ── Public API ───────────────────────────────────────────────
+
+  T.events = {
+    tryFire: function (ctx, doneCb) {
+      var currentTurn = (ctx.gameDoc && ctx.gameDoc.turnNumber) || 0;
+      var lastEventTurn = ctx.gameDoc && ctx.gameDoc.lastEventTurn;
+
+      if (lastEventTurn != null && lastEventTurn >= currentTurn) {
+        doneCb();
+        return;
+      }
+
+      if (_lastEventTurn >= currentTurn) {
+        doneCb();
+        return;
+      }
+
+      if (Math.random() > T.EVENT_CHANCE) {
+        doneCb();
+        return;
+      }
+
+      var pack = T.EVENT_PACKS;
+      if (!pack || !pack.length) {
+        doneCb();
+        return;
+      }
+
+      var event = _pickWeighted(pack);
+      if (!event) {
+        doneCb();
+        return;
+      }
+
+      _lastEventTurn = currentTurn;
+
+      var narrative = event.narratives[_rng(0, event.narratives.length - 1)];
+      _openModal(event, narrative, ctx, doneCb);
+    },
+  };
+})();

--- a/public/apps/tortuga/play/game-map.js
+++ b/public/apps/tortuga/play/game-map.js
@@ -528,26 +528,35 @@
     });
     _renderHud(_lastGameDoc, patchedFlagship);
 
-    if (arrivedAtSettlement) {
-      var arrSett = _settlementIndex[arrivedAtSettlement];
-      if (arrSett && T.FRIENDLY_PORT_TYPES.indexOf(arrSett.type) !== -1) {
-        T.portVisit.open(
-          _gameId,
-          _flagshipId,
-          _lastGameDoc,
-          patchedFlagship,
-          arrivedAtSettlement,
-          arrSett.name,
-          _apMax,
-          function () {
-            _showReachableCells();
+    T.events.tryFire(
+      {
+        gameId: _gameId,
+        flagshipId: _flagshipId,
+        gameDoc: _lastGameDoc,
+        flagship: patchedFlagship,
+      },
+      function _afterEvent() {
+        if (arrivedAtSettlement) {
+          var arrSett = _settlementIndex[arrivedAtSettlement];
+          if (arrSett && T.FRIENDLY_PORT_TYPES.indexOf(arrSett.type) !== -1) {
+            T.portVisit.open(
+              _gameId,
+              _flagshipId,
+              _lastGameDoc,
+              patchedFlagship,
+              arrivedAtSettlement,
+              arrSett.name,
+              _apMax,
+              function () {
+                _showReachableCells();
+              }
+            );
+            return;
           }
-        );
-        return;
+        }
+        _showReachableCells();
       }
-    }
-
-    _showReachableCells();
+    );
   }
 
   // ── End Turn ─────────────────────────────────────────────────

--- a/public/apps/tortuga/state.js
+++ b/public/apps/tortuga/state.js
@@ -11,6 +11,7 @@
   T.DISCOVERY_RADIUS = 30;
   T.HIDDEN_COVE_RADIUS = 12;
   T.FRIENDLY_PORT_TYPES = ['colonial_port', 'free_port'];
+  T.EVENT_CHANCE = 0.25;
 
   T.state = {
     db: null,

--- a/public/apps/tortuga/tortuga.css
+++ b/public/apps/tortuga/tortuga.css
@@ -1575,3 +1575,95 @@
 .game-hud-visit-port:hover {
   background: rgba(102, 187, 106, 0.22);
 }
+
+/* ── Event modal ───────────────────────────────────────────── */
+
+.event-modal-root {
+  position: fixed;
+  inset: 0;
+  z-index: 1010;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  background: rgba(0, 0, 0, 0.72);
+}
+
+.event-type-badge {
+  display: inline-block;
+  padding: 0.15rem 0.55rem;
+  border-radius: 999px;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  margin-bottom: 0.85rem;
+}
+
+.event-type-badge--storm {
+  background: rgba(239, 83, 80, 0.15);
+  color: #ef5350;
+  border: 1px solid rgba(239, 83, 80, 0.35);
+}
+
+.event-type-badge--wreckage {
+  background: rgba(255, 183, 77, 0.12);
+  color: #ffb74d;
+  border: 1px solid rgba(255, 183, 77, 0.35);
+}
+
+.event-type-badge--sighting {
+  background: rgba(128, 203, 196, 0.12);
+  color: #80cbc4;
+  border: 1px solid rgba(128, 203, 196, 0.3);
+}
+
+.event-narrative {
+  font-size: 0.88rem;
+  color: #cdd5e0;
+  line-height: 1.6;
+  margin: 0 0 1.25rem;
+  font-style: italic;
+}
+
+.event-choices {
+  display: flex;
+  gap: 0.65rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.event-choice-btn {
+  padding: 0.35rem 1rem;
+  font-size: 0.82rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  border-radius: 5px;
+  cursor: pointer;
+  border: 1px solid rgba(255, 183, 77, 0.45);
+  background: rgba(255, 183, 77, 0.1);
+  color: #ffb74d;
+  font-family: inherit;
+  transition:
+    background 0.15s,
+    border-color 0.15s;
+}
+
+.event-choice-btn:hover {
+  background: rgba(255, 183, 77, 0.22);
+}
+
+.event-choice-btn--primary {
+  background: rgba(255, 183, 77, 0.18);
+}
+
+.event-choice-btn--secondary {
+  background: transparent;
+  border-color: rgba(144, 164, 174, 0.4);
+  color: #90a4ae;
+}
+
+.event-choice-btn--secondary:hover {
+  color: #e0e0e0;
+  border-color: rgba(224, 224, 224, 0.4);
+}


### PR DESCRIPTION
Implements the random event engine and non-combat event pack for Tortuga
MVP (issue #204). Events fire probabilistically (~25% per move, capped at
1 per turn) at the end of each move action, before port arrival routing.

Three event types shipped:
- Storm (squall / typhoon): deals hull + sails damage, clamped to 0
- Drifting wreckage (merchant / warship): two-choice salvage or sail on
- Sighting (sea turtle, ghost ship, whale pod, distant fleet): pure flavour

New files:
- play/event-packs.js — weighted event catalog with narratives and outcomes
- play/events.js — engine: roll, pick, modal, Firestore outcome write

Modified:
- game-map.js: inject T.events.tryFire in _finishMove, port-visit opens
  after event dismissal via callback chain
- state.js: add T.EVENT_CHANCE = 0.25
- index.html: load event-packs.js and events.js after port-visit.js
- tortuga.css: event modal styles (badge, narrative, choice buttons)

https://claude.ai/code/session_014r3Le1EnJ8CbpSx2Ji99Xy