### PR TITLE
Add game resume UI and campaign list to play lobby

### DIFF
--- a/public/apps/tortuga/app.js
+++ b/public/apps/tortuga/app.js
@@ -51,6 +51,25 @@
     T.newGame.show(worldId, T.firestore.decodeWorld(worldData));
   };
 
+  T._resumeGame = function (gameId, gameDoc) {
+    var flagshipId = gameDoc.flagshipId;
+    if (!flagshipId) return;
+    T.firestore
+      .updateGame(gameId, { lastPlayedAt: firebase.firestore.FieldValue.serverTimestamp() })
+      .catch(function (err) {
+        console.error('[tortuga] lastPlayedAt update failed', err);
+      });
+    T.firestore
+      .getFlagship(gameId, flagshipId)
+      .then(function (flagshipDoc) {
+        var worldData = T.firestore.decodeWorld(gameDoc.worldSnapshot);
+        T.gameMap.open(gameId, gameDoc, flagshipId, flagshipDoc, worldData);
+      })
+      .catch(function (err) {
+        console.error('[tortuga] resumeGame failed', err);
+      });
+  };
+
   // ── Knobs helpers ────────────────────────────────────────────
 
   function _escapeAttr(str) {
@@ -422,92 +441,15 @@
       });
   }
 
-  // §9 size caveat: Firestore docs are capped at 1 MB.
-  // For typical Azgaar maps (1000×600, ~50 coastline polygons, ~200 pts each),
-  // coastlines are ~50 KB; full payload is usually well under 200 KB.
-  // If Phase 2 maps grow larger, move coastlines to a subcollection.
-  //
-  // Firestore forbids nested arrays (array-in-array). All [y, x] coordinate
-  // pairs are stored as {y, x} objects. Coastlines (array of rings) are stored
-  // as [{pts: [{y,x},...]}]. Decode with _decodeWorldPayload when loading.
-  function _ptsToObjs(ring) {
-    return (ring || []).map(function (pt) {
-      return { y: pt[0], x: pt[1] };
-    });
-  }
-
   function _buildWorldPayload(name, description, era, shared) {
-    var w = _generatedWorld;
-    var b = w.bounds || [];
-    return {
+    var base = T.firestore.encodeWorld(_generatedWorld);
+    return Object.assign(base, {
       name: name,
       description: description || '',
       era: era,
       shared: !!shared,
-      sourceFormat: w.sourceFormat || 'azgaar-json',
-      dimensions: w.dimensions || {},
-      bounds: {
-        minY: (b[0] && b[0][0]) || 0,
-        minX: (b[0] && b[0][1]) || 0,
-        maxY: (b[1] && b[1][0]) || 0,
-        maxX: (b[1] && b[1][1]) || 0,
-      },
-      coastlines: (w.coastlines || []).map(function (ring) {
-        return { pts: _ptsToObjs(ring) };
-      }),
-      settlements: (w.settlements || []).map(function (s) {
-        var pos = s.position || s.pos;
-        return {
-          id: s.id,
-          name: s.name,
-          type: s.type || null,
-          position: pos ? { y: pos[0], x: pos[1] } : null,
-          parentFaction: s.parentFaction || s.faction || null,
-          baseSize: s.baseSize || null,
-          hidden: !!s.hidden,
-        };
-      }),
-      hazards: (w.hazards || []).map(function (h) {
-        return {
-          id: h.id,
-          type: h.type,
-          polygon: _ptsToObjs(h.polygon),
-          severity: h.severity || null,
-          name: h.name || null,
-        };
-      }),
-      factions: (w.factions || []).map(function (f) {
-        return {
-          id: f.id,
-          name: f.name,
-          archetype: f.archetype || null,
-          color: f.color || null,
-          homeSettlementId: f.homeSettlementId || null,
-        };
-      }),
-      tradeRoutes: (w.tradeRoutes || []).map(function (r) {
-        return { id: r.id, fromId: r.fromId, toId: r.toId, faction: r.faction || null };
-      }),
-      windCurrentZones: (w.windCurrentZones || []).map(function (wz) {
-        return {
-          id: wz.id,
-          name: wz.name || null,
-          direction: wz.direction || null,
-          strength: wz.strength || null,
-          bounds: _ptsToObjs(wz.bounds),
-        };
-      }),
-      factionTerritory: (w.factionTerritory || []).map(function (ft) {
-        return {
-          id: ft.id,
-          name: ft.name || null,
-          faction: ft.faction || null,
-          color: ft.color || null,
-          polygon: _ptsToObjs(ft.polygon),
-        };
-      }),
       createdByName: T.state.currentUser.displayName || T.state.currentUser.email || '',
-    };
+    });
   }
 
   // ── Init ─────────────────────────────────────────────────────
