### PR TITLE
feat(loom): add Loom app scaffold (L-100)

### DIFF
--- a/public/apps.yaml
+++ b/public/apps.yaml
@@ -18,6 +18,15 @@ apps:
     enabled: true
     order: 10
 
+  - id: loom
+    name: The Loom
+    description: A persistent narrative game world
+    icon: "\U0001F9F5"
+    type: embedded
+    path: /apps/loom/
+    enabled: true
+    order: 11
+
   # ── JSX applets ─────────────────────────────────────────
   - id: pool-powerups
     name: Pool Power-Ups

--- a/public/apps/loom/index.html
+++ b/public/apps/loom/index.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>The Loom — Olympus</title>
+
+    <!-- Firebase SDK (compat) -->
+    <script defer src="/__/firebase/12.9.0/firebase-app-compat.js"></script>
+    <script defer src="/__/firebase/12.9.0/firebase-auth-compat.js"></script>
+    <script defer src="/__/firebase/12.9.0/firebase-firestore-compat.js"></script>
+    <script defer src="/__/firebase/12.9.0/firebase-functions-compat.js"></script>
+    <script defer src="/__/firebase/init.js?useEmulator=true"></script>
+
+    <!-- Shared Olympus styles -->
+    <link rel="stylesheet" href="/styles/app.css" />
+
+    <!-- App-specific styles -->
+    <link rel="stylesheet" href="/apps/loom/loom.css" />
+  </head>
+  <body>
+    <!-- Shared header — rendered by app-header.js -->
+    <div id="appHeader"></div>
+
+    <!-- Auth guard — shown while checking auth state -->
+    <div class="app-loading" id="app-loading">
+      <div class="app-spinner"></div>
+      <p class="app-loading-text">Consulting the Oracle&hellip;</p>
+    </div>
+
+    <!-- Main content — hidden until authenticated -->
+    <main class="app-main hidden" id="app-main">
+      <h1 class="app-title">The Loom</h1>
+      <p class="app-subtitle">A persistent narrative game world</p>
+      <div class="app-divider"></div>
+
+      <div id="loom-root" class="loom-root">
+        <p class="loom-placeholder">The Loom is being woven. Play is coming soon.</p>
+      </div>
+    </main>
+
+    <!-- Shared header component -->
+    <script src="/js/components/app-header.js"></script>
+
+    <!-- Loom modules (load order matters) -->
+    <script src="/apps/loom/js/state.js"></script>
+    <script src="/apps/loom/js/app.js"></script>
+
+    <script>
+      document.addEventListener('DOMContentLoaded', function () {
+        firebase.auth().onAuthStateChanged(function (user) {
+          if (!user) {
+            window.location.href = '/';
+            return;
+          }
+
+          // Render the shared header
+          window.OlympusHeader.render('The Loom');
+
+          // Hide loading, show main content
+          document.getElementById('app-loading').classList.add('hidden');
+          document.getElementById('app-main').classList.remove('hidden');
+
+          // Initialize the app
+          window.Loom.app.init(user);
+        });
+      });
+    </script>
+  </body>
+</html>

--- a/public/apps/loom/js/app.js
+++ b/public/apps/loom/js/app.js
@@ -1,0 +1,14 @@
+(function () {
+  'use strict';
+
+  var Loom = window.Loom;
+  var state = Loom.state;
+
+  Loom.app = {
+    init: function (user) {
+      state.db = firebase.firestore();
+      state.functions = firebase.functions();
+      state.uid = user.uid;
+    },
+  };
+})();

--- a/public/apps/loom/js/state.js
+++ b/public/apps/loom/js/state.js
@@ -1,0 +1,13 @@
+(function () {
+  'use strict';
+
+  window.Loom = window.Loom || {};
+  var Loom = window.Loom;
+
+  // ── Shared mutable state ───────────────────────
+  Loom.state = {
+    db: null,
+    functions: null,
+    uid: null,
+  };
+})();

--- a/public/apps/loom/loom.css
+++ b/public/apps/loom/loom.css
@@ -1,0 +1,11 @@
+.loom-root {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 40vh;
+}
+
+.loom-placeholder {
+  color: #90a4ae;
+  font-style: italic;
+}


### PR DESCRIPTION
## Summary
- Scaffolds the embedded Loom app at `public/apps/loom/` following the standard Olympus "add a new app" path: IIFE namespace (`window.Loom`), `state.js` → `app.js` load order, Firebase auth guard, shared header.
- Registers the app in `apps.yaml` (`id: loom`, `type: embedded`, gated on the `loom` claim once granted via The Pantheon).
- Placeholder main content only — world/save routing and turn play land in later Phase 1 issues (L-120, L-121).

Closes #293 (L-100).

## Test plan
- [x] `npm run lint:fix` / `npm run format` clean
- [x] Verified via hosting emulator that `/apps/loom/`, `/apps/loom/js/state.js`, `/apps/loom/loom.css` all serve 200 and the `apps.yaml` entry parses correctly
- [x] Auth-guard/init code mirrors the already-deployed Symposium/`_template` pattern exactly
- [ ] Manual click-through in a real browser once merged/deployed to a preview channel (no Playwright/browser-test harness exists in this repo to automate it)


---
_Generated by [Claude Code](https://claude.ai/code/session_01XVNW1uHGnfWpM69kac16WF)_