### PR TITLE
feat(tortuga): difficulty toggle — picker in new-game flow, supply consumption, in-game settings (#207)

### DIFF
--- a/public/apps/tortuga/new-game.js
+++ b/public/apps/tortuga/new-game.js
@@ -137,6 +137,7 @@
     _selectedPortrait: PORTRAITS[0].id,
     _selectedShipClass: null,
     _selectedPortId: null,
+    _selectedDifficulty: 'normal',
     _portMap: null,
     _portMarkers: null,
     _worldId: null,
@@ -150,6 +151,7 @@
       this._selectedPortrait = PORTRAITS[0].id;
       this._selectedShipClass = Object.keys(T.SHIP_TYPES)[0];
       this._selectedPortId = null;
+      this._selectedDifficulty = 'normal';
       this._captainName = '';
       this._captainBio = '';
 
@@ -217,7 +219,7 @@
         '<p class="new-game-error hidden" id="ng-error"></p>' +
         '<div class="new-game-actions">' +
         '<button class="btn-cancel" id="ng-cancel" type="button">Cancel</button>' +
-        '<button class="app-btn app-btn--sm" id="ng-next" type="button">Next: Choose Port</button>' +
+        '<button class="app-btn app-btn--sm" id="ng-next" type="button">Next: Difficulty</button>' +
         '</div>' +
         '</div>';
 
@@ -290,7 +292,75 @@
 
       this._captainName = captainName;
       this._captainBio = (bioEl && bioEl.value.trim()) || '';
-      this._renderPortStep(friendlyPorts);
+      this._renderDifficultyStep(friendlyPorts);
+    },
+
+    _renderDifficultyStep: function (friendlyPorts) {
+      var self = this;
+      var panelEl = this._panelEl;
+      if (!panelEl) return;
+      var worldName = (this._worldData && this._worldData.name) || 'Unknown World';
+
+      var difficultyCards = Object.keys(T.DIFFICULTY_LEVELS)
+        .map(function (id) {
+          var d = T.DIFFICULTY_LEVELS[id];
+          var isSelected = id === self._selectedDifficulty;
+          return (
+            '<button class="difficulty-card' +
+            (isSelected ? ' difficulty-card--selected' : '') +
+            '" type="button"' +
+            ' data-difficulty="' +
+            _escapeAttr(id) +
+            '"' +
+            ' aria-pressed="' +
+            (isSelected ? 'true' : 'false') +
+            '">' +
+            '<span class="difficulty-card-label">' +
+            _escapeHtml(d.label) +
+            '</span>' +
+            '<span class="difficulty-card-desc">' +
+            _escapeHtml(d.description) +
+            '</span>' +
+            '</button>'
+          );
+        })
+        .join('');
+
+      panelEl.innerHTML =
+        '<div class="new-game-panel">' +
+        '<div class="new-game-world-badge">World: ' +
+        _escapeAttr(worldName) +
+        '</div>' +
+        '<h2 class="new-game-title">Choose Difficulty</h2>' +
+        '<div class="difficulty-picker">' +
+        difficultyCards +
+        '</div>' +
+        '<p class="new-game-error hidden" id="ng-error"></p>' +
+        '<div class="new-game-actions">' +
+        '<button class="btn-cancel" id="ng-back" type="button">Back</button>' +
+        '<button class="app-btn app-btn--sm" id="ng-next" type="button">Next: Choose Port</button>' +
+        '</div>' +
+        '</div>';
+
+      panelEl.querySelectorAll('.difficulty-card').forEach(function (card) {
+        card.addEventListener('click', function () {
+          self._selectedDifficulty = card.getAttribute('data-difficulty');
+          panelEl.querySelectorAll('.difficulty-card').forEach(function (c) {
+            c.classList.remove('difficulty-card--selected');
+            c.setAttribute('aria-pressed', 'false');
+          });
+          card.classList.add('difficulty-card--selected');
+          card.setAttribute('aria-pressed', 'true');
+        });
+      });
+
+      document.getElementById('ng-back').addEventListener('click', function () {
+        self._renderStep1();
+      });
+
+      document.getElementById('ng-next').addEventListener('click', function () {
+        self._renderPortStep(friendlyPorts);
+      });
     },
 
     _renderPortStep: function (friendlyPorts) {
@@ -344,7 +414,7 @@
           self._portMap = null;
         }
         self._portMarkers = [];
