### PR TITLE
feat(loom): Firestore rules + indexes for loom_* collections (L-101)

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -63,6 +63,14 @@
         { "fieldPath": "category", "order": "ASCENDING" },
         { "fieldPath": "createdAt", "order": "ASCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "loom_saves",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "ownerUid", "order": "ASCENDING" },
+        { "fieldPath": "worldId", "order": "ASCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/firestore.rules
+++ b/firestore.rules
@@ -297,6 +297,33 @@ service cloud.firestore {
       allow delete: if hasApp('symposium');
     }
 
+    // ── The Loom ───────────────────────────────────────────
+    // World/canon and shared World State are server/admin-managed only — no
+    // client writes. Saves and their turn log are owner-scoped for reads;
+    // all mutation goes through the loomPlayTurn callable (Admin SDK, which
+    // bypasses these rules). Soft-canon is server-write-only.
+
+    match /loom_worlds/{worldId} {
+      allow read: if hasApp('loom');
+    }
+
+    match /loom_world_state/{worldId} {
+      allow read: if hasApp('loom');
+    }
+
+    match /loom_saves/{saveId} {
+      allow read: if hasApp('loom') && resource.data.ownerUid == request.auth.uid;
+
+      match /loom_turns/{turnId} {
+        allow read: if hasApp('loom')
+            && get(/databases/$(database)/documents/loom_saves/$(saveId)).data.ownerUid == request.auth.uid;
+      }
+    }
+
+    match /loom_softcanon/{entityId} {
+      allow read: if hasApp('loom');
+    }
+
     // ── App registry ──────────────────────────────────────
 
     match /apps/{appId} {

--- a/tests/firestore-rules.test.js
+++ b/tests/firestore-rules.test.js
@@ -1483,3 +1483,176 @@ describe('apps — Firestore Security Rules', function () {
     });
   });
 });
