### PR TITLE
fix(ci): treat known transient release race as deploy success

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -15,27 +15,31 @@ jobs:
     environment: production
     steps:
       - uses: actions/checkout@v4
+      - uses: w9jds/setup-firebase@v1.0.0
+        with:
+          gcp_sa_key: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_OLYMPUS_DFA00 }}
       - name: Deploy to Firebase Hosting
         id: deploy
         continue-on-error: true
-        uses: FirebaseExtended/action-hosting-deploy@v0
-        with:
-          repoToken: ${{ secrets.GITHUB_TOKEN }}
-          firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_OLYMPUS_DFA00 }}
-          channelId: live
-          projectId: olympus-dfa00
-      # The action above occasionally fails with "supplied version is the
-      # current active version" after a network-level retry races its own
-      # earlier request. The content is already live at that point; retrying
-      # with a fresh CLI deploy creates a new version and releases cleanly.
-      - name: Set up Firebase CLI for retry
+        run: |
+          set -o pipefail
+          firebase deploy --only hosting --project olympus-dfa00 2>&1 | tee deploy.log
+      # A network-level "premature close" can cause the Firebase CLI to
+      # retry a release request whose first attempt already succeeded;
+      # the retry then reports the version as already active even though
+      # the deploy did go live. Treat that specific message as success
+      # instead of failing the job — retrying the deploy hits the same
+      # race and does not help.
+      - name: Check for transient release race
         if: steps.deploy.outcome == 'failure'
-        uses: w9jds/setup-firebase@v1.0.0
-        with:
-          gcp_sa_key: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_OLYMPUS_DFA00 }}
-      - name: Retry hosting deploy
-        if: steps.deploy.outcome == 'failure'
-        run: firebase deploy --only hosting --project olympus-dfa00
+        run: |
+          if grep -q "is the current active version" deploy.log; then
+            echo "Hosting content is already live (transient client-retry race) — treating as success."
+          else
+            echo "Hosting deploy failed:"
+            cat deploy.log
+            exit 1
+          fi
   deploy_firestore:
     runs-on: ubuntu-latest
     environment: production


### PR DESCRIPTION
## Summary
- Follow-up to #321. That fix retried the hosting deploy via the Firebase CLI on failure, but the very next production merge (run [28543073086](https://github.com/bcolemutech/olympus-web/actions/runs/28543073086)) proved the retry hits the *same* race: the retry uses the same CLI HTTP client, which is equally susceptible to the "premature close" bug that causes a duplicate release request
- Root cause (confirmed twice now): a network hiccup causes the Firebase CLI to retry a release request whose first attempt already succeeded server-side; the retry's response reports `supplied version ... is the current active version` even though the content is live
- Fix: replace `FirebaseExtended/action-hosting-deploy@v0` with a direct `firebase deploy --only hosting` call (same pattern already used by the other jobs in this workflow), capture its output, and on failure check for that specific benign message — if found, treat the job as successful; any other failure still fails the job

## Test plan
- [x] YAML is valid
- [ ] Next production merge to `main` will exercise the happy path
- [ ] If the race recurs, the job should go green (soft-pass) instead of failing, and the log will show "Hosting content is already live... treating as success"


---
_Generated by [Claude Code](https://claude.ai/code/session_01J684fWRCRMAyRqG4DqCm5o)_