-        self._renderStep1();
+        self._renderDifficultyStep(friendlyPorts);
       });
 
       document.getElementById('ng-confirm').addEventListener('click', function () {
@@ -501,7 +571,7 @@
         flagshipId: null,
         startingPortId: startingPortId,
         fog: [startingPortId],
-        settings: { difficulty: 'normal', mythicEnabled: true, pacing: 'async' },
+        settings: { difficulty: this._selectedDifficulty, mythicEnabled: true, pacing: 'async' },
         worldSnapshot: T.firestore.encodeWorld(this._worldData),
       };
 

--- a/public/apps/tortuga/play/game-map.js
+++ b/public/apps/tortuga/play/game-map.js
@@ -306,6 +306,7 @@
         : '') +
       '<button class="game-hud-end-turn" id="game-hud-end-turn" type="button">End Turn</button>' +
       '<button class="game-hud-log-btn" id="game-hud-log-btn" type="button">Log</button>' +
+      '<button class="game-hud-settings-btn" id="game-hud-settings-btn" type="button">Settings</button>' +
       '</div>';
 
     // Re-attach button listeners after innerHTML replacement.
@@ -318,6 +319,8 @@
       logBtn.addEventListener('click', function () {
         T.captainLog.open(_gameId);
       });
+    var settingsBtn = document.getElementById('game-hud-settings-btn');
+    if (settingsBtn) settingsBtn.addEventListener('click', _openSettingsPanel);
 
     if (savedMoveInfo) {
       var confirmBtn = document.getElementById('game-hud-move-confirm');
@@ -603,11 +606,133 @@
     );
   }
 
