### PR TITLE
feat(loom): data model constructors/validators + mutation application (L-102)

### DIFF
--- a/functions/loom-models.js
+++ b/functions/loom-models.js
@@ -1,0 +1,320 @@
+'use strict';
+
+/**
+ * The Loom — §8 data model constructors, validators, and mutation application.
+ *
+ * Mirrors planning/the-loom-design.md §8. These are pure, framework-free
+ * functions (no firebase-admin import) so they can be unit-tested without an
+ * emulator; callers pass in timestamps (e.g. FieldValue.serverTimestamp())
+ * rather than this module generating them.
+ */
+
+// ── Mutation vocabulary (design doc §8, §11 L-401) ─────────────────────────
+// state_mutations are deltas, never whole-document overwrites, so retried
+// transactional writes (batch tick, concurrent turns) merge cleanly.
+
+const MUTATION_OPS = ['add', 'remove', 'increment', 'set-flag'];
+
+function getAtPath(obj, path) {
+  return path.split('.').reduce(function (acc, key) {
+    return acc == null ? undefined : acc[key];
+  }, obj);
+}
+
+function setAtPath(obj, path, value) {
+  const keys = path.split('.');
+  let target = obj;
+  for (let i = 0; i < keys.length - 1; i++) {
+    const key = keys[i];
+    if (target[key] == null || typeof target[key] !== 'object') {
+      target[key] = {};
+    }
+    target = target[key];
+  }
+  target[keys[keys.length - 1]] = value;
+}
+
+/**
+ * Applies a single delta mutation to a state object in place.
+ *   { op: 'add',       path, value }  — push value onto the array at path (no-op if already present)
+ *   { op: 'remove',    path, value }  — remove the first matching value from the array at path
+ *   { op: 'increment', path, value }  — add value (a number) to the number at path (default 0)
+ *   { op: 'set-flag',  path, value }  — set path to value verbatim
+ */
+function applyMutation(state, mutation) {
+  if (!mutation || MUTATION_OPS.indexOf(mutation.op) === -1) {
+    throw new Error('applyMutation: unknown op ' + (mutation && mutation.op));
+  }
+  if (typeof mutation.path !== 'string' || mutation.path.length === 0) {
+    throw new Error('applyMutation: path is required');
+  }
+
+  switch (mutation.op) {
+    case 'add': {
+      let arr = getAtPath(state, mutation.path);
+      if (!Array.isArray(arr)) {
+        arr = [];
+        setAtPath(state, mutation.path, arr);
+      }
+      if (arr.indexOf(mutation.value) === -1) {
+        arr.push(mutation.value);
+      }
+      break;
+    }
+    case 'remove': {
+      const arr = getAtPath(state, mutation.path);
+      if (Array.isArray(arr)) {
+        const idx = arr.indexOf(mutation.value);
+        if (idx !== -1) arr.splice(idx, 1);
+      }
+      break;
+    }
+    case 'increment': {
+      const current = getAtPath(state, mutation.path);
+      setAtPath(state, mutation.path, (typeof current === 'number' ? current : 0) + mutation.value);
+      break;
+    }
+    case 'set-flag': {
+      setAtPath(state, mutation.path, mutation.value);
+      break;
+    }
+  }
+
+  return state;
+}
+
+/** Applies an ordered list of mutations to a state object in place. Returns the same object. */
+function applyStateMutations(state, mutations) {
+  (mutations || []).forEach(function (mutation) {
+    applyMutation(state, mutation);
+  });
+  return state;
+}
+
+// ── Validators ──────────────────────────────────────────────────────────────
+// Return { valid: boolean, errors: string[] }. Constructors call these and
+// throw on invalid input so a malformed document can never be written.
+
+function validateWorldState(data) {
+  const errors = [];
+  if (!data || typeof data !== 'object') return { valid: false, errors: ['not an object'] };
+
+  if (typeof data.worldId !== 'string' || data.worldId.length === 0) {
+    errors.push('worldId must be a non-empty string');
+  }
+  if (
+    typeof data.locations !== 'object' ||
+    data.locations === null ||
+    Array.isArray(data.locations)
+  ) {
+    errors.push('locations must be an object');
+  }
+  if (typeof data.factions !== 'object' || data.factions === null || Array.isArray(data.factions)) {
+    errors.push('factions must be an object');
+  }
+  if (
+    typeof data.globalFlags !== 'object' ||
+    data.globalFlags === null ||
+    Array.isArray(data.globalFlags)
+  ) {
+    errors.push('globalFlags must be an object');
+  }
+  if (typeof data.worldClock !== 'number') {
+    errors.push('worldClock must be a number');
+  }
+
+  return { valid: errors.length === 0, errors: errors };
+}
+
+function validateCharacter(character) {
+  const errors = [];
+  if (!character || typeof character !== 'object')
+    return { valid: false, errors: ['not an object'] };
+
+  if (typeof character.name !== 'string' || character.name.length === 0) {
+    errors.push('character.name must be a non-empty string');
+  }
+  if (typeof character.condition !== 'string' || character.condition.length === 0) {
+    errors.push('character.condition must be a non-empty string');
+  }
+  if (!Array.isArray(character.inventory)) {
+    errors.push('character.inventory must be an array');
+  }
+  if (!Array.isArray(character.abilities)) {
+    errors.push('character.abilities must be an array');
+  }
+  if (!Array.isArray(character.goals)) {
+    errors.push('character.goals must be an array');
+  }
+
+  return { valid: errors.length === 0, errors: errors };
+}
+
+function validateSave(data) {
+  const errors = [];
+  if (!data || typeof data !== 'object') return { valid: false, errors: ['not an object'] };
+
+  if (typeof data.ownerUid !== 'string' || data.ownerUid.length === 0) {
+    errors.push('ownerUid must be a non-empty string');
+  }
+  if (typeof data.worldId !== 'string' || data.worldId.length === 0) {
+    errors.push('worldId must be a non-empty string');
+  }
+  if (typeof data.name !== 'string' || data.name.length === 0) {
+    errors.push('name must be a non-empty string');
+  }
+  const characterResult = validateCharacter(data.character);
+  if (!characterResult.valid) {
+    errors.push.apply(errors, characterResult.errors);
+  }
+  if (
+    typeof data.privateFlags !== 'object' ||
+    data.privateFlags === null ||
+    Array.isArray(data.privateFlags)
+  ) {
+    errors.push('privateFlags must be an object');
+  }
+  if (
+    typeof data.relationships !== 'object' ||
+    data.relationships === null ||
+    Array.isArray(data.relationships)
+  ) {
+    errors.push('relationships must be an object');
+  }
+  if (typeof data.recentSummary !== 'string') {
+    errors.push('recentSummary must be a string');
+  }
+
+  return { valid: errors.length === 0, errors: errors };
+}
+
+function validateTurn(data) {
+  const errors = [];
+  if (!data || typeof data !== 'object') return { valid: false, errors: ['not an object'] };
+
+  if (typeof data.index !== 'number' || data.index < 0) {
+    errors.push('index must be a non-negative number');
+  }
+  if (typeof data.actionText !== 'string' || data.actionText.length === 0) {
+    errors.push('actionText must be a non-empty string');
+  }
+  if (!data.proposedAction || typeof data.proposedAction !== 'object') {
+    errors.push('proposedAction must be an object');
+  } else {
+    if (typeof data.proposedAction.verb !== 'string')
+      errors.push('proposedAction.verb must be a string');
+    if (!Array.isArray(data.proposedAction.targets))
+      errors.push('proposedAction.targets must be an array');
+    if (typeof data.proposedAction.params !== 'object' || data.proposedAction.params === null) {
+      errors.push('proposedAction.params must be an object');
+    }
+  }
+  if (!data.resolution || typeof data.resolution !== 'object') {
+    errors.push('resolution must be an object');
+  } else {
+    if (typeof data.resolution.outcome !== 'string')
+      errors.push('resolution.outcome must be a string');
+    if (!Array.isArray(data.resolution.mutations))
+      errors.push('resolution.mutations must be an array');
+    if (!Array.isArray(data.resolution.constraints)) {
+      errors.push('resolution.constraints must be an array');
+    }
+  }
+  if (typeof data.narration !== 'string') {
+    errors.push('narration must be a string');
+  }
+  if (!Array.isArray(data.entityRefs)) {
+    errors.push('entityRefs must be an array');
+  }
+
+  return { valid: errors.length === 0, errors: errors };
+}
+
+// ── Constructors ──────────────────────────────────────────────────────────
+// Build a valid document shape from caller-supplied fields, applying §8
+// defaults for anything omitted. Throw on invalid input so a malformed
+// document can never reach a write.
+
+function makeWorldState(fields) {
+  fields = fields || {};
+  const worldState = {
+    worldId: fields.worldId,
+    updatedAt: fields.updatedAt,
+    locations: fields.locations || {},
+    factions: fields.factions || {},
+    globalFlags: fields.globalFlags || {},
+    worldClock: typeof fields.worldClock === 'number' ? fields.worldClock : 0,
+  };
+
+  const result = validateWorldState(worldState);
+  if (!result.valid) {
+    throw new Error('makeWorldState: invalid world state — ' + result.errors.join('; '));
+  }
+  return worldState;
+}
+
+function makeCharacter(fields) {
+  fields = fields || {};
+  return {
+    name: fields.name,
+    condition: fields.condition || 'healthy',
+    inventory: fields.inventory || [],
+    abilities: fields.abilities || [],
+    goals: fields.goals || [],
+  };
+}
+
+function makeSave(fields) {
+  fields = fields || {};
+  const save = {
+    ownerUid: fields.ownerUid,
+    worldId: fields.worldId,
+    name: fields.name,
+    character: makeCharacter(fields.character),
+    location: fields.location || null,
+    privateFlags: fields.privateFlags || {},
+    relationships: fields.relationships || {},
+    recentSummary: fields.recentSummary || '',
+    createdAt: fields.createdAt,
+    updatedAt: fields.updatedAt,
+  };
+
+  const result = validateSave(save);
+  if (!result.valid) {
+    throw new Error('makeSave: invalid save — ' + result.errors.join('; '));
+  }
+  return save;
+}
+
+function makeTurn(fields) {
+  fields = fields || {};
+  const turn = {
+    index: fields.index,
+    actionText: fields.actionText,
+    proposedAction: fields.proposedAction || { verb: '', targets: [], params: {} },
+    resolution: fields.resolution || { outcome: '', mutations: [], constraints: [] },
+    narration: fields.narration || '',
+    entityRefs: fields.entityRefs || [],
+    createdAt: fields.createdAt,
+  };
+
+  const result = validateTurn(turn);
+  if (!result.valid) {
+    throw new Error('makeTurn: invalid turn — ' + result.errors.join('; '));
+  }
+  return turn;
+}
+
+module.exports = {
+  MUTATION_OPS,
+  applyMutation,
+  applyStateMutations,
+  validateWorldState,
+  validateCharacter,
+  validateSave,
+  validateTurn,
+  makeWorldState,
+  makeCharacter,
+  makeSave,
+  makeTurn,
+};