@@ -555,6 +497,17 @@
           if (e.target && e.target.id === 'knobs-save-btn') {
             _onSaveClick();
           }
+        });
+      }
+    }
+
+    if (mode === T.MODES.PLAY) {
+      var gameListEl = document.getElementById('game-list-play');
+      if (gameListEl) {
+        T.gameList.render(gameListEl, {
+          onResume: function (gameId, gameDoc) {
+            T._resumeGame(gameId, gameDoc);
+          },
         });
       }
     }

--- a/public/apps/tortuga/firestore.js
+++ b/public/apps/tortuga/firestore.js
@@ -243,5 +243,95 @@
           : null,
       });
     },
+
+    // ── Encode ────────────────────────────────────────────
+
+    encodeWorld: function (decoded) {
+      function ptsToObjs(ring) {
+        return (ring || []).map(function (pt) {
+          return { y: pt[0], x: pt[1] };
+        });
+      }
+      var b = decoded.bounds || [];
+      return {
+        name: decoded.name || '',
+        era: decoded.era || '',
+        sourceFormat: decoded.sourceFormat || 'azgaar-json',
+        dimensions: decoded.dimensions || {},
+        bounds: {
+          minY: (b[0] && b[0][0]) || 0,
+          minX: (b[0] && b[0][1]) || 0,
+          maxY: (b[1] && b[1][0]) || 0,
+          maxX: (b[1] && b[1][1]) || 0,
+        },
+        coastlines: (decoded.coastlines || []).map(function (ring) {
+          return { pts: ptsToObjs(ring) };
+        }),
+        settlements: (decoded.settlements || []).map(function (s) {
+          var pos = s.position || s.pos;
+          return {
+            id: s.id,
+            name: s.name,
+            type: s.type || null,
+            position: pos ? { y: pos[0], x: pos[1] } : null,
+            parentFaction: s.parentFaction || s.faction || null,
+            baseSize: s.baseSize || null,
+            hidden: !!s.hidden,
+          };
+        }),
+        hazards: (decoded.hazards || []).map(function (h) {
+          return {
+            id: h.id,
+            type: h.type,
+            polygon: ptsToObjs(h.polygon),
+            severity: h.severity || null,
+            name: h.name || null,
+          };
+        }),
+        factions: (decoded.factions || []).map(function (f) {
+          return {
+            id: f.id,
+            name: f.name,
+            archetype: f.archetype || null,
+            color: f.color || null,
+            homeSettlementId: f.homeSettlementId || null,
+          };
+        }),
+        tradeRoutes: (decoded.tradeRoutes || []).map(function (r) {
+          return { id: r.id, fromId: r.fromId, toId: r.toId, faction: r.faction || null };
+        }),
+        windCurrentZones: (decoded.windCurrentZones || []).map(function (wz) {
+          return {
+            id: wz.id,
+            name: wz.name || null,
+            direction: wz.direction || null,
+            strength: wz.strength || null,
+            bounds: ptsToObjs(wz.bounds),
+          };
+        }),
+        factionTerritory: (decoded.factionTerritory || []).map(function (ft) {
+          return {
+            id: ft.id,
+            name: ft.name || null,
+            faction: ft.faction || null,
+            color: ft.color || null,
+            polygon: ptsToObjs(ft.polygon),
+          };
+        }),
+      };
+    },
+
+    getFlagship: function (gameId, flagshipId) {
+      return T.state.db
+        .collection('tortuga_games')
+        .doc(gameId)
+        .collection('ships')
+        .doc(flagshipId)
+        .get()
+        .then(function (snap) {
+          if (!snap.exists) throw new Error('Flagship not found.');
+          return Object.assign({ id: snap.id }, snap.data());
+        });
+    },
   };
 })();

