### PR TITLE
feat(loom): canon layer schema + Shattered Coast seed world (L-103)

### DIFF
--- a/functions/loom-canon/index.js
+++ b/functions/loom-canon/index.js
@@ -1,0 +1,152 @@
+'use strict';
+
+/**
+ * The Loom — Canon layer (design doc §4, §7, §8; L-103 / #296).
+ *
+ * Canon is read-only at play time: places, factions, characters, and lore for
+ * a hand-authored world, expressed as static JS config. There is no runtime
+ * write path into canon, client or server (L-141 / #310) — world content
+ * changes only through an authoring commit.
+ *
+ * Schema (one entry per world, keyed by world id):
+ *
+ *   CanonWorld
+ *     id, name, tagline, openingHook
+ *     locations:  { [locationId]:  CanonLocation  }
+ *     factions:   { [factionId]:   CanonFaction   }
+ *     characters: { [characterId]: CanonCharacter }
+ *     lore:       { [loreId]:      CanonLoreEntry }
+ *     rules:      { ...small world-level rule-set hooks, data only }
+ *
+ *   CanonLocation
+ *     id, name, description
+ *     connections: string[]   — ids of directly reachable locations
+ *     factionIds:  string[]   — factions with a default presence here
+ *     npcIds:      string[]   — characters found here by default
+ *     rules:       object     — rule-set hooks (e.g. { requiresAbility, hostileToFactionId })
+ *
+ *   CanonFaction
+ *     id, name, description
+ *     disposition: 'friendly' | 'neutral' | 'hostile'  — default stance toward the player
+ *
+ *   CanonCharacter
+ *     id, name, description
+ *     factionId:  string | undefined  — faction this character belongs to
+ *     locationId: string              — default/home location
+ *
+ *   CanonLoreEntry
+ *     id, title, text
+ *     entityRefs: string[]  — location/faction/character ids this lore concerns
+ *
+ * Rule-set hooks are plain data consumed by the deterministic rules engine
+ * (§5 ADJUDICATE, L-112 / #299) once it exists — this module does not
+ * interpret them.
+ *
+ * Firestore-backed canon seam (Phase 3, L-300 / #314): a future
+ * getWorld(worldId) can check a `loom_worlds` Firestore doc first and fall
+ * back to WORLDS below, as long as it returns the same CanonWorld shape.
+ * Nothing here forecloses that — callers only depend on getWorld/getEntity/
+ * getEntitySnippet, not on the static-config storage detail.
+ */
+
+const WORLDS = {
+  'shattered-coast': require('./worlds/shattered-coast'),
+};
+
+/** Recursively freezes an object graph so canon can never be mutated at play time. */
+function deepFreeze(value) {
+  if (value === null || typeof value !== 'object' || Object.isFrozen(value)) {
+    return value;
+  }
+  Object.values(value).forEach(deepFreeze);
+  return Object.freeze(value);
+}
+
+Object.keys(WORLDS).forEach(function (worldId) {
+  deepFreeze(WORLDS[worldId]);
+});
+
+/** Returns the ids of all statically-defined worlds. */
+function listWorldIds() {
+  return Object.keys(WORLDS);
+}
+
+/** Returns the full CanonWorld for worldId, or null if unknown. Read-only (frozen). */
+function getWorld(worldId) {
+  return WORLDS[worldId] || null;
+}
+
+function getLocation(worldId, locationId) {
+  const world = getWorld(worldId);
+  if (!world) return null;
+  return world.locations[locationId] || null;
+}
+
+function getFaction(worldId, factionId) {
+  const world = getWorld(worldId);
+  if (!world) return null;
+  return world.factions[factionId] || null;
+}
+
+function getCharacter(worldId, characterId) {
+  const world = getWorld(worldId);
+  if (!world) return null;
+  return world.characters[characterId] || null;
+}
+
+function getLoreEntry(worldId, loreId) {
+  const world = getWorld(worldId);
+  if (!world) return null;
+  return world.lore[loreId] || null;
+}
+
+/**
+ * Resolves an entity id of unknown kind against a world's locations, factions,
+ * and characters (checked in that order). Returns { type, entity } or null.
+ */
+function getEntity(worldId, entityId) {
+  const world = getWorld(worldId);
+  if (!world) return null;
+
+  if (world.locations[entityId]) return { type: 'location', entity: world.locations[entityId] };
+  if (world.factions[entityId]) return { type: 'faction', entity: world.factions[entityId] };
+  if (world.characters[entityId]) {
+    return { type: 'character', entity: world.characters[entityId] };
+  }
+  return null;
+}
+
+/**
+ * Builds a denormalized text snippet for an entity — its own description plus
+ * any lore entries that reference it — for the NARRATE stage (L-113 / #300)
+ * and entity-keyed retrieval (L-117 / #304) to drop into prompt context.
+ * Returns null if the entity does not exist in the world.
+ */
+function getEntitySnippet(worldId, entityId) {
+  const world = getWorld(worldId);
+  if (!world) return null;
+
+  const resolved = getEntity(worldId, entityId);
+  if (!resolved) return null;
+
+  const lines = [resolved.entity.name + ' — ' + resolved.entity.description];
+
+  Object.values(world.lore).forEach(function (loreEntry) {
+    if (loreEntry.entityRefs.indexOf(entityId) !== -1) {
+      lines.push(loreEntry.title + ': ' + loreEntry.text);
+    }
+  });
+
+  return lines.join('\n\n');
+}
+
+module.exports = {
+  listWorldIds,
+  getWorld,
+  getLocation,
+  getFaction,
+  getCharacter,
+  getLoreEntry,
+  getEntity,
+  getEntitySnippet,
+};

