### PR TITLE
feat(tortuga): Captain's log — scrolling narrative of player actions (#206)

### DIFF
--- a/public/apps/tortuga/firestore.js
+++ b/public/apps/tortuga/firestore.js
@@ -333,5 +333,32 @@
           return Object.assign({ id: snap.id }, snap.data());
         });
     },
+
+    // ── Captain's Log ─────────────────────────────────────
+
+    addLogEntry: function (gameId, entry) {
+      var ts = firebase.firestore.FieldValue.serverTimestamp();
+      return T.state.db
+        .collection('tortuga_games')
+        .doc(gameId)
+        .collection('log')
+        .add(Object.assign({}, entry, { createdAt: ts }));
+    },
+
+    loadLogEntries: function (gameId, options) {
+      var opts = options || {};
+      var query = T.state.db
+        .collection('tortuga_games')
+        .doc(gameId)
+        .collection('log')
+        .orderBy('createdAt', 'desc');
+      if (opts.startAfter) query = query.startAfter(opts.startAfter);
+      query = query.limit(opts.limit || 50);
+      return query.get().then(function (snap) {
+        return snap.docs.map(function (d) {
+          return Object.assign({ id: d.id }, d.data());
+        });
+      });
+    },
   };
 })();

--- a/public/apps/tortuga/index.html
+++ b/public/apps/tortuga/index.html
@@ -135,6 +135,7 @@
     <script src="/apps/tortuga/play/port-visit.js"></script>
     <script src="/apps/tortuga/play/event-packs.js"></script>
     <script src="/apps/tortuga/play/events.js"></script>
+    <script src="/apps/tortuga/play/captain-log.js"></script>
     <script src="/apps/tortuga/new-game.js"></script>
     <script src="/apps/tortuga/app.js"></script>
 