--- a/public/apps/tortuga/game-list.js
+++ b/public/apps/tortuga/game-list.js
@@ -1,0 +1,175 @@
+(function () {
+  'use strict';
+
+  window.Tortuga = window.Tortuga || {};
+  var T = window.Tortuga;
+
+  var PORTRAIT_SYMBOLS = {
+    anchor: '⚓',
+    skull: '💀',
+    compass: '🧭',
+    wheel: '⚙️',
+    telescope: '🔭',
+    map: '🗺️',
+  };
+
+  function _esc(str) {
+    return String(str || '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+  }
+
+  function _formatDate(ts) {
+    if (!ts || !ts.toDate) return '—';
+    return ts.toDate().toLocaleDateString(undefined, {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    });
+  }
+
+  function _renderSkeleton(container) {
+    container.innerHTML = '';
+    for (var i = 0; i < 2; i++) {
+      var card = document.createElement('div');
+      card.className = 'game-card game-card--skeleton';
+
+      var header = document.createElement('div');
+      header.className = 'game-card-header';
+
+      var portrait = document.createElement('div');
+      portrait.className = 'skeleton-block';
+      portrait.style.width = '2rem';
+      portrait.style.height = '2rem';
+      portrait.style.borderRadius = '4px';
+      portrait.style.flexShrink = '0';
+      header.appendChild(portrait);
+
+      var titleLine = document.createElement('div');
+      titleLine.className = 'skeleton-line skeleton-line--title';
+      header.appendChild(titleLine);
+
+      card.appendChild(header);
+
+      var subLine = document.createElement('div');
+      subLine.className = 'skeleton-line skeleton-line--sub';
+      card.appendChild(subLine);
+
+      container.appendChild(card);
+    }
+  }
+
+  function _renderEmpty(container) {
+    container.innerHTML = '';
+    var msg = document.createElement('p');
+    msg.className = 'game-list-empty';
+    msg.textContent = 'No campaigns yet. Start a new one below.';
+    container.appendChild(msg);
+  }
+
+  function _buildCard(game, onResume) {
+    var card = document.createElement('div');
+    card.className = 'game-card';
+
+    var header = document.createElement('div');
+    header.className = 'game-card-header';
+
+    var portraitEl = document.createElement('span');
+    portraitEl.className = 'game-card-portrait';
+    portraitEl.textContent =
+      PORTRAIT_SYMBOLS[(game.captain && game.captain.portrait) || ''] || '🏴‍☠️';
+    header.appendChild(portraitEl);
+
+    var captainEl = document.createElement('span');
+    captainEl.className = 'game-card-captain';
+    captainEl.textContent = (game.captain && game.captain.name) || 'Unknown Captain';
+    header.appendChild(captainEl);
+
+    card.appendChild(header);
+
+    var worldEl = document.createElement('div');
+    worldEl.className = 'game-card-world';
+    worldEl.textContent = game.worldName || 'Unknown World';
+    card.appendChild(worldEl);
+
+    var metaEl = document.createElement('div');
+    metaEl.className = 'game-card-meta';
+    metaEl.innerHTML =
+      '<span>Turn ' +
+      _esc(game.turnNumber != null ? game.turnNumber : '0') +
+      '</span>' +
+      '<span>Last played: ' +
+      _esc(_formatDate(game.lastPlayedAt)) +
+      '</span>';
+    card.appendChild(metaEl);
+
+    var actionsEl = document.createElement('div');
+    actionsEl.className = 'game-card-actions';
+
+    var continueBtn = document.createElement('button');
+    continueBtn.className = 'app-btn app-btn--sm';
+    continueBtn.setAttribute('type', 'button');
+    continueBtn.textContent = 'Continue';
+    continueBtn.addEventListener('click', function () {
+      onResume(game.id, game);
+    });
+    actionsEl.appendChild(continueBtn);
+
+    card.appendChild(actionsEl);
+
+    return card;
+  }
+
+  T.gameList = {
+    _container: null,
+    _onResume: null,
+    _unsub: null,
+
+    render: function (containerEl, opts) {
+      this.destroy();
+      this._container = containerEl;
+      this._onResume = (opts && opts.onResume) || null;
+
+      var self = this;
+
+      _renderSkeleton(containerEl);
+
+      this._unsub = T.firestore.listGames(function (games, err) {
+        if (err) {
+          console.error('[game-list] listGames error', err);
+          containerEl.innerHTML = '<p class="game-list-empty">Failed to load campaigns.</p>';
+          return;
+        }
+
+        if (!games.length) {
+          _renderEmpty(containerEl);
+          return;
+        }
+
+        games.sort(function (a, b) {
+          var ta = a.lastPlayedAt && a.lastPlayedAt.toMillis ? a.lastPlayedAt.toMillis() : 0;
+          var tb = b.lastPlayedAt && b.lastPlayedAt.toMillis ? b.lastPlayedAt.toMillis() : 0;
+          return tb - ta;
+        });
+
+        containerEl.innerHTML = '';
+        games.forEach(function (game) {
+          containerEl.appendChild(
+            _buildCard(game, function (id, doc) {
+              if (self._onResume) self._onResume(id, doc);
+            })
+          );
+        });
+      });
+    },
+
+    destroy: function () {
+      if (typeof this._unsub === 'function') {
+        this._unsub();
+        this._unsub = null;
+      }
+    },
+  };
+})();

--- a/public/apps/tortuga/index.html
+++ b/public/apps/tortuga/index.html
@@ -77,15 +77,33 @@
         <h1 class="app-title">The Account</h1>
         <p class="app-subtitle">On the account, Captain.</p>
         <div class="app-divider"></div>
-        <div class="world-list-section">
-          <div class="world-list-panel">
-            <div id="world-list-toolbar-play"></div>
-            <div id="world-list-play" class="world-list"></div>
+
+        <!-- Lobby: hidden while a game is active -->
+        <div class="play-lobby">
+          <!-- Your Campaigns -->
+          <div class="play-lobby-section">
+            <h2 class="play-lobby-heading">Your Campaigns</h2>
+            <div id="game-list-play" class="game-list"></div>
           </div>
-          <div id="world-preview-play" class="world-preview">
-            <p class="world-preview-placeholder">Select a world to preview</p>
+
+          <div class="app-divider"></div>
+
+          <!-- New Campaign (world chooser) -->
+          <div class="play-lobby-section">
+            <h2 class="play-lobby-heading">New Campaign</h2>
+            <div class="world-list-section">
+              <div class="world-list-panel">
+                <div id="world-list-toolbar-play"></div>
+                <div id="world-list-play" class="world-list"></div>
+              </div>
+              <div id="world-preview-play" class="world-preview">
+                <p class="world-preview-placeholder">Select a world to preview</p>
+              </div>
+            </div>
           </div>
         </div>
+        <!-- /.play-lobby -->
+
         <div id="new-game-panel" class="hidden"></div>
         <div id="game-map-panel" class="hidden">
           <div id="game-hud" class="game-hud"></div>
@@ -107,6 +125,7 @@
     <script src="/apps/tortuga/map-renderer.js"></script>
     <script src="/apps/tortuga/firestore.js"></script>
     <script src="/apps/tortuga/world-list.js"></script>
+    <script src="/apps/tortuga/game-list.js"></script>
     <script src="/apps/tortuga/cartographer/pathfinder.js"></script>
     <script src="/apps/tortuga/cartographer/overlay.js"></script>
     <script src="/apps/tortuga/cartographer/importer.js"></script>

--- a/public/apps/tortuga/new-game.js
+++ b/public/apps/tortuga/new-game.js
@@ -487,6 +487,7 @@
 
       var gameDoc = {
         worldId: this._worldId,
+        worldName: (this._worldData && this._worldData.name) || '',
         phase: 'exploration',
         turnNumber: 0,
         captain: {
@@ -501,6 +502,7 @@
         startingPortId: startingPortId,
         fog: [startingPortId],
         settings: { difficulty: 'normal', mythicEnabled: true, pacing: 'async' },
+        worldSnapshot: T.firestore.encodeWorld(this._worldData),
       };
 
       var flagshipDoc = {

--- a/public/apps/tortuga/play/game-map.js
+++ b/public/apps/tortuga/play/game-map.js
@@ -659,11 +659,11 @@
 
       // Show/hide panels.
       var shellPlayEl = document.getElementById('shell-play');
-      var worldListSection = shellPlayEl && shellPlayEl.querySelector('.world-list-section');
+      var lobbyEl = shellPlayEl && shellPlayEl.querySelector('.play-lobby');
       var newGamePanel = document.getElementById('new-game-panel');
       var gameMapPanel = document.getElementById('game-map-panel');
 
-      if (worldListSection) worldListSection.classList.add('hidden');
+      if (lobbyEl) lobbyEl.classList.add('hidden');
       if (newGamePanel) {
         newGamePanel.classList.add('hidden');
         newGamePanel.innerHTML = '';
@@ -722,8 +722,8 @@
       if (gameMapPanel) gameMapPanel.classList.add('hidden');
 
       var shellPlayEl = document.getElementById('shell-play');
-      var worldListSection = shellPlayEl && shellPlayEl.querySelector('.world-list-section');
-      if (worldListSection) worldListSection.classList.remove('hidden');
+      var lobbyEl = shellPlayEl && shellPlayEl.querySelector('.play-lobby');
+      if (lobbyEl) lobbyEl.classList.remove('hidden');
     },
   };
 })();

--- a/public/apps/tortuga/tortuga.css
+++ b/public/apps/tortuga/tortuga.css
@@ -1667,3 +1667,92 @@
   color: #e0e0e0;
   border-color: rgba(224, 224, 224, 0.4);
 }
