### PR TITLE
fix(void-odyssey): soft-retire Void Odyssey in app registry

### DIFF
--- a/public/apps.yaml
+++ b/public/apps.yaml
@@ -15,7 +15,7 @@ apps:
     icon: "\U0001F680"
     type: embedded
     path: /apps/void-odyssey/
-    enabled: true
+    enabled: false
     order: 2
 
   - id: tortuga


### PR DESCRIPTION
## Summary
- Set `enabled: false` on the `void-odyssey` entry in `public/apps.yaml`
- The Grand Hall launcher (`public/index.html`) already filters the app list by `a.enabled`, so no code change is needed there — the tile is hidden automatically once the flag flips
- No app code removed; existing user claims and deep links to `/apps/void-odyssey/` continue to resolve as before (soft retire only)

## Test plan
- [x] `npm run lint:fix` — no issues
- [x] `npm run format` — no changes needed
- [x] Confirmed `index.html`'s `fetchAllApps()`/filter logic (`.filter((a) => a.enabled && appIds.includes(a.id))`) already excludes disabled apps from the launcher
- [ ] Verify in deployed preview/production that the Void Odyssey tile no longer appears in the Grand Hall and no console errors are introduced

Closes #286


---
_Generated by [Claude Code](https://claude.ai/code/session_01J684fWRCRMAyRqG4DqCm5o)_