+  // ── Supply consumption ───────────────────────────────────────
+
+  function _consumeSupplies() {
+    var difficulty =
+      (_lastGameDoc && _lastGameDoc.settings && _lastGameDoc.settings.difficulty) || 'normal';
+    var mod = (T.DIFFICULTY_LEVELS[difficulty] || T.DIFFICULTY_LEVELS.normal).supplyRate;
+    var crew = (_lastFlagshipDoc && _lastFlagshipDoc.crew && _lastFlagshipDoc.crew.current) || 1;
+    var current = (_lastFlagshipDoc && _lastFlagshipDoc.supplies) || {};
+    var updates = {};
+    Object.keys(T.SUPPLY_BASE_RATES).forEach(function (key) {
+      var consumed = Math.round(crew * T.SUPPLY_BASE_RATES[key] * mod);
+      if (consumed > 0) {
+        updates['supplies.' + key] = Math.max(0, (current[key] || 0) - consumed);
+      }
+    });
+    if (Object.keys(updates).length === 0) return;
+    T.firestore.updateFlagship(_gameId, _flagshipId, updates).catch(function (err) {
+      console.error('[game-map] supply consumption failed', err);
+    });
+  }
+
+  // ── Settings panel ───────────────────────────────────────────
+
+  function _openSettingsPanel() {
+    var currentDifficulty =
+      (_lastGameDoc && _lastGameDoc.settings && _lastGameDoc.settings.difficulty) || 'normal';
+    var selectedDifficulty = currentDifficulty;
+
+    var overlayEl = document.createElement('div');
+    overlayEl.className = 'settings-modal-root';
+
+    var difficultyCards = Object.keys(T.DIFFICULTY_LEVELS)
+      .map(function (id) {
+        var d = T.DIFFICULTY_LEVELS[id];
+        var isSelected = id === currentDifficulty;
+        return (
+          '<button class="difficulty-card' +
+          (isSelected ? ' difficulty-card--selected' : '') +
+          '" type="button" data-difficulty="' +
+          id +
+          '" aria-pressed="' +
+          (isSelected ? 'true' : 'false') +
+          '">' +
+          '<span class="difficulty-card-label">' +
+          _escapeHtml(d.label) +
+          '</span>' +
+          '<span class="difficulty-card-desc">' +
+          _escapeHtml(d.description) +
+          '</span>' +
+          '</button>'
+        );
+      })
+      .join('');
+
+    overlayEl.innerHTML =
+      '<div class="settings-dialog">' +
+      '<div class="settings-dialog-header">' +
+      '<span class="settings-dialog-title">Game Settings</span>' +
+      '<button class="port-modal-close" id="settings-close" type="button" aria-label="Close">✕</button>' +
+      '</div>' +
+      '<div class="settings-section">' +
+      '<p class="settings-section-title">Difficulty</p>' +
+      '<p class="settings-hint">Changes apply to future turns.</p>' +
+      '<div class="difficulty-picker">' +
+      difficultyCards +
+      '</div>' +
+      '</div>' +
+      '<p class="settings-error hidden" id="settings-error"></p>' +
+      '<div class="settings-actions">' +
+      '<button class="btn-cancel" id="settings-cancel" type="button">Cancel</button>' +
+      '<button class="app-btn app-btn--sm" id="settings-save" type="button">Save</button>' +
+      '</div>' +
+      '</div>';
+
+    document.body.appendChild(overlayEl);
+
+    overlayEl.querySelectorAll('.difficulty-card').forEach(function (card) {
+      card.addEventListener('click', function () {
+        selectedDifficulty = card.getAttribute('data-difficulty');
+        overlayEl.querySelectorAll('.difficulty-card').forEach(function (c) {
+          c.classList.remove('difficulty-card--selected');
+          c.setAttribute('aria-pressed', 'false');
+        });
+        card.classList.add('difficulty-card--selected');
+        card.setAttribute('aria-pressed', 'true');
+      });
+    });
+
+    function _close() {
+      if (overlayEl.parentNode) overlayEl.parentNode.removeChild(overlayEl);
+    }
+
+    document.getElementById('settings-close').addEventListener('click', _close);
+    document.getElementById('settings-cancel').addEventListener('click', _close);
+
+    document.getElementById('settings-save').addEventListener('click', function () {
+      var saveBtn = document.getElementById('settings-save');
+      if (saveBtn) {
+        saveBtn.disabled = true;
+        saveBtn.textContent = 'Saving…';
+      }
+      T.firestore
+        .updateGame(_gameId, { 'settings.difficulty': selectedDifficulty })
+        .then(function () {
+          _close();
+        })
+        .catch(function (err) {
+          console.error('[game-map] settings save failed', err);
+          var errEl = document.getElementById('settings-error');
+          if (errEl) {
+            errEl.textContent = 'Save failed: ' + err.message;
+            errEl.classList.remove('hidden');
+          }
+          if (saveBtn) {
+            saveBtn.disabled = false;
+            saveBtn.textContent = 'Save';
+          }
+        });
+    });
+  }
+
   // ── End Turn ─────────────────────────────────────────────────
 
   function _endTurn() {
     if (_movementAnimating) return;
     _clearPathPreview();
+    _consumeSupplies();
     _apRemaining = _apMax;
 
     T.firestore.updateFlagship(_gameId, _flagshipId, { apRemaining: _apMax }).catch(function (err) {

--- a/public/apps/tortuga/state.js
+++ b/public/apps/tortuga/state.js
@@ -13,6 +13,39 @@
   T.FRIENDLY_PORT_TYPES = ['colonial_port', 'free_port'];
   T.EVENT_CHANCE = 0.25;
 
+  T.DIFFICULTY_LEVELS = {
+    easy: {
+      label: 'Easy',
+      description: 'Forgiving seas. Supply use halved.',
+      supplyRate: 0.5,
+      eventLethality: 0.5,
+    },
+    normal: {
+      label: 'Normal',
+      description: 'Balanced challenge.',
+      supplyRate: 1.0,
+      eventLethality: 1.0,
+    },
+    hard: {
+      label: 'Hard',
+      description: 'Every league costs you.',
+      supplyRate: 1.5,
+      eventLethality: 1.5,
+    },
+    brutal: {
+      label: 'Brutal',
+      description: 'The sea shows no mercy.',
+      supplyRate: 2.0,
+      eventLethality: 2.0,
+    },
+  };
+
+  T.SUPPLY_BASE_RATES = {
+    food: 0.2,
+    water: 0.2,
+    rum: 0.1,
+  };
+
   T.state = {
     db: null,
     currentUser: null,

--- a/public/apps/tortuga/tortuga.css
+++ b/public/apps/tortuga/tortuga.css
@@ -1771,6 +1771,129 @@
   pointer-events: none;
 }
 
+/* ── Difficulty picker (new-game + settings panel) ─────────── */
+
+.difficulty-picker {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.5rem;
+  margin-top: 0.25rem;
+}
+
+.difficulty-card {
+  padding: 0.75rem;
+  background: var(--color-bg, #12121a);
+  border: 2px solid var(--color-border, #333);
+  border-radius: 6px;
+  cursor: pointer;
+  text-align: left;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  transition:
+    border-color 0.15s,
+    background 0.15s;
+  font-family: inherit;
+  font-size: inherit;
+  color: var(--color-text, #e8e8f0);
+}
+
+.difficulty-card:hover {
+  border-color: #ffb74d;
+}
+
+.difficulty-card--selected {
+  border-color: #ffb74d;
+  background: rgba(255, 183, 77, 0.12);
+}
+
+.difficulty-card-label {
+  font-weight: 700;
+  font-size: 0.9rem;
+  color: var(--color-text, #e8e8f0);
+}
+
+.difficulty-card-desc {
+  font-size: 0.75rem;
+  color: var(--color-text-muted, #888);
+  line-height: 1.35;
+}
+
+@media (max-width: 480px) {
+  .difficulty-picker {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ── Settings modal ─────────────────────────────────────────── */
+
+.settings-modal-root {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  background: rgba(0, 0, 0, 0.65);
+}
+
+.settings-dialog {
+  background: #131929;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 12px;
+  padding: 1.5rem;
+  width: 100%;
+  max-width: 420px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.settings-dialog-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.settings-dialog-title {
+  font-size: 1rem;
+  font-weight: 700;
+  color: #ffb74d;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.settings-section-title {
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: #ffb74d;
+  margin: 0 0 0.3rem;
+}
+
+.settings-hint {
+  font-size: 0.75rem;
+  color: var(--color-text-muted, #888);
+  margin: 0 0 0.5rem;
+  font-style: italic;
+}
+
+.settings-error {
+  font-size: 0.8rem;
+  color: #e05555;
+  margin: 0;
+}
+
+.settings-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
 /* ── Game HUD: Log button ──────────────────────────────────── */
 
 .game-hud-log-btn {
@@ -1788,6 +1911,27 @@
 
 .game-hud-log-btn:hover {
   background: rgba(100, 181, 246, 0.2);
+}
+
+/* ── Game HUD: Settings button ─────────────────────────────── */
+
+.game-hud-settings-btn {
+  padding: 0.25rem 0.75rem;
+  background: rgba(144, 164, 174, 0.08);
+  color: #90a4ae;
+  border: 1px solid rgba(144, 164, 174, 0.3);
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+  margin-left: 0.4rem;
+}
+
+.game-hud-settings-btn:hover {
+  background: rgba(144, 164, 174, 0.16);
+  color: #cdd5e0;
 }
 
 /* ── Captain's Log overlay ─────────────────────────────────── */


### PR DESCRIPTION
- Add T.DIFFICULTY_LEVELS (easy/normal/hard/brutal with supplyRate/eventLethality modifiers) and T.SUPPLY_BASE_RATES to state.js as single source of truth
- Insert difficulty picker as step 2 in the new-game wizard; selection persists to game.settings.difficulty
- Apply per-turn supply consumption (food, water, rum) scaled by difficulty modifier on End Turn
- Add Settings HUD button that opens a panel to view/change difficulty mid-game (changes apply going forward)

https://claude.ai/code/session_01TEXektAF7DzAbupsYyjAx5