+
+/* ── Play lobby ─────────────────────────────────────────────── */
+
+.play-lobby-section {
+  margin: 1rem 0;
+}
+
+.play-lobby-heading {
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: var(--color-text-muted, #90a4ae);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin: 0 0 0.75rem;
+}
+
+/* ── Game list ──────────────────────────────────────────────── */
+
+.game-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 0.75rem;
+}
+
+.game-list-empty {
+  color: var(--color-text-muted, #888);
+  font-style: italic;
+  font-size: 0.88rem;
+  margin: 0;
+}
+
+.game-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 0.9rem 1rem;
+  background: var(--color-surface, #1e1e2e);
+  border: 1px solid var(--color-border, #333);
+  border-radius: 8px;
+  transition: border-color 0.15s;
+}
+
+.game-card:hover {
+  border-color: rgba(255, 183, 77, 0.45);
+}
+
+.game-card-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.game-card-portrait {
+  font-size: 1.4rem;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.game-card-captain {
+  font-weight: 700;
+  font-size: 0.95rem;
+  color: var(--color-text, #e0e0e0);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.game-card-world {
+  font-size: 0.78rem;
+  color: var(--color-text-muted, #888);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.game-card-meta {
+  display: flex;
+  gap: 1rem;
+  font-size: 0.75rem;
+  color: var(--color-text-muted, #888);
+}
+
+.game-card-actions {
+  margin-top: 0.35rem;
+}
+
+.game-card--skeleton {
+  pointer-events: none;
+}


### PR DESCRIPTION
## Summary

Adds a campaign list UI to the play lobby that displays saved games and allows players to resume them. This includes a new `game-list.js` module for rendering game cards, integration with Firestore to fetch and display campaigns, and UI styling for the lobby.

## Key Changes

- **New `game-list.js` module** — Renders a grid of game cards showing captain name, world name, turn number, and last played date. Includes skeleton loading state and empty state messaging.
- **Game card styling** — Added `.game-card`, `.game-card-header`, `.game-card-portrait`, `.game-card-meta`, and related CSS classes to `tortuga.css` for a cohesive card-based layout.
- **Play lobby restructuring** — Reorganized `index.html` to separate "Your Campaigns" (game list) from "New Campaign" (world chooser) sections with a new `.play-lobby` container.
- **Resume game flow** — Added `T._resumeGame()` in `app.js` to handle loading a saved game, updating `lastPlayedAt` timestamp, and opening the game map.
- **Firestore helpers** — Extracted world encoding logic into `T.firestore.encodeWorld()` for reuse, and added `T.firestore.getFlagship()` to fetch flagship data when resuming.
- **Game document enrichment** — Updated `new-game.js` to store `worldName` in game documents for display in the campaign list.
- **Panel visibility** — Updated `game-map.js` to hide/show the `.play-lobby` container (instead of `.world-list-section`) when entering/exiting game mode.

## Implementation Details

- Game cards display a pirate emoji portrait (anchor, skull, compass, etc.) based on captain portrait type, with a fallback to the pirate flag emoji.
- Games are sorted by `lastPlayedAt` in descending order (most recent first).
- The game list uses a responsive CSS Grid with `minmax(240px, 1fr)` columns for flexible layout.
- Skeleton loaders appear while Firestore data is being fetched; real-time listener is properly cleaned up on destroy.
- All HTML content is escaped to prevent XSS; dates are formatted using `toLocaleDateString()`.

https://claude.ai/code/session_01SpU73B9ag679CFRfEM2v6H