--- a/public/apps/tortuga/play/captain-log.js
+++ b/public/apps/tortuga/play/captain-log.js
@@ -1,0 +1,194 @@
+(function () {
+  'use strict';
+
+  window.Tortuga = window.Tortuga || {};
+  var T = window.Tortuga;
+
+  var TYPE_FILTERS = ['all', 'move', 'discovery', 'port_visit', 'event'];
+
+  var TYPE_LABELS = {
+    all: 'All',
+    move: 'Move',
+    discovery: 'Discovery',
+    port_visit: 'Port',
+    event: 'Event',
+  };
+
+  var TYPE_BADGE_CLASSES = {
+    move: '',
+    discovery: 'log-badge--discovery',
+    port_visit: 'log-badge--port',
+    event: 'log-badge--event',
+  };
+
+  var _overlayEl = null;
+  var _allEntries = [];
+  var _filter = { search: '', type: null };
+  var _pageSize = 20;
+  var _displayedCount = 0;
+
+  function _esc(str) {
+    return String(str == null ? '' : str)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+  }
+
+  function _getFiltered() {
+    return _allEntries.filter(function (entry) {
+      if (_filter.type && entry.type !== _filter.type) return false;
+      if (_filter.search) {
+        var q = _filter.search;
+        if ((entry.summary || '').toLowerCase().indexOf(q) === -1) return false;
+      }
+      return true;
+    });
+  }
+
+  function _renderEntries() {
+    var resultsEl = _overlayEl && _overlayEl.querySelector('#log-results');
+    if (!resultsEl) return;
+
+    var filtered = _getFiltered();
+    var toShow = filtered.slice(0, _displayedCount + _pageSize);
+    _displayedCount = toShow.length;
+
+    if (toShow.length === 0) {
+      resultsEl.innerHTML = '<p class="captain-log-empty">No entries found.</p>';
+      return;
+    }
+
+    var html = '';
+    for (var i = 0; i < toShow.length; i++) {
+      var entry = toShow[i];
+      var badgeCls = TYPE_BADGE_CLASSES[entry.type] || '';
+      html +=
+        '<div class="captain-log-entry">' +
+        '<div class="captain-log-entry-meta">' +
+        '<span class="captain-log-badge ' +
+        badgeCls +
+        '">' +
+        _esc(TYPE_LABELS[entry.type] || entry.type || '?') +
+        '</span>' +
+        '<span class="captain-log-turn">Turn ' +
+        (entry.turn != null ? entry.turn : '?') +
+        '</span>' +
+        '</div>' +
+        '<div class="captain-log-summary">' +
+        _esc(entry.summary || '') +
+        '</div>' +
+        '</div>';
+    }
+
+    if (toShow.length < filtered.length) {
+      html +=
+        '<button type="button" class="btn btn-secondary captain-log-load-more">' +
+        'Load more (' +
+        (filtered.length - toShow.length) +
+        ' remaining)</button>';
+    }
+
+    resultsEl.innerHTML = html;
+
+    var loadMore = resultsEl.querySelector('.captain-log-load-more');
+    if (loadMore) {
+      loadMore.addEventListener('click', function () {
+        _renderEntries();
+      });
+    }
+  }
+
+  function _renderUI(container, gameId) {
+    var html =
+      '<div class="captain-log-dialog">' +
+      '<div class="captain-log-header">' +
+      '<span class="captain-log-title">Captain\'s Log</span>' +
+      '<button type="button" class="captain-log-close" id="captain-log-close-btn" aria-label="Close">&times;</button>' +
+      '</div>' +
+      '<div style="margin-bottom:0.5rem">' +
+      '<input type="text" class="form-input captain-log-search" placeholder="Search log&hellip;" />' +
+      '</div>' +
+      '<div class="captain-log-filters">';
+    for (var i = 0; i < TYPE_FILTERS.length; i++) {
+      var f = TYPE_FILTERS[i];
+      html +=
+        '<button type="button" class="captain-log-filter-btn" data-type="' +
+        f +
+        '">' +
+        _esc(TYPE_LABELS[f]) +
+        '</button>';
+    }
+    html +=
+      '</div>' +
+      '<div id="log-results" class="captain-log-results">' +
+      '<p class="captain-log-empty">Loading&hellip;</p>' +
+      '</div>' +
+      '</div>';
+
+    container.innerHTML = html;
+
+    container.querySelector('#captain-log-close-btn').addEventListener('click', function () {
+      T.captainLog.close();
+    });
+
+    var searchInput = container.querySelector('.captain-log-search');
+    searchInput.addEventListener('input', function () {
+      _filter.search = searchInput.value.trim().toLowerCase();
+      _displayedCount = 0;
+      _renderEntries();
+    });
+
+    container.querySelectorAll('.captain-log-filter-btn').forEach(function (btn) {
+      btn.addEventListener('click', function () {
+        var type = btn.dataset.type;
+        _filter.type = type === 'all' ? null : type;
+        _displayedCount = 0;
+        container.querySelectorAll('.captain-log-filter-btn').forEach(function (b) {
+          b.classList.toggle('captain-log-filter-btn--active', b.dataset.type === type);
+        });
+        _renderEntries();
+      });
+    });
+
+    // Default "All" active
+    var allBtn = container.querySelector('.captain-log-filter-btn[data-type="all"]');
+    if (allBtn) allBtn.classList.add('captain-log-filter-btn--active');
+
+    T.firestore
+      .loadLogEntries(gameId, { limit: 100 })
+      .then(function (entries) {
+        _allEntries = entries;
+        _displayedCount = 0;
+        _renderEntries();
+      })
+      .catch(function (err) {
+        console.error('[captain-log] load failed', err);
+        var resultsEl = container.querySelector('#log-results');
+        if (resultsEl) resultsEl.innerHTML = '<p class="captain-log-empty">Failed to load log.</p>';
+      });
+  }
+
+  T.captainLog = {
+    open: function (gameId) {
+      if (_overlayEl) T.captainLog.close();
+
+      _allEntries = [];
+      _filter = { search: '', type: null };
+      _displayedCount = 0;
+
+      _overlayEl = document.createElement('div');
+      _overlayEl.className = 'captain-log-root';
+      document.body.appendChild(_overlayEl);
+
+      _renderUI(_overlayEl, gameId);
+    },
+
+    close: function () {
+      if (_overlayEl && _overlayEl.parentNode) {
+        _overlayEl.parentNode.removeChild(_overlayEl);
+      }
+      _overlayEl = null;
+    },
+  };
+})();