+
+// ── loom_* collections ────────────────────────────────────────────────────────
+
+describe('loom_* — Firestore Security Rules', function () {
+  var testEnv;
+  var loomDb;
+  var wrongOwnerDb;
+  var noClaimDb;
+  var unauthDb;
+
+  var OWNER_UID = 'owner-001';
+  var SAVE_ID = 'save-001';
+
+  beforeAll(async function () {
+    var firestoreConfig = {
+      rules: readFileSync(RULES_PATH, 'utf8'),
+    };
+
+    var emulatorHost = process.env.FIRESTORE_EMULATOR_HOST;
+    if (emulatorHost) {
+      var parts = emulatorHost.split(':');
+      var host = parts[0];
+      var portString = parts[1];
+      if (host) {
+        firestoreConfig.host = host;
+      }
+      if (portString) {
+        var parsedPort = parseInt(portString, 10);
+        if (!isNaN(parsedPort)) {
+          firestoreConfig.port = parsedPort;
+        }
+      }
+    } else {
+      firestoreConfig.host = '127.0.0.1';
+      firestoreConfig.port = 8080;
+    }
+
+    testEnv = await initializeTestEnvironment({
+      projectId: PROJECT_ID,
+      firestore: firestoreConfig,
+    });
+  });
+
+  beforeEach(async function () {
+    await testEnv.clearFirestore();
+
+    await testEnv.withSecurityRulesDisabled(async function (ctx) {
+      var db = ctx.firestore();
+      await setDoc(doc(db, 'loom_worlds', 'world-001'), { name: 'Test World' });
+      await setDoc(doc(db, 'loom_world_state', 'world-001'), { worldClock: 0 });
+      await setDoc(doc(db, 'loom_saves', SAVE_ID), {
+        ownerUid: OWNER_UID,
+        worldId: 'world-001',
+      });
+      await setDoc(doc(db, 'loom_saves', SAVE_ID, 'loom_turns', 'turn-001'), {
+        index: 0,
+        actionText: 'look around',
+      });
+      await setDoc(doc(db, 'loom_softcanon', 'entity-001'), { name: 'Doral' });
+    });
+
+    loomDb = testEnv.authenticatedContext(OWNER_UID, { apps: ['loom'] }).firestore();
+    wrongOwnerDb = testEnv.authenticatedContext('owner-002', { apps: ['loom'] }).firestore();
+    noClaimDb = testEnv.authenticatedContext('no-claim-user', {}).firestore();
+    unauthDb = testEnv.unauthenticatedContext().firestore();
+  });
+
+  afterAll(async function () {
+    await testEnv.cleanup();
+  });
+
+  describe('loom_worlds', function () {
+    it('allows read for a user with the loom claim', async function () {
+      await assertSucceeds(getDoc(doc(loomDb, 'loom_worlds', 'world-001')));
+    });
+
+    it('denies read for a user without the loom claim', async function () {
+      await assertFails(getDoc(doc(noClaimDb, 'loom_worlds', 'world-001')));
+    });
+
+    it('denies read for an unauthenticated user', async function () {
+      await assertFails(getDoc(doc(unauthDb, 'loom_worlds', 'world-001')));
+    });
+
+    it('denies client write even with the loom claim', async function () {
+      await assertFails(setDoc(doc(loomDb, 'loom_worlds', 'world-002'), { name: 'Hack' }));
+    });
+  });
+
+  describe('loom_world_state', function () {
+    it('allows read for a user with the loom claim', async function () {
+      await assertSucceeds(getDoc(doc(loomDb, 'loom_world_state', 'world-001')));
+    });
+
+    it('denies read for a user without the loom claim', async function () {
+      await assertFails(getDoc(doc(noClaimDb, 'loom_world_state', 'world-001')));
+    });
+
+    it('denies client write even with the loom claim', async function () {
+      await assertFails(
+        setDoc(doc(loomDb, 'loom_world_state', 'world-001'), { worldClock: 999 })
+      );
+    });
+  });
+
+  describe('loom_saves', function () {
+    it('allows the owner to read their own save', async function () {
+      await assertSucceeds(getDoc(doc(loomDb, 'loom_saves', SAVE_ID)));
+    });
+
+    it('denies read for a different loom-claimed user', async function () {
+      await assertFails(getDoc(doc(wrongOwnerDb, 'loom_saves', SAVE_ID)));
+    });
+
+    it('denies read for a user without the loom claim', async function () {
+      await assertFails(getDoc(doc(noClaimDb, 'loom_saves', SAVE_ID)));
+    });
+
+    it('denies client write even by the owner', async function () {
+      await assertFails(
+        setDoc(doc(loomDb, 'loom_saves', SAVE_ID), { ownerUid: OWNER_UID, worldId: 'world-001' })
+      );
+    });
+
+    it('denies client create of a new save by the owner', async function () {
+      await assertFails(
+        setDoc(doc(loomDb, 'loom_saves', 'save-new'), {
+          ownerUid: OWNER_UID,
+          worldId: 'world-001',
+        })
+      );
+    });
+
+    describe('loom_turns subcollection', function () {
+      it('allows the owner to read their own turn log', async function () {
+        await assertSucceeds(
+          getDoc(doc(loomDb, 'loom_saves', SAVE_ID, 'loom_turns', 'turn-001'))
+        );
+      });
+
+      it('denies read for a different loom-claimed user', async function () {
+        await assertFails(
+          getDoc(doc(wrongOwnerDb, 'loom_saves', SAVE_ID, 'loom_turns', 'turn-001'))
+        );
+      });
+
+      it('denies client write even by the owner', async function () {
+        await assertFails(
+          setDoc(doc(loomDb, 'loom_saves', SAVE_ID, 'loom_turns', 'turn-002'), {
+            index: 1,
+            actionText: 'hack',
+          })
+        );
+      });
+    });
+  });
+
+  describe('loom_softcanon', function () {
+    it('allows read for a user with the loom claim', async function () {
+      await assertSucceeds(getDoc(doc(loomDb, 'loom_softcanon', 'entity-001')));
+    });
+
+    it('denies read for a user without the loom claim', async function () {
+      await assertFails(getDoc(doc(noClaimDb, 'loom_softcanon', 'entity-001')));
+    });
+
+    it('denies client write even with the loom claim', async function () {
+      await assertFails(
+        setDoc(doc(loomDb, 'loom_softcanon', 'entity-002'), { name: 'Hacked NPC' })
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds default-deny Firestore rules for `loom_worlds`, `loom_world_state`, `loom_saves` (+ `loom_turns` subcollection), and `loom_softcanon`.
- `loom_worlds` / `loom_world_state`: read gated on `hasApp('loom')`; no client writes (server/admin only — World State is server-mutated per the design doc).
- `loom_saves` / `loom_turns`: read gated on `hasApp('loom')` + `ownerUid == request.auth.uid`; **no client writes at all** — every mutation goes through the `loomPlayTurn` callable (Admin SDK, which bypasses these rules), per the issue spec.
- `loom_softcanon`: read gated on `hasApp('loom')`; server-write-only.
- Adds a `loom_saves` composite index (`ownerUid` + `worldId`) to `firestore.indexes.json` for the save-list query. The `entityRefs` index for entity-keyed retrieval is deferred to L-117 (#304) as noted in that issue.
- Default-deny preserved for everything else.

Closes #294 (L-101).

## Test plan
- [x] Extended `tests/firestore-rules.test.js` with allow/deny coverage for all four collections + the `loom_turns` subcollection (owner read, non-owner deny, no-claim deny, unauthenticated deny, and denied client writes/creates throughout)
- [x] `firebase emulators:exec --only firestore --project demo-olympus-rules-test "cd tests && npm test"` — all 111 rules tests pass (93 pre-existing + 18 new)
- [x] `npm run lint:fix` / `npm run format` clean
- Note: `gemini.test.js` fails in this sandbox with "Cannot find module '@google/genai'" — confirmed pre-existing on unmodified `main` (missing `functions/node_modules` install in this environment), unrelated to this change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XVNW1uHGnfWpM69kac16WF)_