### PR TITLE
fix(tortuga): salvage gold, location arrival, fog of war, settlement visibility

### DIFF
--- a/public/apps/tortuga/index.html
+++ b/public/apps/tortuga/index.html
@@ -133,6 +133,7 @@
     <script src="/apps/tortuga/play/sea-graph.js"></script>
     <script src="/apps/tortuga/play/game-map.js"></script>
     <script src="/apps/tortuga/play/port-visit.js"></script>
+    <script src="/apps/tortuga/play/explore-visit.js"></script>
     <script src="/apps/tortuga/play/event-packs.js"></script>
     <script src="/apps/tortuga/play/events.js"></script>
     <script src="/apps/tortuga/play/captain-log.js"></script>

--- a/public/apps/tortuga/play/event-packs.js
+++ b/public/apps/tortuga/play/event-packs.js
@@ -20,6 +20,7 @@
   //                  hullDmg?:  [min, max],
   //                  sailsDmg?: [min, max],
   //                  supplies?: { key: [min, max] },
+  //                  gold?:     [min, max],
   //                }
   //              }>}
   //
@@ -95,6 +96,7 @@
               rum: [0, 2],
               repairMaterials: [0, 2],
             },
+            gold: [0, 25],
           },
         },
         {
@@ -128,6 +130,7 @@
               shot: [1, 3],
               repairMaterials: [0, 1],
             },
+            gold: [0, 10],
           },
         },
         {

--- a/public/apps/tortuga/play/events.js
+++ b/public/apps/tortuga/play/events.js
@@ -81,6 +81,11 @@
       }
     }
 
+    var goldGain = 0;
+    if (outcome.gold) {
+      goldGain = _rng(outcome.gold[0], outcome.gold[1]);
+    }
+
     var currentTurn = (ctx.gameDoc && ctx.gameDoc.turnNumber) || 0;
 
     var promises = [];
@@ -93,9 +98,13 @@
       );
     }
 