--- a/public/apps/tortuga/play/events.js
+++ b/public/apps/tortuga/play/events.js
@@ -44,7 +44,7 @@
 
   // ── Outcome resolution ───────────────────────────────────────
 
-  function _applyOutcome(outcome, ctx, doneCb) {
+  function _applyOutcome(outcome, ctx, doneCb, eventMeta) {
     _closeModal();
 
     var patch = {};
@@ -98,6 +98,22 @@
         console.error('[events] updateGame (lastEventTurn) failed', err);
       })
     );
+
+    if (eventMeta) {
+      T.firestore
+        .addLogEntry(ctx.gameId, {
+          turn: currentTurn,
+          type: 'event',
+          summary: eventMeta.title + ': ' + eventMeta.choiceLabel,
+          payload: Object.assign(
+            { eventTitle: eventMeta.title, choiceLabel: eventMeta.choiceLabel },
+            outcome
+          ),
+        })
+        .catch(function (err) {
+          console.error('[events] addLogEntry failed', err);
+        });
+    }
 
     Promise.all(promises).then(doneCb).catch(doneCb);
   }
@@ -166,7 +182,8 @@
       btn.addEventListener('click', function () {
         var choiceId = btn.getAttribute('data-choice-id');
         var choice = choiceMap[choiceId];
-        _applyOutcome(choice ? choice.outcome : {}, ctx, doneCb);
+        var meta = { title: event.title, choiceLabel: choice ? choice.label : '' };
+        _applyOutcome(choice ? choice.outcome : {}, ctx, doneCb, meta);
       });
     });
   }

--- a/public/apps/tortuga/play/game-map.js
+++ b/public/apps/tortuga/play/game-map.js
@@ -305,6 +305,7 @@
         ? '<button class="game-hud-visit-port" id="game-hud-visit-port" type="button">Visit Port</button>'
         : '') +
       '<button class="game-hud-end-turn" id="game-hud-end-turn" type="button">End Turn</button>' +
+      '<button class="game-hud-log-btn" id="game-hud-log-btn" type="button">Log</button>' +
       '</div>';
 
     // Re-attach button listeners after innerHTML replacement.
@@ -312,6 +313,11 @@
     if (endTurnBtn) endTurnBtn.addEventListener('click', _endTurn);
     var visitPortBtn = document.getElementById('game-hud-visit-port');
     if (visitPortBtn) visitPortBtn.addEventListener('click', _openPortVisit);
