### PR TITLE
feat(scripts): add Void Odyssey Firestore export/archive script

### DIFF
--- a/.github/workflows/export-void-odyssey.yml
+++ b/.github/workflows/export-void-odyssey.yml
@@ -1,0 +1,29 @@
+name: Export Void Odyssey Firestore Data
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  export:
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install script dependencies
+        run: npm ci --prefix scripts
+      - name: Export Void Odyssey Firestore data
+        env:
+          FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_OLYMPUS_DFA00 }}
+        run: node scripts/export-void-odyssey.js
+      - name: Upload export archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: void-odyssey-export
+          path: scripts/export-output/*.json
+          retention-days: 90

--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ node_modules/
 # Large Azgaar JSON exports used as manual-test artifacts
 # (Jest uses a small synthetic fixture in azgaar-json-sample.js instead)
 tests/fixtures/*.json
+
+# Void Odyssey Firestore export archives (may contain live user game data)
+scripts/export-output/

--- a/planning/the-loom-design.md
+++ b/planning/the-loom-design.md
@@ -204,7 +204,12 @@ Nothing is discarded — both projects contribute their best ideas to the Loom a
 
 1. Set `enabled: false` in `apps.yaml` (soft retire; existing claims still resolve, no new entry point).
 2. Extract salvage: journeys/ships config → Loom scenario; document the resolution-injection approach into §5.
-3. Export/archive VO Firestore collections.
+3. Export/archive VO Firestore collections. Run via the "Export Void Odyssey
+   Firestore Data" GitHub Actions workflow (`workflow_dispatch`), which invokes
+   `scripts/export-void-odyssey.js` against production and uploads the archive
+   as a build artifact (90-day retention — download and store it elsewhere
+   before that window closes if VO isn't fully retired yet). See the script's
+   header comment for the restore procedure.
 4. Remove app code under `/public/apps/`; clean VO entry from `apps.yaml`.
 5. Revoke or repurpose `void-odyssey` custom claims.
 

--- a/scripts/export-void-odyssey.js
+++ b/scripts/export-void-odyssey.js
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+
+/**
+ * Export/archive Void Odyssey Firestore data ahead of code removal (L-004 / #289).
+ *
+ * Walks void_odyssey_games and each game's subcollections (crew, locations,
+ * entities, items, quests, star_map, narrative_log) into a single JSON file.
+ * Firestore Timestamps are tagged as { __timestamp: <ISO string> } so restore
+ * can reconstruct them exactly.
+ *
+ * Usage:
+ *   FIREBASE_SERVICE_ACCOUNT='<json>' node scripts/export-void-odyssey.js
+ *     -> writes scripts/export-output/void-odyssey-export-<ISO timestamp>.json
+ *
+ * Restore procedure (re-run if VO data ever needs to come back):
+ *   FIREBASE_SERVICE_ACCOUNT='<json>' node scripts/export-void-odyssey.js --restore <path-to-export.json>
+ *     -> re-writes every game doc and subcollection doc from the archive via
+ *        set() keyed by original document ID (overwrite, safe to re-run)
+ *
+ * Exit codes:
+ *   0 - success
+ *   1 - missing configuration or arguments
+ *   3 - Firebase API error
+ */
+
+import { writeFile, readFile, mkdir } from 'node:fs/promises';
+import path from 'node:path';
+import { initializeApp, cert } from 'firebase-admin/app';
+import { getFirestore, Timestamp } from 'firebase-admin/firestore';
+
+const SUBCOLLECTIONS = [
+  'crew',
+  'locations',
+  'entities',
+  'items',
+  'quests',
+  'star_map',
+  'narrative_log',
+];
+
+const saKeyJson = process.env.FIREBASE_SERVICE_ACCOUNT;
+if (!saKeyJson) {
+  console.error('Error: FIREBASE_SERVICE_ACCOUNT environment variable is not set.');
+  process.exit(1);
+}
+
+let serviceAccount;
+try {
+  serviceAccount = JSON.parse(saKeyJson);
+} catch {
+  console.error('Error: FIREBASE_SERVICE_ACCOUNT is not valid JSON.');
+  process.exit(1);
+}
+
+const app = initializeApp({ credential: cert(serviceAccount) });
+const db = getFirestore(app);
+
+function serializeValue(value) {
+  if (value instanceof Timestamp) {
+    return { __timestamp: value.toDate().toISOString() };
+  }
+  if (Array.isArray(value)) {
+    return value.map(serializeValue);
+  }
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(Object.entries(value).map(([k, v]) => [k, serializeValue(v)]));
+  }
+  return value;
+}
+
+function deserializeValue(value) {
+  if (value && typeof value === 'object' && typeof value.__timestamp === 'string') {
+    return Timestamp.fromDate(new Date(value.__timestamp));
+  }
+  if (Array.isArray(value)) {
+    return value.map(deserializeValue);
+  }
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(Object.entries(value).map(([k, v]) => [k, deserializeValue(v)]));
+  }
+  return value;
+}
+
+async function exportGames() {
+  const gamesSnap = await db.collection('void_odyssey_games').get();
+  const counts = { games: gamesSnap.size };
+  for (const key of SUBCOLLECTIONS) counts[key] = 0;
+
+  const games = [];
+  for (const gameDoc of gamesSnap.docs) {
+    const gameRecord = { id: gameDoc.id, data: serializeValue(gameDoc.data()) };
+    for (const sub of SUBCOLLECTIONS) {
+      const subSnap = await gameDoc.ref.collection(sub).get();
+      gameRecord[sub] = subSnap.docs.map((d) => ({ id: d.id, data: serializeValue(d.data()) }));
+      counts[sub] += subSnap.size;
+    }
+    games.push(gameRecord);
+  }
+
+  const archive = {
+    exportedAt: new Date().toISOString(),
+    sourceProject: serviceAccount.project_id,
+    counts,
+    games,
+  };
+
+  const outDir = path.join(process.cwd(), 'scripts', 'export-output');
+  await mkdir(outDir, { recursive: true });
+  const outPath = path.join(
+    outDir,
+    `void-odyssey-export-${archive.exportedAt.replace(/[:.]/g, '-')}.json`
+  );
+  await writeFile(outPath, JSON.stringify(archive, null, 2));
+
+  console.log(`Exported ${counts.games} game(s) to ${outPath}`);
+  console.log('Document counts:', JSON.stringify(counts, null, 2));
+
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    const summary = [
+      '## Void Odyssey Firestore Export',
+      '',
+      `- Exported at: ${archive.exportedAt}`,
+      `- Games: ${counts.games}`,
+      ...SUBCOLLECTIONS.map((k) => `- ${k}: ${counts[k]}`),
+      '',
+      `Archive file: \`${path.relative(process.cwd(), outPath)}\` (uploaded as a workflow artifact)`,
+    ].join('\n');
+    await writeFile(process.env.GITHUB_STEP_SUMMARY, `${summary}\n`, { flag: 'a' });
+  }
+}
+
+async function restoreGames(archivePath) {
+  const raw = await readFile(archivePath, 'utf8');
+  const archive = JSON.parse(raw);
+
+  let restoredDocs = 0;
+  for (const game of archive.games) {
+    const gameRef = db.collection('void_odyssey_games').doc(game.id);
+    await gameRef.set(deserializeValue(game.data));
+    restoredDocs += 1;
+    for (const sub of SUBCOLLECTIONS) {
+      for (const doc of game[sub] || []) {
+        await gameRef.collection(sub).doc(doc.id).set(deserializeValue(doc.data));
+        restoredDocs += 1;
+      }
+    }
+  }
+
+  console.log(
+    `Restored ${archive.games.length} game(s), ${restoredDocs} document(s) total, from ${archivePath}`
+  );
+}
+
+const restoreIndex = process.argv.indexOf('--restore');
+try {
+  if (restoreIndex !== -1) {
+    const archivePath = process.argv[restoreIndex + 1];
+    if (!archivePath) {
+      console.error('Error: --restore requires a path to an export JSON file.');
+      process.exit(1);
+    }
+    await restoreGames(archivePath);
+  } else {
+    await exportGames();
+  }
+} catch (err) {
+  console.error(`Firebase error (${err.code || 'unknown'}): ${err.message}`);
+  process.exit(3);
+}