--- a/functions/loom-canon/worlds/shattered-coast.js
+++ b/functions/loom-canon/worlds/shattered-coast.js
@@ -1,0 +1,213 @@
+'use strict';
+
+/**
+ * The Shattered Coast — Phase 1 MVP seed world.
+ *
+ * A compact pirate-age Caribbean scenario, hand-authored from the salvaged
+ * Tortuga Caribbean flavor material (planning/loom-salvage-tortuga-caribbean.md)
+ * and shaped to the canon schema in functions/loom-canon/index.js. This is a
+ * deliberately small world sized for one multi-session single-player
+ * adventure (Phase 1 exit criterion), not the full Caribbean/VO conversion —
+ * that broader effort is L-301 (#315), a Phase 3 issue.
+ */
+
+module.exports = {
+  id: 'shattered-coast',
+  name: 'The Shattered Coast',
+  tagline: 'Where hidden coves and old scores meet the tide.',
+  openingHook:
+    "Your ship limps into Widow's Reach with a Spanish patrol closing on your wake and the " +
+    "hold half-empty. Captain Orla Vance is waiting on the dock — she has a job, and it isn't " +
+    'the last one that went bad.',
+
+  locations: {
+    'widows-reach': {
+      id: 'widows-reach',
+      name: "Widow's Reach",
+      description:
+        'A hidden cove behind a wall of black rock, deep enough for a keel and narrow enough ' +
+        'that no patrol has ever found the entrance twice. Lean-tos and a careened hull crowd ' +
+        'the shingle; smoke from the cookfires never rises above the treeline.',
+      connections: ['skeleton-cove', 'the-drowned-shoals'],
+      factionIds: ['pirate-brethren'],
+      npcIds: ['captain-orla-vance'],
+      rules: {},
+    },
+    'skeleton-cove': {
+      id: 'skeleton-cove',
+      name: 'Skeleton Cove',
+      description:
+        'A shallow bay choked with the ribs of wrecked hulls, some centuries old. The locals ' +
+        'say the cove takes a ship a generation and gives nothing back but splinters and ' +
+        'stories.',
+      connections: ['widows-reach'],
+      factionIds: ['pirate-brethren'],
+      npcIds: ['old-mireille'],
+      rules: {},
+    },
+    'the-drowned-shoals': {
+      id: 'the-drowned-shoals',
+      name: 'The Drowned Shoals',
+      description:
+        'Open water threading between reefs sharp enough to gut a hull in a swell. Every ' +
+        'crossing is a gamble with the weather and with whoever else is crossing it that day.',
+      connections: ['widows-reach', 'free-city-of-marabel', 'fort-augustine'],
+      factionIds: [],
+      npcIds: [],
+      rules: { requiresAbility: 'seaworthy-vessel' },
+    },
+    'free-city-of-marabel': {
+      id: 'free-city-of-marabel',
+      name: 'The Free City of Marabel',
+      description:
+        'A crowded, lawless trading port that answers to no crown. Every flag flies here for ' +
+        'the right price, and the only law is the Guild ledger.',
+      connections: ['the-drowned-shoals', 'fort-augustine'],
+      factionIds: ['free-traders-guild'],
+      npcIds: ['quartermaster-doone'],
+      rules: {},
+    },
+    'fort-augustine': {
+      id: 'fort-augustine',
+      name: 'Fort Augustine',
+      description:
+        'A stone garrison town flying the Spanish Crown’s colors, its harbor guarded by a ' +
+        'battery that has sunk more smuggler hulls than storms have.',
+      connections: ['the-drowned-shoals', 'free-city-of-marabel'],
+      factionIds: ['spanish-crown'],
+      npcIds: ['commandant-de-alva'],
+      rules: { hostileToFactionId: 'pirate-brethren' },
+    },
+  },
+
+  factions: {
+    'pirate-brethren': {
+      id: 'pirate-brethren',
+      name: 'The Pirate Brethren',
+      description:
+        "A loose confederation of crews who answer to no crown, held together by the Reach's " +
+        'unwritten codes more than by any flag.',
+      disposition: 'friendly',
+    },
+    'spanish-crown': {
+      id: 'spanish-crown',
+      name: 'The Spanish Crown',
+      description:
+        'The colonial authority holding Fort Augustine and the shipping lanes around it. ' +
+        'Views every unflagged hull as a smuggler until proven otherwise.',
+      disposition: 'hostile',
+    },
+    'free-traders-guild': {
+      id: 'free-traders-guild',
+      name: 'The Free Traders’ Guild',
+      description:
+        "Marabel's merchant council. Neutral by policy and profitable by habit — the Guild " +
+        'will deal with pirates and crown officers alike, at a price.',
+      disposition: 'neutral',
+    },
+  },
+
+  characters: {
+    'captain-orla-vance': {
+      id: 'captain-orla-vance',
+      name: 'Captain Orla Vance',
+      description:
+        'Weathered, sharp-eyed, and missing two fingers on her left hand. She built Widow’s ' +
+        "Reach's fragile peace between a dozen quarrelsome crews and does not intend to lose it " +
+        'to anyone’s recklessness — including the player’s.',
+      factionId: 'pirate-brethren',
+      locationId: 'widows-reach',
+    },
+    'old-mireille': {
+      id: 'old-mireille',
+      name: 'Old Mireille',
+      description:
+        'A lookout who has outlived three captains and reads the wrecks at Skeleton Cove like ' +
+        'other people read scripture. Superstitious, half-blind, and usually right.',
+      factionId: 'pirate-brethren',
+      locationId: 'skeleton-cove',
+    },
+    'quartermaster-doone': {
+      id: 'quartermaster-doone',
+      name: 'Quartermaster Doone',
+      description:
+        'Keeper of the Guild ledger in Marabel. Knows the price of everything and the loyalty ' +
+        'of no one, including the highest bidder.',
+      factionId: 'free-traders-guild',
+      locationId: 'free-city-of-marabel',
+    },
+    'commandant-de-alva': {
+      id: 'commandant-de-alva',
+      name: 'Commandant de Alva',
+      description:
+        "Fort Augustine's garrison commander. Ambitious, correct to the point of cruelty, and " +
+        'convinced that hanging the right pirate captain will finally earn him a posting back ' +
+        'home.',
+      factionId: 'spanish-crown',
+      locationId: 'fort-augustine',
+    },
+  },
+
+  lore: {
+    'founding-of-widows-reach': {
+      id: 'founding-of-widows-reach',
+      title: "The Founding of Widow's Reach",
+      text:
+        'Three generations ago a single crew, widowed of their captain in a Crown ambush, ' +
+        'found the cove and swore no flag would ever find it again. The name stuck; the oath ' +
+        'mostly held.',
+      entityRefs: ['widows-reach', 'pirate-brethren'],
+    },
+    'the-sunken-warship': {
+      id: 'the-sunken-warship',
+      title: 'The Sunken Warship',
+      text:
+        'The cannon-pocked hull of a naval sloop lies on a sandbar in Skeleton Cove, gun-ports ' +
+        'still open. No one alive knows which crown she sailed for, and Old Mireille insists ' +
+        'the not-knowing is the point.',
+      entityRefs: ['skeleton-cove', 'old-mireille'],
+    },
+    'the-ghost-ship-omen': {
+      id: 'the-ghost-ship-omen',
+      title: 'The Ghost Ship Omen',
+      text:
+        'A full-rigged ship under all sail with no crew visible and no flag at her masthead is ' +
+        'said to cross the Drowned Shoals before a bad storm. Sailors who claim to have seen ' +
+        'her rarely tell the same story twice.',
+      entityRefs: ['the-drowned-shoals'],
+    },
+    'the-guild-neutrality-pact': {
+      id: 'the-guild-neutrality-pact',
+      title: "The Guild's Neutrality Pact",
+      text:
+        "Marabel's charter forbids any crown or crew from raising arms within the city walls " +
+        'on pain of the Guild closing its warehouses to the offender for a year — a penalty ' +
+        'feared more than any navy.',
+      entityRefs: ['free-city-of-marabel', 'free-traders-guild'],
+    },
+    'de-alvas-standing-order': {
+      id: 'de-alvas-standing-order',
+      title: "De Alva's Standing Order",
+      text:
+        'Fort Augustine’s battery has standing orders to fire on any vessel that cannot ' +
+        'produce Crown papers within hailing distance. Commandant de Alva has never rescinded ' +
+        'it, even in a storm.',
+      entityRefs: ['fort-augustine', 'commandant-de-alva'],
+    },
+    'the-tropical-typhoon-season': {
+      id: 'the-tropical-typhoon-season',
+      title: 'Typhoon Season',
+      text:
+        'The Shoals turn treacherous for months each year: the barometer can drop like a ' +
+        'stone and leave a ship fighting for its life in mountainous swells within the hour.',
+      entityRefs: ['the-drowned-shoals'],
+    },
+  },
+
+  // Small world-level rule-set hooks. Data only — the deterministic rules
+  // engine that reads these (§5 ADJUDICATE, L-112 / #299) does not exist yet.
+  rules: {
+    startingLocationId: 'widows-reach',
+    startingAbilities: ['seaworthy-vessel'],
+  },
+};