+    var logBtn = document.getElementById('game-hud-log-btn');
+    if (logBtn)
+      logBtn.addEventListener('click', function () {
+        T.captainLog.open(_gameId);
+      });
 
     if (savedMoveInfo) {
       var confirmBtn = document.getElementById('game-hud-move-confirm');
@@ -437,6 +443,7 @@
   function _confirmMove() {
     if (!_pendingMoveResult || _movementAnimating) return;
     var result = _pendingMoveResult;
+    var fromPos = _currentPosition;
     _pendingMoveResult = null;
     _setMoveInfo('');
 
@@ -447,7 +454,7 @@
     function _step() {
       stepIndex++;
       if (stepIndex >= gridPath.length) {
-        _finishMove(gridPath[gridPath.length - 1], result.steps);
+        _finishMove(gridPath[gridPath.length - 1], result.steps, fromPos);
         return;
       }
       var pos = gridPath[stepIndex];
@@ -459,7 +466,7 @@
     setTimeout(_step, 150);
   }
 
-  function _finishMove(finalPos, stepsUsed) {
+  function _finishMove(finalPos, stepsUsed, fromPos) {
     _movementAnimating = false;
     _clearPathPreview();
 
@@ -520,6 +527,43 @@
       .catch(function (err) {
         console.error('[game-map] updateFlagship failed', err);
       });
+
+    var currentTurn = (_lastGameDoc && _lastGameDoc.turnNumber) || 0;
+    var arrSettlement = arrivedAtSettlement ? _settlementIndex[arrivedAtSettlement] : null;
+    var moveSummary = arrSettlement
+      ? 'Sailed to ' + arrSettlement.name + ' (' + stepsUsed + ' AP)'
+      : 'Sailed ' + stepsUsed + ' league' + (stepsUsed !== 1 ? 's' : '');
+    T.firestore
+      .addLogEntry(_gameId, {
+        turn: currentTurn,
+        type: 'move',
+        summary: moveSummary,
+        payload: {
+          from: fromPos ? { y: fromPos[0], x: fromPos[1] } : null,
+          to: { y: finalPos[0], x: finalPos[1] },
+          stepsUsed: stepsUsed,
+          settlementId: arrivedAtSettlement || null,
+        },
+      })
+      .catch(function (err) {
+        console.error('[game-map] addLogEntry (move) failed', err);
+      });
+
+    if (newlyDiscovered.length > 0) {
+      var discNames = newlyDiscovered.map(function (id) {
+        return (_settlementIndex[id] && _settlementIndex[id].name) || 'Unknown';
+      });
+      T.firestore
+        .addLogEntry(_gameId, {
+          turn: currentTurn,
+          type: 'discovery',
+          summary: 'Discovered: ' + discNames.join(', '),
+          payload: { settlementIds: newlyDiscovered, settlementNames: discNames },
+        })
+        .catch(function (err) {
+          console.error('[game-map] addLogEntry (discovery) failed', err);
+        });
+    }
 
     var patchedFlagship = Object.assign({}, _lastFlagshipDoc, {
       apRemaining: newAP,

--- a/public/apps/tortuga/play/port-visit.js
+++ b/public/apps/tortuga/play/port-visit.js
@@ -636,6 +636,18 @@
       document.body.appendChild(_overlayEl);
 
       _render();
+
+      var portTurn = (gameDoc && gameDoc.turnNumber) || 0;
+      T.firestore
+        .addLogEntry(gameId, {
+          turn: portTurn,
+          type: 'port_visit',
+          summary: 'Made port at ' + (settlementName || 'Unknown Port'),
+          payload: { settlementId: settlementId || null, settlementName: settlementName || '' },
+        })
+        .catch(function (err) {
+          console.error('[port-visit] addLogEntry failed', err);
+        });
     },
 
     close: function () {

--- a/public/apps/tortuga/tortuga.css
+++ b/public/apps/tortuga/tortuga.css
@@ -1770,3 +1770,184 @@
 .game-card--skeleton {
   pointer-events: none;
 }
+
+/* ── Game HUD: Log button ──────────────────────────────────── */
+
+.game-hud-log-btn {
+  padding: 0.25rem 0.75rem;
+  background: rgba(100, 181, 246, 0.1);
+  color: #64b5f6;
+  border: 1px solid rgba(100, 181, 246, 0.35);
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+}
+
+.game-hud-log-btn:hover {
+  background: rgba(100, 181, 246, 0.2);
+}
+
+/* ── Captain's Log overlay ─────────────────────────────────── */
+
+.captain-log-root {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: flex-start;
+  justify-content: flex-end;
+  padding: 1rem;
+  background: rgba(0, 0, 0, 0.6);
+}
+
+.captain-log-dialog {
+  background: #131929;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 12px;
+  padding: 1.25rem;
+  width: 100%;
+  max-width: 380px;
+  max-height: 85vh;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.captain-log-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.85rem;
+}
+
+.captain-log-title {
+  font-size: 1rem;
+  font-weight: 700;
+  color: #e0e0e0;
+  letter-spacing: 0.03em;
+}
+
+.captain-log-close {
+  background: none;
+  border: none;
+  color: #888;
+  font-size: 1.3rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0.1rem 0.3rem;
+}
+
+.captain-log-close:hover {
+  color: #e0e0e0;
+}
+
+.captain-log-search {
+  width: 100%;
+  font-size: 0.82rem;
+  padding: 0.4rem 0.6rem;
+  margin-bottom: 0.5rem;
+}
+
+.captain-log-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+  margin-bottom: 0.75rem;
+}
+
+.captain-log-filter-btn {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 4px;
+  color: #aaa;
+  font-size: 0.72rem;
+  padding: 0.2rem 0.55rem;
+  cursor: pointer;
+}
+
+.captain-log-filter-btn:hover {
+  background: rgba(255, 255, 255, 0.1);
+  color: #e0e0e0;
+}
+
+.captain-log-filter-btn--active {
+  background: rgba(100, 181, 246, 0.15);
+  border-color: rgba(100, 181, 246, 0.45);
+  color: #64b5f6;
+  font-weight: 700;
+}
+
+.captain-log-results {
+  overflow-y: auto;
+  flex: 1;
+  min-height: 0;
+}
+
+.captain-log-entry {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  border-radius: 6px;
+  padding: 0.55rem 0.75rem;
+  margin-bottom: 0.4rem;
+}
+
+.captain-log-entry-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.25rem;
+}
+
+.captain-log-badge {
+  font-size: 0.68rem;
+  font-weight: 600;
+  padding: 0.1rem 0.45rem;
+  border-radius: 3px;
+  background: rgba(255, 255, 255, 0.1);
+  color: #ccc;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.log-badge--discovery {
+  background: rgba(102, 187, 106, 0.18);
+  color: #66bb6a;
+}
+
+.log-badge--port {
+  background: rgba(255, 183, 77, 0.18);
+  color: #ffb74d;
+}
+
+.log-badge--event {
+  background: rgba(239, 83, 80, 0.18);
+  color: #ef5350;
+}
+
+.captain-log-turn {
+  font-size: 0.7rem;
+  color: #666;
+}
+
+.captain-log-summary {
+  font-size: 0.82rem;
+  color: #ccc;
+  line-height: 1.4;
+}
+
+.captain-log-empty {
+  font-size: 0.82rem;
+  color: #666;
+  text-align: center;
+  padding: 1.5rem 0;
+}
+
+.captain-log-load-more {
+  width: 100%;
+  padding: 0.5rem;
+  font-size: 0.8rem;
+  margin-top: 0.4rem;
+}


### PR DESCRIPTION
Adds a persistent log subcollection (tortuga_games/{gameId}/log/{entryId})
that records every significant game action: ship movements, settlement
discoveries, port arrivals, and random events. A HUD Log button opens a
slide-over panel with type filters, search, and pagination (20 per page).

- firestore.js: addLogEntry() and loadLogEntries() for the log subcollection
- captain-log.js: new UI module — overlay panel, filter buttons, search, pagination
- game-map.js: write move + discovery entries in _finishMove; add HUD Log button
- port-visit.js: write port_visit entry on port arrival
- events.js: write event entry in _applyOutcome (threads eventMeta through _openModal)
- index.html: load captain-log.js after events.js
- tortuga.css: styles for Log HUD button and log overlay panel

Firestore rules unchanged — wildcard subcollection rule already covers log.

https://claude.ai/code/session_017D6RtoUs2FGj1Meiaoeha2