+    var gameUpdate = { lastEventTurn: currentTurn };
+    if (goldGain > 0) {
+      gameUpdate['captain.gold'] = firebase.firestore.FieldValue.increment(goldGain);
+    }
     promises.push(
-      T.firestore.updateGame(ctx.gameId, { lastEventTurn: currentTurn }).catch(function (err) {
-        console.error('[events] updateGame (lastEventTurn) failed', err);
+      T.firestore.updateGame(ctx.gameId, gameUpdate).catch(function (err) {
+        console.error('[events] updateGame failed', err);
       })
     );
 
@@ -191,6 +200,25 @@
   // ── Public API ───────────────────────────────────────────────
 
   T.events = {
+    // Force an exploration event drawn only from wreckage-type events.
+    // Bypasses the random EVENT_CHANCE and lastEventTurn guard.
+    fireExploration: function (ctx, doneCb) {
+      var pack = (T.EVENT_PACKS || []).filter(function (ev) {
+        return ev.type === 'wreckage';
+      });
+      if (!pack.length) {
+        doneCb();
+        return;
+      }
+      var event = _pickWeighted(pack);
+      if (!event) {
+        doneCb();
+        return;
+      }
+      var narrative = event.narratives[_rng(0, event.narratives.length - 1)];
+      _openModal(event, narrative, ctx, doneCb);
+    },
+
     tryFire: function (ctx, doneCb) {
       var currentTurn = (ctx.gameDoc && ctx.gameDoc.turnNumber) || 0;
       var lastEventTurn = ctx.gameDoc && ctx.gameDoc.lastEventTurn;

--- a/public/apps/tortuga/play/explore-visit.js
+++ b/public/apps/tortuga/play/explore-visit.js
@@ -1,0 +1,138 @@
+(function () {
+  'use strict';
+
+  window.Tortuga = window.Tortuga || {};
+  var T = window.Tortuga;
+
+  // ── Module-local state ───────────────────────────────────────
+
+  var _gameId = null;
+  var _flagshipId = null;
+  var _gameDoc = null;
+  var _flagshipDoc = null;
+  var _settlementName = '';
+  var _settlementType = '';
+  var _onCloseCb = null;
+  var _overlayEl = null;
+
+  // ── Helpers ──────────────────────────────────────────────────
+
+  function _esc(str) {
+    return String(str == null ? '' : str)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+  }
+
+  var TYPE_FLAVOUR = {
+    fort: 'The fortification looms ahead — crumbling walls, rusted cannon, and the silence of abandonment. Who knows what the garrison left behind.',
+    hidden_cove:
+      'A sheltered cove, hidden from the main shipping lanes. The kind of place smugglers and desperate men retreat to.',
+    ruin: 'Overgrown stonework juts from the jungle floor. Once a settlement of some kind — now only debris and echoes.',
+  };
+
+  function _flavourFor(type) {
+    return (
+      TYPE_FLAVOUR[type] || 'An uncharted site. The crew stand ready, uncertain what awaits ashore.'
+    );
+  }
+
+  // ── Modal ────────────────────────────────────────────────────
+
+  function _close() {
+    if (_overlayEl && _overlayEl.parentNode) {
+      _overlayEl.parentNode.removeChild(_overlayEl);
+    }
+    _overlayEl = null;
+  }
+
+  function _render() {
+    if (!_overlayEl) return;
+    var flavour = _flavourFor(_settlementType);
+    _overlayEl.innerHTML =
+      '<div class="event-modal-root">' +
+      '<div class="port-dialog">' +
+      '<div class="port-modal-header">' +
+      '<span class="port-modal-title">' +
+      _esc(_settlementName) +
+      '</span>' +
+      '</div>' +
+      '<span class="event-type-badge event-type-badge--wreckage">Exploration</span>' +
+      '<p class="event-narrative">' +
+      _esc(flavour) +
+      '</p>' +
+      '<div class="event-choices">' +
+      '<button class="event-choice-btn event-choice-btn--primary" id="explore-btn" type="button">Search the Site</button>' +
+      '<button class="event-choice-btn event-choice-btn--secondary" id="explore-leave-btn" type="button">Leave</button>' +
+      '</div>' +
+      '</div>' +
+      '</div>';
+
+    _overlayEl.querySelector('#explore-btn').addEventListener('click', function () {
+      _close();
+      T.events.fireExploration(
+        {
+          gameId: _gameId,
+          flagshipId: _flagshipId,
+          gameDoc: _gameDoc,
+          flagship: _flagshipDoc,
+        },
+        function () {
+          if (_onCloseCb) _onCloseCb();
+        }
+      );
+    });
+
+    _overlayEl.querySelector('#explore-leave-btn').addEventListener('click', function () {
+      _close();
+      if (_onCloseCb) _onCloseCb();
+    });
+  }
+
+  // ── Public API ───────────────────────────────────────────────
+
+  T.exploreVisit = {
+    open: function (
+      gameId,
+      flagshipId,
+      gameDoc,
+      flagshipDoc,
+      settlementId,
+      settlementName,
+      settlementType,
+      onClose
+    ) {
+      if (_overlayEl) _close();
+
+      _gameId = gameId;
+      _flagshipId = flagshipId;
+      _gameDoc = JSON.parse(JSON.stringify(gameDoc || {}));
+      _flagshipDoc = JSON.parse(JSON.stringify(flagshipDoc || {}));
+      _settlementName = settlementName || 'Unknown Site';
+      _settlementType = settlementType || '';
+      _onCloseCb = onClose || null;
+
+      _overlayEl = document.createElement('div');
+      document.body.appendChild(_overlayEl);
+
+      _render();
+
+      var turn = (gameDoc && gameDoc.turnNumber) || 0;
+      T.firestore
+        .addLogEntry(gameId, {
+          turn: turn,
+          type: 'exploration',
+          summary: 'Explored ' + (settlementName || 'Unknown Site'),
+          payload: { settlementId: settlementId || null, settlementName: settlementName || '' },
+        })
+        .catch(function (err) {
+          console.error('[explore-visit] addLogEntry failed', err);
+        });
+    },
+
+    isOpen: function () {
+      return _overlayEl !== null;
+    },
+  };
+})();

--- a/public/apps/tortuga/play/game-map.js
+++ b/public/apps/tortuga/play/game-map.js
@@ -14,6 +14,7 @@
   var _lastFlagshipDoc = null;
   var _fogLayerRef = null;
   var _shipLayerRef = null;
+  var _playSettlementLayerRef = null;
 
   // Movement state
   var _seaGraph = null;
@@ -96,8 +97,9 @@
   // when holes overlap).
 
   var _FogLayer = L.Layer.extend({
-    initialize: function (fog, worldData) {
+    initialize: function (fog, fogTrail, worldData) {
       this._fog = fog;
+      this._fogTrail = fogTrail || [];
       this._worldData = worldData;
     },
 
@@ -147,6 +149,7 @@
       var revealR = Math.max(15, Math.min(mapH, mapW) * 0.035);
 
       ctx.globalCompositeOperation = 'destination-out';
+
       (this._fog || []).forEach(function (settlementId) {
         var s = _settlementIndex[settlementId];
         if (!s || !s.position) return;
@@ -157,12 +160,28 @@
         ctx.arc(pt.x + pad, pt.y + pad, rPx, 0, 2 * Math.PI);
         ctx.fill();
       });
+
+      // Reveal corridors along the sailed trail
+      var trailR = Math.max(8, revealR * 0.7);
+      (this._fogTrail || []).forEach(function (token) {
+        var parts = token.split(',');
+        var ty = parseFloat(parts[0]);
+        var tx = parseFloat(parts[1]);
+        if (isNaN(ty) || isNaN(tx)) return;
+        var pt = map.latLngToContainerPoint([ty, tx]);
+        var northPt = map.latLngToContainerPoint([ty + trailR, tx]);
+        var rPx = Math.max(4, Math.abs(pt.y - northPt.y));
+        ctx.beginPath();
+        ctx.arc(pt.x + pad, pt.y + pad, rPx, 0, 2 * Math.PI);
+        ctx.fill();
+      });
+
       ctx.globalCompositeOperation = 'source-over';
     },
   });
 
-  function _buildFogLayer(fog, worldData) {
-    return new _FogLayer(fog, worldData);
+  function _buildFogLayer(fog, fogTrail, worldData) {
+    return new _FogLayer(fog, fogTrail, worldData);
   }
 
   function _setFogLayer(layer) {
@@ -218,6 +237,47 @@
     if (_shipLayerRef) _shipLayerRef.remove();
     _shipLayerRef = layer;
     T.mapRenderer.addExternalLayer('ship', layer);
+  }
+
+  // ── Play-mode settlement layer (fog-filtered) ─────────────────
+
+  var SETTLEMENT_COLORS = {
+    colonial_port: '#4dd0e1',
+    free_port: '#81c784',
+    fort: '#ff8a65',
+    hidden_cove: '#ce93d8',
+  };
+
+  function _buildPlaySettlementLayer(fog, worldData) {
+    var group = L.layerGroup();
+    if (!worldData || !worldData.settlements) return group;
+    var fogSet = {};
+    (fog || []).forEach(function (id) {
+      fogSet[id] = true;
+    });
+    worldData.settlements.forEach(function (s) {
+      if (!fogSet[s.id]) return;
+      var pos = s.position || s.pos;
+      if (!pos) return;
+      var color = SETTLEMENT_COLORS[s.type] || '#90a4ae';
+      L.circleMarker(pos, {
+        radius: 7,
+        color: color,
+        fillColor: color,
+        fillOpacity: 0.85,
+        weight: 2,
+        interactive: false,
+      })
+        .bindTooltip(_escapeHtml(s.name || ''), { permanent: false, direction: 'top' })
+        .addTo(group);
+    });
+    return group;
+  }
+
+  function _setPlaySettlementLayer(layer) {
+    if (_playSettlementLayerRef) _playSettlementLayerRef.remove();
+    _playSettlementLayerRef = layer;
+    T.mapRenderer.addExternalLayer('play-settlements', layer);
   }
 
   // ── HUD ──────────────────────────────────────────────────────
@@ -457,7 +517,7 @@
     function _step() {
       stepIndex++;
       if (stepIndex >= gridPath.length) {
-        _finishMove(gridPath[gridPath.length - 1], result.steps, fromPos);
+        _finishMove(gridPath[gridPath.length - 1], result.steps, fromPos, gridPath);
         return;
       }
       var pos = gridPath[stepIndex];
@@ -469,7 +529,7 @@
     setTimeout(_step, 150);
   }
 
-  function _finishMove(finalPos, stepsUsed, fromPos) {
+  function _finishMove(finalPos, stepsUsed, fromPos, gridPath) {
     _movementAnimating = false;
     _clearPathPreview();
 
@@ -477,17 +537,18 @@
     _apRemaining = newAP;
     _currentPosition = finalPos;
 
-    // Determine if final position is at a settlement.
+    // Determine if final position is at a settlement — pick the nearest within ARRIVAL_RADIUS.
     var arrivedAtSettlement = null;
-    var cellSize =
-      _seaGraph && _seaGraph.cellH ? Math.max(_seaGraph.cellH, _seaGraph.cellW) / 2 : 8;
+    var arrivedDist = Infinity;
     Object.keys(_settlementIndex).forEach(function (id) {
       var s = _settlementIndex[id];
       if (!s || !s.position) return;
       var dy = s.position[0] - finalPos[0];
       var dx = s.position[1] - finalPos[1];
-      if (Math.sqrt(dy * dy + dx * dx) < cellSize) {
+      var dist = Math.sqrt(dy * dy + dx * dx);
+      if (dist < T.ARRIVAL_RADIUS && dist < arrivedDist) {
         arrivedAtSettlement = id;
+        arrivedDist = dist;
       }
     });
 
@@ -519,6 +580,31 @@
           console.error('[game-map] fog discovery update failed', err);
         });
       _showDiscoveryToast(newlyDiscovered);
+    }
+
+    // Persist sailed positions as fog trail tokens ("y,x") for open-water reveal.
+    // Sample every 3rd cell from the grid path plus the final position.
+    if (gridPath && gridPath.length > 0) {
+      var trailTokens = [];
+      var seen = {};
+      for (var ti = 0; ti < gridPath.length; ti++) {
+        if (ti % 3 === 0 || ti === gridPath.length - 1) {
+          var token = Math.round(gridPath[ti][0]) + ',' + Math.round(gridPath[ti][1]);
+          if (!seen[token]) {
+            seen[token] = true;
+            trailTokens.push(token);
+          }
+        }
+      }
+      if (trailTokens.length > 0) {
+        T.firestore
+          .updateGame(_gameId, {
+            fogTrail: firebase.firestore.FieldValue.arrayUnion.apply(null, trailTokens),
+          })
+          .catch(function (err) {
+            console.error('[game-map] fogTrail update failed', err);
+          });
+      }
     }
 
     T.firestore
@@ -594,6 +680,21 @@
               arrivedAtSettlement,
               arrSett.name,
               _apMax,
+              function () {
+                _showReachableCells();
+              }
+            );
+            return;
+          }
+          if (arrSett) {
+            T.exploreVisit.open(
+              _gameId,
+              _flagshipId,
+              _lastGameDoc,
+              patchedFlagship,
+              arrivedAtSettlement,
+              arrSett.name,
+              arrSett.type,
               function () {
                 _showReachableCells();
               }
@@ -767,7 +868,8 @@
 
     var mapPanel = document.getElementById('game-map-panel');
     if (!mapPanel || mapPanel.classList.contains('hidden')) return;
-    _setFogLayer(_buildFogLayer(gameDoc.fog, _worldData));
+    _setFogLayer(_buildFogLayer(gameDoc.fog, gameDoc.fogTrail, _worldData));
+    _setPlaySettlementLayer(_buildPlaySettlementLayer(gameDoc.fog, _worldData));
   }
 
   function _onFlagshipUpdate(flagshipDoc, err) {
@@ -846,9 +948,13 @@
       var mapEl = document.getElementById('map-play');
       T.mapRenderer.init(mapEl, worldData);
 
-      // Add fog and ship layers.
-      _setFogLayer(_buildFogLayer(gameDoc.fog, worldData));
+      // Hide the world-mode settlement layer; play mode uses its own fog-filtered layer.
+      T.mapRenderer.hideLayer(T.mapRenderer.LAYERS.SETTLEMENTS);
+
+      // Add fog, ship, and play-settlement layers.
+      _setFogLayer(_buildFogLayer(gameDoc.fog, gameDoc.fogTrail, worldData));
       _setShipLayer(_buildShipLayer(flagshipDoc));
+      _setPlaySettlementLayer(_buildPlaySettlementLayer(gameDoc.fog, worldData));
 
       // Show reachable-cell markers for tap-to-move.
       _showReachableCells();

--- a/public/apps/tortuga/state.js
+++ b/public/apps/tortuga/state.js
@@ -10,6 +10,7 @@
   T.STAT_SCALE = 100;
   T.DISCOVERY_RADIUS = 30;
   T.HIDDEN_COVE_RADIUS = 12;
+  T.ARRIVAL_RADIUS = 30;
   T.FRIENDLY_PORT_TYPES = ['colonial_port', 'free_port'];
   T.EVENT_CHANCE = 0.25;
 


### PR DESCRIPTION
- Salvage encounters now award chance-based gold (merchant 0–25, warship
  0–10) via a new `outcome.gold` field in event-packs and a gold handler
  in _applyOutcome that increments captain.gold in a single updateGame call

- Arrival detection replaced half-cell radius with T.ARRIVAL_RADIUS (30)
  and picks the nearest settlement instead of the last iterated, so ports
  and locations reliably trigger on approach regardless of grid alignment

- Non-port locations (forts, hidden coves) now open an Explore Site modal
  (play/explore-visit.js) that fires a wreckage salvage roll via
  T.events.fireExploration

- Undiscovered settlements are now hidden in play mode: the shared renderer
  settlement layer is suppressed and replaced with a fog-filtered play layer
  that only shows settlements present in gameDoc.fog

- Open-water fog lifts permanently as the ship sails: each move samples
  the grid path into "y,x" token strings written to gameDoc.fogTrail via
  arrayUnion; the fog canvas layer draws reveal corridors over these points

https://claude.ai/code/session_017gmk2DZkwTTHUiHqZRVsii