--- a/tests/loom-canon.test.js
+++ b/tests/loom-canon.test.js
@@ -1,0 +1,181 @@
+'use strict';
+
+/**
+ * Unit tests for functions/loom-canon/ (L-103).
+ *
+ * Pure module — no Firestore emulator required.
+ *
+ * Run: cd tests && npx jest loom-canon --verbose
+ */
+
+const {
+  listWorldIds,
+  getWorld,
+  getLocation,
+  getFaction,
+  getCharacter,
+  getLoreEntry,
+  getEntity,
+  getEntitySnippet,
+} = require('../functions/loom-canon');
+
+describe('listWorldIds', () => {
+  it('includes the Phase 1 seed world', () => {
+    expect(listWorldIds()).toContain('shattered-coast');
+  });
+});
+
+describe('getWorld', () => {
+  it('returns the world for a known id', () => {
+    const world = getWorld('shattered-coast');
+    expect(world).not.toBeNull();
+    expect(world.id).toBe('shattered-coast');
+    expect(world.name).toBe('The Shattered Coast');
+  });
+
+  it('returns null for an unknown world id', () => {
+    expect(getWorld('nonexistent-world')).toBeNull();
+  });
+
+  it('is frozen — canon cannot be mutated at play time', () => {
+    const world = getWorld('shattered-coast');
+    expect(Object.isFrozen(world)).toBe(true);
+    expect(Object.isFrozen(world.locations)).toBe(true);
+    expect(Object.isFrozen(world.locations['widows-reach'])).toBe(true);
+
+    expect(() => {
+      'use strict';
+      world.name = 'Hacked';
+    }).toThrow();
+    expect(getWorld('shattered-coast').name).toBe('The Shattered Coast');
+  });
+});
+
+describe('getLocation / getFaction / getCharacter / getLoreEntry', () => {
+  it('resolves a known location', () => {
+    const location = getLocation('shattered-coast', 'widows-reach');
+    expect(location).not.toBeNull();
+    expect(location.name).toBe("Widow's Reach");
+  });
+
+  it('returns null for an unknown location', () => {
+    expect(getLocation('shattered-coast', 'nonexistent')).toBeNull();
+  });
+
+  it('resolves a known faction', () => {
+    const faction = getFaction('shattered-coast', 'pirate-brethren');
+    expect(faction).not.toBeNull();
+    expect(faction.disposition).toBe('friendly');
+  });
+
+  it('resolves a known character', () => {
+    const character = getCharacter('shattered-coast', 'captain-orla-vance');
+    expect(character).not.toBeNull();
+    expect(character.locationId).toBe('widows-reach');
+  });
+
+  it('resolves a known lore entry', () => {
+    const lore = getLoreEntry('shattered-coast', 'founding-of-widows-reach');
+    expect(lore).not.toBeNull();
+    expect(lore.entityRefs).toContain('widows-reach');
+  });
+
+  it('returns null for any lookup against an unknown world', () => {
+    expect(getLocation('nope', 'widows-reach')).toBeNull();
+    expect(getFaction('nope', 'pirate-brethren')).toBeNull();
+    expect(getCharacter('nope', 'captain-orla-vance')).toBeNull();
+    expect(getLoreEntry('nope', 'founding-of-widows-reach')).toBeNull();
+  });
+});
+
+describe('getEntity', () => {
+  it('resolves a location id with type "location"', () => {
+    const result = getEntity('shattered-coast', 'widows-reach');
+    expect(result).toEqual({ type: 'location', entity: getLocation('shattered-coast', 'widows-reach') });
+  });
+
+  it('resolves a faction id with type "faction"', () => {
+    const result = getEntity('shattered-coast', 'spanish-crown');
+    expect(result.type).toBe('faction');
+  });
+
+  it('resolves a character id with type "character"', () => {
+    const result = getEntity('shattered-coast', 'commandant-de-alva');
+    expect(result.type).toBe('character');
+  });
+
+  it('returns null for an id that matches nothing', () => {
+    expect(getEntity('shattered-coast', 'nonexistent-entity')).toBeNull();
+  });
+
+  it('returns null for an unknown world', () => {
+    expect(getEntity('nope', 'widows-reach')).toBeNull();
+  });
+});
+
+describe('getEntitySnippet', () => {
+  it('includes the entity description and any lore entries that reference it', () => {
+    const snippet = getEntitySnippet('shattered-coast', 'skeleton-cove');
+    expect(snippet).toContain('Skeleton Cove');
+    expect(snippet).toContain('The Sunken Warship');
+  });
+
+  it('still returns a snippet for an entity with no referencing lore', () => {
+    const snippet = getEntitySnippet('shattered-coast', 'quartermaster-doone');
+    expect(snippet).toContain('Quartermaster Doone');
+  });
+
+  it('returns null for an entity that does not exist', () => {
+    expect(getEntitySnippet('shattered-coast', 'nonexistent-entity')).toBeNull();
+  });
+
+  it('returns null for an unknown world', () => {
+    expect(getEntitySnippet('nope', 'widows-reach')).toBeNull();
+  });
+});
+
+describe('shattered-coast world content — structural integrity', () => {
+  const world = getWorld('shattered-coast');
+
+  it('every location connection points at another location that exists', () => {
+    Object.values(world.locations).forEach(function (location) {
+      location.connections.forEach(function (connectedId) {
+        expect(world.locations[connectedId]).toBeDefined();
+      });
+    });
+  });
+
+  it('every location factionId/npcId reference resolves', () => {
+    Object.values(world.locations).forEach(function (location) {
+      location.factionIds.forEach(function (factionId) {
+        expect(world.factions[factionId]).toBeDefined();
+      });
+      location.npcIds.forEach(function (npcId) {
+        expect(world.characters[npcId]).toBeDefined();
+      });
+    });
+  });
+
+  it('every character factionId/locationId reference resolves', () => {
+    Object.values(world.characters).forEach(function (character) {
+      if (character.factionId) {
+        expect(world.factions[character.factionId]).toBeDefined();
+      }
+      expect(world.locations[character.locationId]).toBeDefined();
+    });
+  });
+
+  it('every lore entityRef resolves to a location, faction, or character', () => {
+    Object.values(world.lore).forEach(function (loreEntry) {
+      loreEntry.entityRefs.forEach(function (entityId) {
+        const resolved =
+          world.locations[entityId] || world.factions[entityId] || world.characters[entityId];
+        expect(resolved).toBeDefined();
+      });
+    });
+  });
+
+  it('the starting location referenced by world.rules exists', () => {
+    expect(world.locations[world.rules.startingLocationId]).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `functions/loom-canon/index.js`: a read-only canon loader, with the CanonWorld/CanonLocation/CanonFaction/CanonCharacter/CanonLoreEntry schema documented in a header comment for future world authors and for the L-300 (Cartographer ingestion) mapping.
- Adds `functions/loom-canon/worlds/shattered-coast.js`: one hand-authored seed world — "The Shattered Coast," a compact pirate-age Caribbean scenario (5 locations, 3 factions, 4 NPCs, 6 lore entries, a couple of rule-set hooks) built from the salvaged Tortuga Caribbean flavor material (`planning/loom-salvage-tortuga-caribbean.md`). Deliberately sized for one multi-session single-player adventure per the Phase 1 exit criterion — not the full Caribbean/VO conversion, which is L-301 (#315, Phase 3).
- Canon is recursively `Object.freeze`'d at module load, so it's provably read-only at play time (no runtime write path, per L-141 / #310) rather than just documented as such.
- `getEntity(worldId, id)` resolves an id of unknown kind (location/faction/character); `getEntitySnippet(worldId, id)` builds a denormalized description + relevant-lore text blob for the later NARRATE (L-113 / #300) and entity-keyed retrieval (L-117 / #304) stages to consume.
- Documents (but does not build) the Firestore-backed canon seam for Phase 3 Cartographer ingestion (L-300 / #314) — a future `getWorld` could check Firestore first and fall back to the static config, same return shape.
- Rule-set hooks (e.g. `requiresAbility`, `hostileToFactionId`) are plain data only — the deterministic rules engine that reads them is L-112 (#299), not built here.

Closes #296 (L-103).

## Test plan
- [x] `tests/loom-canon.test.js` — 24 new tests: loader lookups (all four entity kinds + unknown-world/unknown-id null cases), immutability (frozen at every level, mutation attempts throw and don't stick), `getEntity` type resolution, `getEntitySnippet` content, and structural integrity of the seed world itself (every `connections`/`factionIds`/`npcIds`/`entityRefs` cross-reference resolves to a real entity, starting location exists)
- [x] Full suite: `firebase emulators:exec --only firestore --project demo-olympus-rules-test "cd tests && npm test"` — 168/168 passing (144 pre-existing + 24 new); `gemini.test.js`'s pre-existing failure is unrelated (confirmed on unmodified `main` in the L-101 PR)
- [x] `npm run lint:fix` / `npm run format` clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01XVNW1uHGnfWpM69kac16WF)_