### PR DESCRIPTION
## Summary
- Adds `scripts/export-void-odyssey.js`: walks `void_odyssey_games` and its subcollections (`crew`, `locations`, `entities`, `items`, `quests`, `star_map`, `narrative_log`) into a single JSON archive. Firestore `Timestamp` fields are tagged (`{ __timestamp: <ISO> }`) so they round-trip exactly.
- Includes a `--restore <path>` mode that writes the archive back via `set()`, keyed by original document IDs (idempotent, safe to re-run) — this is the documented restore procedure per the issue's acceptance criteria.
- Adds `.github/workflows/export-void-odyssey.yml` (`workflow_dispatch`, `environment: production`, same pattern as the existing `set-admin.yml`/`seed-categories.yml`), which runs the script against production and uploads the resulting JSON as a build artifact (90-day retention) so it doesn't need to be committed to the repo (may contain live user data).
- Adds `scripts/export-output/` to `.gitignore`.
- Cross-references the workflow from `planning/the-loom-design.md` §9 retirement step 3.
- No app code touched — this only adds an export/archive tool ahead of VO code removal in L-004 (#289).

## Test plan
- [x] `npm run lint:fix` / `npm run format` — clean
- [x] Verified end-to-end against the Firestore emulator: seeded a fake game doc + all 7 subcollections (including a `Timestamp` field), ran the export script, confirmed the JSON output and document counts, then ran `--restore` against a fresh emulator instance and confirmed all documents (including the reconstructed `Timestamp`) matched the original
- [ ] Run the "Export Void Odyssey Firestore Data" workflow against production once merged, to produce the actual archive and sanity-check row counts against live data (I don't have production Firestore credentials in this environment — will trigger the workflow after merge and verify the artifact)

Closes #288


---
_Generated by [Claude Code](https://claude.ai/code/session_01J684fWRCRMAyRqG4DqCm5o)_