### PR TITLE
fix(ci): retry hosting deploy on transient release race

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -15,12 +15,27 @@ jobs:
     environment: production
     steps:
       - uses: actions/checkout@v4
-      - uses: FirebaseExtended/action-hosting-deploy@v0
+      - name: Deploy to Firebase Hosting
+        id: deploy
+        continue-on-error: true
+        uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}
           firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_OLYMPUS_DFA00 }}
           channelId: live
           projectId: olympus-dfa00
+      # The action above occasionally fails with "supplied version is the
+      # current active version" after a network-level retry races its own
+      # earlier request. The content is already live at that point; retrying
+      # with a fresh CLI deploy creates a new version and releases cleanly.
+      - name: Set up Firebase CLI for retry
+        if: steps.deploy.outcome == 'failure'
+        uses: w9jds/setup-firebase@v1.0.0
+        with:
+          gcp_sa_key: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_OLYMPUS_DFA00 }}
+      - name: Retry hosting deploy
+        if: steps.deploy.outcome == 'failure'
+        run: firebase deploy --only hosting --project olympus-dfa00
   deploy_firestore:
     runs-on: ubuntu-latest
     environment: production


### PR DESCRIPTION
## Summary
- The `build_and_deploy` job in `.github/workflows/firebase-hosting-merge.yml` uses `FirebaseExtended/action-hosting-deploy@v0`, which occasionally fails with `Can't release ...: supplied version ... is the current active version`
- Root cause: a network hiccup (`premature close`) causes the Firebase CLI to retry a release request whose first attempt already succeeded server-side; the retry's response reports a conflict even though the content is already live. Observed on two unrelated production deploys (2026-06-28 main merge, and the L-001 #320 merge) — confirmed in both cases that production was actually serving the new content despite the reported CI failure
- Fix: mark the action step `continue-on-error: true`, and if it fails, fall back to a direct `firebase deploy --only hosting` via the CLI, which creates a fresh version and releases it cleanly (no conflict, since it's a new version object)

## Test plan
- [x] YAML is valid (workflow parses / no syntax errors)
- [ ] Next production merge to `main` will exercise the happy path (deploy succeeds on first try, retry steps skipped)
- [ ] If the flake recurs, the retry step should kick in and the job should go green instead of failing


---
_Generated by [Claude Code](https://claude.ai/code/session_01J684fWRCRMAyRqG4DqCm5o)_