--- a/tests/loom-models.test.js
+++ b/tests/loom-models.test.js
@@ -1,0 +1,309 @@
+'use strict';
+
+/**
+ * Unit tests for functions/loom-models.js (L-102).
+ *
+ * Pure-function constructors/validators/mutation-application — no
+ * Firestore emulator required.
+ *
+ * Run: cd tests && npx jest loom-models --verbose
+ */
+
+const {
+  applyMutation,
+  applyStateMutations,
+  validateWorldState,
+  validateCharacter,
+  validateSave,
+  validateTurn,
+  makeWorldState,
+  makeCharacter,
+  makeSave,
+  makeTurn,
+} = require('../functions/loom-models');
+
+describe('applyMutation', () => {
+  it('add: pushes a value onto an array at path', () => {
+    const state = { locations: { tavern: { presentEntities: [] } } };
+    applyMutation(state, { op: 'add', path: 'locations.tavern.presentEntities', value: 'npc-doral' });
+    expect(state.locations.tavern.presentEntities).toEqual(['npc-doral']);
+  });
+
+  it('add: is idempotent for an already-present value', () => {
+    const state = { locations: { tavern: { presentEntities: ['npc-doral'] } } };
+    applyMutation(state, { op: 'add', path: 'locations.tavern.presentEntities', value: 'npc-doral' });
+    expect(state.locations.tavern.presentEntities).toEqual(['npc-doral']);
+  });
+
+  it('add: creates missing intermediate objects and the array itself', () => {
+    const state = {};
+    applyMutation(state, { op: 'add', path: 'locations.tavern.presentEntities', value: 'npc-doral' });
+    expect(state.locations.tavern.presentEntities).toEqual(['npc-doral']);
+  });
+
+  it('remove: removes a matching value from an array at path', () => {
+    const state = { locations: { tavern: { presentEntities: ['npc-doral', 'npc-mara'] } } };
+    applyMutation(state, { op: 'remove', path: 'locations.tavern.presentEntities', value: 'npc-doral' });
+    expect(state.locations.tavern.presentEntities).toEqual(['npc-mara']);
+  });
+
+  it('remove: is a no-op when the value is not present', () => {
+    const state = { locations: { tavern: { presentEntities: ['npc-mara'] } } };
+    applyMutation(state, { op: 'remove', path: 'locations.tavern.presentEntities', value: 'npc-doral' });
+    expect(state.locations.tavern.presentEntities).toEqual(['npc-mara']);
+  });
+
+  it('increment: adds to an existing number', () => {
+    const state = { factions: { pirates: { standing: 5 } } };
+    applyMutation(state, { op: 'increment', path: 'factions.pirates.standing', value: 3 });
+    expect(state.factions.pirates.standing).toBe(8);
+  });
+
+  it('increment: defaults missing values to 0 before adding', () => {
+    const state = { factions: { pirates: {} } };
+    applyMutation(state, { op: 'increment', path: 'factions.pirates.standing', value: -2 });
+    expect(state.factions.pirates.standing).toBe(-2);
+  });
+
+  it('set-flag: sets an arbitrary value at path, creating intermediates', () => {
+    const state = {};
+    applyMutation(state, { op: 'set-flag', path: 'globalFlags.metCaptain', value: true });
+    expect(state.globalFlags.metCaptain).toBe(true);
+  });
+
+  it('throws on an unknown op', () => {
+    expect(() => applyMutation({}, { op: 'overwrite', path: 'x', value: 1 })).toThrow(
+      /unknown op/
+    );
+  });
+
+  it('throws on a missing path', () => {
+    expect(() => applyMutation({}, { op: 'set-flag', value: 1 })).toThrow(/path is required/);
+  });
+});
+
+describe('applyStateMutations', () => {
+  it('applies an ordered list of mutations in place and returns the same object', () => {
+    const state = { worldClock: 0, globalFlags: {} };
+    const result = applyStateMutations(state, [
+      { op: 'increment', path: 'worldClock', value: 1 },
+      { op: 'set-flag', path: 'globalFlags.stormPassed', value: true },
+    ]);
+    expect(result).toBe(state);
+    expect(state.worldClock).toBe(1);
+    expect(state.globalFlags.stormPassed).toBe(true);
+  });
+
+  it('treats a missing/empty mutation list as a no-op', () => {
+    const state = { worldClock: 0 };
+    applyStateMutations(state, undefined);
+    expect(state.worldClock).toBe(0);
+  });
+});
+
+describe('validateWorldState', () => {
+  it('accepts a well-formed world state', () => {
+    const result = validateWorldState({
+      worldId: 'world-001',
+      locations: {},
+      factions: {},
+      globalFlags: {},
+      worldClock: 0,
+    });
+    expect(result.valid).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('rejects a missing worldId', () => {
+    const result = validateWorldState({
+      locations: {},
+      factions: {},
+      globalFlags: {},
+      worldClock: 0,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('worldId must be a non-empty string');
+  });
+
+  it('rejects worldClock as a non-number', () => {
+    const result = validateWorldState({
+      worldId: 'world-001',
+      locations: {},
+      factions: {},
+      globalFlags: {},
+      worldClock: '0',
+    });
+    expect(result.valid).toBe(false);
+  });
+});
+
+describe('validateCharacter', () => {
+  it('accepts a well-formed character', () => {
+    const result = validateCharacter({
+      name: 'Ishmael',
+      condition: 'healthy',
+      inventory: [],
+      abilities: [],
+      goals: [],
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects a character missing name', () => {
+    const result = validateCharacter({
+      condition: 'healthy',
+      inventory: [],
+      abilities: [],
+      goals: [],
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('character.name must be a non-empty string');
+  });
+});
+
+describe('validateSave', () => {
+  const validSave = {
+    ownerUid: 'uid-001',
+    worldId: 'world-001',
+    name: 'My Save',
+    character: { name: 'Ishmael', condition: 'healthy', inventory: [], abilities: [], goals: [] },
+    location: 'tavern',
+    privateFlags: {},
+    relationships: {},
+    recentSummary: '',
+  };
+
+  it('accepts a well-formed save', () => {
+    expect(validateSave(validSave).valid).toBe(true);
+  });
+
+  it('rejects a save missing ownerUid', () => {
+    const data = Object.assign({}, validSave);
+    delete data.ownerUid;
+    const result = validateSave(data);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('ownerUid must be a non-empty string');
+  });
+
+  it('surfaces nested character validation errors', () => {
+    const data = Object.assign({}, validSave, { character: {} });
+    const result = validateSave(data);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('character.name must be a non-empty string');
+  });
+});
+
+describe('validateTurn', () => {
+  const validTurn = {
+    index: 0,
+    actionText: 'look around',
+    proposedAction: { verb: 'look', targets: [], params: {} },
+    resolution: { outcome: 'success', mutations: [], constraints: [] },
+    narration: 'You see a dimly lit tavern.',
+    entityRefs: [],
+  };
+
+  it('accepts a well-formed turn', () => {
+    expect(validateTurn(validTurn).valid).toBe(true);
+  });
+
+  it('rejects a negative index', () => {
+    const result = validateTurn(Object.assign({}, validTurn, { index: -1 }));
+    expect(result.valid).toBe(false);
+  });
+
+  it('rejects a malformed proposedAction', () => {
+    const result = validateTurn(Object.assign({}, validTurn, { proposedAction: { verb: 'look' } }));
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('proposedAction.targets must be an array');
+  });
+
+  it('rejects a malformed resolution', () => {
+    const result = validateTurn(
+      Object.assign({}, validTurn, { resolution: { outcome: 'success' } })
+    );
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('resolution.mutations must be an array');
+  });
+});
+
+describe('makeWorldState', () => {
+  it('fills in §8 defaults for omitted fields', () => {
+    const worldState = makeWorldState({ worldId: 'world-001' });
+    expect(worldState).toEqual({
+      worldId: 'world-001',
+      updatedAt: undefined,
+      locations: {},
+      factions: {},
+      globalFlags: {},
+      worldClock: 0,
+    });
+  });
+
+  it('throws when worldId is missing', () => {
+    expect(() => makeWorldState({})).toThrow(/invalid world state/);
+  });
+});
+
+describe('makeCharacter', () => {
+  it('fills in §8 defaults for omitted fields', () => {
+    expect(makeCharacter({ name: 'Ishmael' })).toEqual({
+      name: 'Ishmael',
+      condition: 'healthy',
+      inventory: [],
+      abilities: [],
+      goals: [],
+    });
+  });
+});
+
+describe('makeSave', () => {
+  it('builds a valid save with default character/flags/relationships', () => {
+    const save = makeSave({
+      ownerUid: 'uid-001',
+      worldId: 'world-001',
+      name: 'My Save',
+      character: { name: 'Ishmael' },
+    });
+    expect(save.ownerUid).toBe('uid-001');
+    expect(save.character).toEqual({
+      name: 'Ishmael',
+      condition: 'healthy',
+      inventory: [],
+      abilities: [],
+      goals: [],
+    });
+    expect(save.privateFlags).toEqual({});
+    expect(save.relationships).toEqual({});
+    expect(save.recentSummary).toBe('');
+  });
+
+  it('throws when the character is missing a name', () => {
+    expect(() =>
+      makeSave({ ownerUid: 'uid-001', worldId: 'world-001', name: 'My Save', character: {} })
+    ).toThrow(/invalid save/);
+  });
+
+  it('throws when ownerUid is missing', () => {
+    expect(() =>
+      makeSave({ worldId: 'world-001', name: 'My Save', character: { name: 'Ishmael' } })
+    ).toThrow(/invalid save/);
+  });
+});
+
+describe('makeTurn', () => {
+  it('builds a valid turn with default nested shapes', () => {
+    const turn = makeTurn({ index: 0, actionText: 'look around' });
+    expect(turn.proposedAction).toEqual({ verb: '', targets: [], params: {} });
+    expect(turn.resolution).toEqual({ outcome: '', mutations: [], constraints: [] });
+    expect(turn.entityRefs).toEqual([]);
+  });
+
+  it('throws when actionText is missing', () => {
+    expect(() => makeTurn({ index: 0 })).toThrow(/invalid turn/);
+  });
+
+  it('throws when index is missing', () => {
+    expect(() => makeTurn({ actionText: 'look around' })).toThrow(/invalid turn/);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `functions/loom-models.js`: framework-free (no `firebase-admin` import) constructors and validators for the §8 data models — `loom_world_state`, `loom_saves` (with a nested `character` shape), and `loom_turns`.
- Constructors (`makeWorldState`, `makeCharacter`, `makeSave`, `makeTurn`) fill in §8 defaults for omitted fields and throw if the result fails validation, so a malformed document can never reach a write.
- Adds a generic delta-mutation applier (`applyMutation` / `applyStateMutations`) implementing the `add` / `remove` / `increment` / `set-flag` vocabulary from §8 / §11 (L-401) — this is what the later COMMIT stage (L-114) will run inside a Firestore transaction against `loom_world_state` / `loom_saves`.
- Timestamps (`createdAt`/`updatedAt`) are caller-supplied rather than generated here, so callers pass `FieldValue.serverTimestamp()` at write time and the module stays testable without the emulator.

Closes #295 (L-102).

## Test plan
- [x] `tests/loom-models.test.js` — 33 new unit tests covering every mutation op, all four validators, and all four constructors (including their throw-on-invalid paths)
- [x] Full suite: `firebase emulators:exec --only firestore --project demo-olympus-rules-test "cd tests && npm test"` — 144/144 passing (111 pre-existing + 33 new); `gemini.test.js`'s pre-existing failure (missing `functions/node_modules` install in this sandbox) is unrelated, as confirmed on unmodified `main` in the L-101 PR
- [x] `npm run lint:fix` / `npm run format` clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01XVNW1uHGnfWpM69kac16WF)_