### PR TITLE
feat(loom): loomPlayTurn orchestrator with INTAKE + COMMIT (L-110)

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -2,8 +2,10 @@
 
 const { initializeApp } = require('firebase-admin/app');
 const { getAuth } = require('firebase-admin/auth');
+const { getFirestore } = require('firebase-admin/firestore');
 const { onCall, HttpsError } = require('firebase-functions/v2/https');
 const { GoogleAuth } = require('google-auth-library');
+const { runTurnPipeline, LoomTurnError } = require('./loom-turn');
 
 initializeApp();
 
@@ -356,4 +358,54 @@ exports.inviteUser = onCall(async (request) => {
   }
 
   return { uid: userRecord.uid, email: email.trim() };
+});
+
+/**
+ * loomPlayTurn — runs one turn of The Loom's turn pipeline (design doc §5,
+ * §7). Callable by any signed-in user with the `loom` app claim who owns the
+ * target save; the client only ever receives the narration/summary contract,
+ * never raw state authority.
+ *
+ * Data: { worldId: string, saveId: string, actionText: string }
+ * Returns: { narration: string, stateSummary: string, suggestedActions: string[] }
+ */
+exports.loomPlayTurn = onCall(async (request) => {
+  if (!request.auth) {
+    throw new HttpsError('unauthenticated', 'You must be signed in to play The Loom.');
+  }
+  const tokenApps = request.auth.token.apps;
+  if (!Array.isArray(tokenApps) || !tokenApps.includes('loom')) {
+    throw new HttpsError('permission-denied', "You don't have access to The Loom.");
+  }
+
+  const { worldId, saveId, actionText } = request.data || {};
+
+  if (typeof worldId !== 'string' || worldId.trim().length === 0) {
+    throw new HttpsError('invalid-argument', 'worldId is required.');
+  }
+  if (typeof saveId !== 'string' || saveId.trim().length === 0) {
+    throw new HttpsError('invalid-argument', 'saveId is required.');
+  }
+  if (typeof actionText !== 'string' || actionText.trim().length === 0) {
+    throw new HttpsError('invalid-argument', 'actionText is required.');
+  }
+  if (actionText.length > 2000) {
+    throw new HttpsError('invalid-argument', 'actionText must be 2000 characters or fewer.');
+  }
+
+  try {
+    return await runTurnPipeline({
+      db: getFirestore(),
+      uid: request.auth.uid,
+      worldId: worldId.trim(),
+      saveId: saveId.trim(),
+      actionText: actionText.trim(),
+    });
+  } catch (err) {
+    if (err instanceof LoomTurnError) {
+      throw new HttpsError(err.code, err.message);
+    }
+    console.error('loomPlayTurn error:', err);
+    throw new HttpsError('internal', 'Failed to process turn.');
+  }
 });

--- a/functions/loom-turn/adjudicate.js
+++ b/functions/loom-turn/adjudicate.js
@@ -1,0 +1,45 @@
+'use strict';
+
+/**
+ * Stage 3 — ADJUDICATE (design doc §5, §11 L-140).
+ *
+ * The spine of the control thesis: a deterministic rules engine + server-side
+ * dice evaluate the proposed action against authoritative state and produce a
+ * fixed Resolution. The model never adjudicates legality. Per the L-140
+ * decision (#309), the pipeline reaches rules only through this seam:
+ *
+ *   evaluate(proposedAction, worldState, characterState, dice) → Resolution
+ *
+ * so a data-driven rules engine (Phase 2, L-202) can later replace the body
+ * of evaluate() without reshaping the pipeline.
+ *
+ * STUB (L-110 / #297): evaluate() always returns a no-op acknowledgment with
+ * no mutations and no constraints. Replaced by L-112 (#299) with the real
+ * hand-coded rules engine + server dice.
+ *
+ * @param {object} proposedAction
+ * @param {object} worldState
+ * @param {object} characterState
+ * @param {*} dice
+ * @returns {{ outcome: string, mutations: object[], constraints: string[] }}
+ */
+function evaluate(proposedAction, worldState, characterState, dice) {
+  return {
+    outcome: 'acknowledged',
+    mutations: [],
+    constraints: [],
+  };
+}
+
+/**
+ * @param {{ proposedAction: object, canonWorld: object, save: object, worldState: object }} params
+ * @returns {Promise<{ outcome: string, mutations: object[], constraints: string[] }>}
+ */
+async function adjudicateAction(params) {
+  const { proposedAction, save, worldState } = params;
+  // Server-side dice belongs here once real rules land (L-112); none needed yet.
+  const dice = null;
+  return evaluate(proposedAction, worldState, save, dice);
+}
+
+module.exports = { evaluate, adjudicateAction };

--- a/functions/loom-turn/commit.js
+++ b/functions/loom-turn/commit.js
@@ -1,0 +1,103 @@
+'use strict';
+
+const { FieldValue } = require('firebase-admin/firestore');
+const { makeTurn, applyStateMutations } = require('../loom-models');
+
+/**
+ * Stage 5 — COMMIT (design doc §5, §8).
+ *
+ * Applies state_mutations to World/Character state, appends the turn to the
+ * event log, and returns the client-facing contract. Runs inside a Firestore
+ * transaction — re-reading fresh state and retrying on conflict — so a batch
+ * tick (L-201) or another turn can never tear a write.
+ *
+ * L-110 (#297) ships a minimal version: mutation application + append-only
+ * turn log + updatedAt bookkeeping. L-114 (#301) hardens this with soft-canon
+ * handoff (L-115 / #302) and threshold-triggered summary regeneration
+ * (L-116 / #303) — same signature, richer body.
+ *
+ * Mutations may carry a `target: 'save'` field to route them to Character
+ * state instead of World State; anything else (the default) applies to World
+ * State. This routing is COMMIT-only bookkeeping — applyStateMutations
+ * itself (functions/loom-models.js) is state-shape agnostic.
+ *
+ * @param {{
+ *   db: FirebaseFirestore.Firestore,
+ *   saveRef: FirebaseFirestore.DocumentReference,
+ *   worldStateRef: FirebaseFirestore.DocumentReference,
+ *   worldId: string,
+ *   actionText: string,
+ *   proposedAction: object,
+ *   resolution: { outcome: string, mutations: object[], constraints: string[] },
+ *   narration: string,
+ *   entityRefs: string[],
+ *   suggestedActions: string[],
+ * }} params
+ * @returns {Promise<{ narration: string, stateSummary: string, suggestedActions: string[] }>}
+ */
+async function commitTurn(params) {
+  const {
+    db,
+    saveRef,
+    worldStateRef,
+    worldId,
+    actionText,
+    proposedAction,
+    resolution,
+    narration,
+    entityRefs,
+    suggestedActions,
+  } = params;
+
+  return db.runTransaction(async (transaction) => {
+    const turnsQuery = saveRef.collection('loom_turns').orderBy('index', 'desc').limit(1);
+    const [saveSnap, worldStateSnap, lastTurnSnap] = await Promise.all([
+      transaction.get(saveRef),
+      transaction.get(worldStateRef),
+      transaction.get(turnsQuery),
+    ]);
+
+    if (!saveSnap.exists) {
+      throw new Error('commitTurn: save no longer exists');
+    }
+
+    const save = saveSnap.data();
+    const worldState = worldStateSnap.exists
+      ? worldStateSnap.data()
+      : { worldId, locations: {}, factions: {}, globalFlags: {}, worldClock: 0 };
+
+    const mutations = resolution.mutations || [];
+    const saveMutations = mutations.filter((m) => m.target === 'save');
+    const worldMutations = mutations.filter((m) => m.target !== 'save');
+
+    applyStateMutations(save, saveMutations);
+    applyStateMutations(worldState, worldMutations);
+
+    const nextIndex = lastTurnSnap.empty ? 0 : lastTurnSnap.docs[0].data().index + 1;
+
+    const turn = makeTurn({
+      index: nextIndex,
+      actionText,
+      proposedAction,
+      resolution,
+      narration,
+      entityRefs,
+      createdAt: FieldValue.serverTimestamp(),
+    });
+
+    transaction.set(saveRef.collection('loom_turns').doc(), turn);
+    transaction.set(saveRef, Object.assign({}, save, { updatedAt: FieldValue.serverTimestamp() }));
+    transaction.set(
+      worldStateRef,
+      Object.assign({}, worldState, { updatedAt: FieldValue.serverTimestamp() })
+    );
+
+    return {
+      narration,
+      stateSummary: save.recentSummary || '',
+      suggestedActions: suggestedActions || [],
+    };
+  });
+}
+
+module.exports = { commitTurn };

--- a/functions/loom-turn/index.js
+++ b/functions/loom-turn/index.js
@@ -1,0 +1,102 @@
+'use strict';
+
+const loomCanon = require('../loom-canon');
+const { makeWorldState } = require('../loom-models');
+const { interpretAction } = require('./interpret');
+const { adjudicateAction } = require('./adjudicate');
+const { narrateResolution } = require('./narrate');
+const { commitTurn } = require('./commit');
+
+/**
+ * Thrown by pipeline stages to signal a specific HttpsError code the
+ * loomPlayTurn callable (functions/index.js) should surface to the client.
+ */
+class LoomTurnError extends Error {
+  constructor(code, message) {
+    super(message);
+    this.name = 'LoomTurnError';
+    this.code = code;
+  }
+}
+
+/**
+ * Stage 1 — INTAKE (design doc §5).
+ *
+ * Loads the save and world state and validates ownership/world consistency.
+ * Real from day one (not stubbed) — this is where "server owns truth" starts.
+ *
+ * @param {{ db: FirebaseFirestore.Firestore, uid: string, worldId: string, saveId: string }} params
+ */
+async function intake(params) {
+  const { db, uid, worldId, saveId } = params;
+
+  const saveRef = db.collection('loom_saves').doc(saveId);
+  const saveSnap = await saveRef.get();
+  if (!saveSnap.exists) {
+    throw new LoomTurnError('not-found', 'Save not found.');
+  }
+
+  const save = saveSnap.data();
+  if (save.ownerUid !== uid) {
+    throw new LoomTurnError('permission-denied', 'This is not your save.');
+  }
+  if (save.worldId !== worldId) {
+    throw new LoomTurnError('failed-precondition', 'worldId does not match this save.');
+  }
+
+  const canonWorld = loomCanon.getWorld(worldId);
+  if (!canonWorld) {
+    throw new LoomTurnError('not-found', 'Unknown world.');
+  }
+
+  const worldStateRef = db.collection('loom_world_state').doc(worldId);
+  const worldStateSnap = await worldStateRef.get();
+  const worldState = worldStateSnap.exists ? worldStateSnap.data() : makeWorldState({ worldId });
+
+  return { save, saveRef, worldState, worldStateRef, canonWorld };
+}
+
+/**
+ * Runs the full §5 pipeline — INTAKE → INTERPRET → ADJUDICATE → NARRATE →
+ * COMMIT — and returns the client-facing contract. The client never sees raw
+ * state authority; only { narration, stateSummary, suggestedActions }.
+ *
+ * @param {{ db: FirebaseFirestore.Firestore, uid: string, worldId: string, saveId: string, actionText: string }} params
+ * @returns {Promise<{ narration: string, stateSummary: string, suggestedActions: string[] }>}
+ */
+async function runTurnPipeline(params) {
+  const { db, uid, worldId, saveId, actionText } = params;
+
+  const { save, saveRef, worldState, worldStateRef, canonWorld } = await intake({
+    db,
+    uid,
+    worldId,
+    saveId,
+  });
+
+  const proposedAction = await interpretAction({ actionText, canonWorld, save, worldState });
+  const resolution = await adjudicateAction({ proposedAction, canonWorld, save, worldState });
+  const { narration, entityRefs, suggestedActions } = await narrateResolution({
+    actionText,
+    proposedAction,
+    resolution,
+    canonWorld,
+    save,
+    worldState,
+  });
+
+  return commitTurn({
+    db,
+    saveRef,
+    worldStateRef,
+    worldId,
+    actionText,
+    proposedAction,
+    resolution,
+    narration,
+    entityRefs,
+    suggestedActions,
+  });
+}
+
+module.exports = { LoomTurnError, intake, runTurnPipeline };

--- a/functions/loom-turn/interpret.js
+++ b/functions/loom-turn/interpret.js
@@ -1,0 +1,25 @@
+'use strict';
+
+/**
+ * Stage 2 — INTERPRET (design doc §5).
+ *
+ * The LLM (Gemini 2.5 Flash, structured output) converts player free-text
+ * into a proposed action — fuzzy intent only, no authority over state or
+ * legality. See ADJUDICATE (./adjudicate.js) for where legality is decided.
+ *
+ * STUB (L-110 / #297): returns a passthrough proposedAction so the pipeline
+ * runs end-to-end. Replaced by L-111 (#298) with a real Flash call.
+ *
+ * @param {{ actionText: string, canonWorld: object, save: object, worldState: object }} params
+ * @returns {Promise<{ verb: string, targets: string[], params: object }>}
+ */
+async function interpretAction(params) {
+  const { actionText } = params;
+  return {
+    verb: 'unknown',
+    targets: [],
+    params: { raw: actionText },
+  };
+}
+
+module.exports = { interpretAction };

--- a/functions/loom-turn/narrate.js
+++ b/functions/loom-turn/narrate.js
@@ -1,0 +1,36 @@
+'use strict';
+
+/**
+ * Stage 4 — NARRATE (design doc §5).
+ *
+ * The LLM (Flash) receives a canon snippet + current state + the FIXED
+ * Resolution + rolling summary and writes prose. It may color *how*
+ * something happened, never *whether* — the Resolution from ADJUDICATE
+ * (./adjudicate.js) is final.
+ *
+ * STUB (L-110 / #297): returns a minimal templated acknowledgment with no
+ * new entities and no suggested actions. Replaced by L-113 (#300) with a
+ * real Flash call assembling canon (L-103 / #296) + entity-keyed retrieval
+ * (L-117 / #304) + rolling summary (L-116 / #303) context.
+ *
+ * @param {{
+ *   actionText: string,
+ *   proposedAction: object,
+ *   resolution: object,
+ *   canonWorld: object,
+ *   save: object,
+ *   worldState: object,
+ * }} params
+ * @returns {Promise<{ narration: string, entityRefs: string[], suggestedActions: string[] }>}
+ */
+async function narrateResolution(params) {
+  const { actionText } = params;
+  return {
+    narration:
+      'You attempt to ' + actionText + '. The Loom takes note, but has little more to say — yet.',
+    entityRefs: [],
+    suggestedActions: [],
+  };
+}
+
+module.exports = { narrateResolution };

--- a/tests/loom-turn.test.js
+++ b/tests/loom-turn.test.js
@@ -1,0 +1,219 @@
+'use strict';
+
+/**
+ * Integration tests for the loomPlayTurn callable orchestrator (L-110).
+ *
+ * Runs against the Firestore emulator with the real (stubbed) pipeline —
+ * INTERPRET/ADJUDICATE/NARRATE are stubs until L-111/112/113 land, so these
+ * tests exercise INTAKE, stage sequencing, auth/ownership enforcement, and
+ * the real COMMIT write path. The fuller emulator + mocked-AI integration
+ * suite (fixtures, per-stage assertions) is L-130 (#307).
+ *
+ * Run: firebase emulators:exec --only firestore --project demo-loom-test "cd tests && npx jest loom-turn --verbose"
+ */
+
+process.env.FIRESTORE_EMULATOR_HOST = process.env.FIRESTORE_EMULATOR_HOST || 'localhost:8080';
+process.env.GCLOUD_PROJECT = 'demo-loom-test';
+
+const functionsTest = require('firebase-functions-test')({ projectId: 'demo-loom-test' }, null);
+
+// This test file's own firebase-admin copy (tests/node_modules) needs its own
+// initialized app to read/write Firestore directly for seeding/assertions —
+// requiring functions/index.js below initializes a *separate* app instance
+// in its own copy (functions/node_modules), which is what loomPlayTurn uses
+// internally. Both point at the same FIRESTORE_EMULATOR_HOST, so data is
+// shared regardless of which copy's handle reads/writes it.
+const admin = require('firebase-admin');
+if (admin.apps.length === 0) {
+  admin.initializeApp({ projectId: 'demo-loom-test' });
+}
+const db = admin.firestore();
+
+const { loomPlayTurn } = require('../functions/index');
+const { makeSave } = require('../functions/loom-models');
+
+const TEST_UID = 'player-001';
+const WORLD_ID = 'shattered-coast';
+const SAVE_ID = 'save-001';
+
+function callTurn(data, authOverride) {
+  return loomPlayTurn.run({
+    data,
+    auth:
+      authOverride !== undefined
+        ? authOverride
+        : { uid: TEST_UID, token: { apps: ['loom'], admin: false } },
+  });
+}
+
+async function seedSave(overrides) {
+  const save = makeSave(
+    Object.assign(
+      {
+        ownerUid: TEST_UID,
+        worldId: WORLD_ID,
+        name: 'Test Save',
+        character: { name: 'Test Character' },
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      overrides
+    )
+  );
+  await db.collection('loom_saves').doc(SAVE_ID).set(save);
+  return save;
+}
+
+async function clearAll() {
+  const saveRef = db.collection('loom_saves').doc(SAVE_ID);
+  const turnsSnap = await saveRef.collection('loom_turns').get();
+  await Promise.all(turnsSnap.docs.map((d) => d.ref.delete()));
+  await saveRef.delete().catch(() => {});
+  await db.collection('loom_world_state').doc(WORLD_ID).delete().catch(() => {});
+}
+
+beforeEach(async () => {
+  await clearAll();
+});
+
+afterAll(async () => {
+  await clearAll();
+  functionsTest.cleanup();
+});
+
+describe('loomPlayTurn — auth and input validation', () => {
+  it('rejects an unauthenticated caller', async () => {
+    await seedSave();
+    await expect(
+      callTurn({ worldId: WORLD_ID, saveId: SAVE_ID, actionText: 'look around' }, null)
+    ).rejects.toThrow(/signed in/i);
+  });
+
+  it('rejects a caller without the loom claim', async () => {
+    await seedSave();
+    await expect(
+      callTurn(
+        { worldId: WORLD_ID, saveId: SAVE_ID, actionText: 'look around' },
+        { uid: TEST_UID, token: { apps: ['other-app'], admin: false } }
+      )
+    ).rejects.toThrow(/access to the loom/i);
+  });
+
+  it('rejects a missing worldId', async () => {
+    await expect(callTurn({ saveId: SAVE_ID, actionText: 'look around' })).rejects.toThrow(
+      /worldId/
+    );
+  });
+
+  it('rejects a missing saveId', async () => {
+    await expect(callTurn({ worldId: WORLD_ID, actionText: 'look around' })).rejects.toThrow(
+      /saveId/
+    );
+  });
+
+  it('rejects a missing actionText', async () => {
+    await expect(callTurn({ worldId: WORLD_ID, saveId: SAVE_ID })).rejects.toThrow(/actionText/);
+  });
+
+  it('rejects actionText longer than 2000 characters', async () => {
+    await seedSave();
+    await expect(
+      callTurn({ worldId: WORLD_ID, saveId: SAVE_ID, actionText: 'a'.repeat(2001) })
+    ).rejects.toThrow(/2000 characters/);
+  });
+});
+
+describe('loomPlayTurn — ownership and world resolution', () => {
+  it('rejects a save that does not exist', async () => {
+    await expect(
+      callTurn({ worldId: WORLD_ID, saveId: 'nonexistent-save', actionText: 'look around' })
+    ).rejects.toThrow(/not found/i);
+  });
+
+  it('rejects a save owned by a different user', async () => {
+    await seedSave({ ownerUid: 'someone-else' });
+    await expect(
+      callTurn({ worldId: WORLD_ID, saveId: SAVE_ID, actionText: 'look around' })
+    ).rejects.toThrow(/not your save/i);
+  });
+
+  it('rejects a worldId that does not match the save', async () => {
+    await seedSave({ worldId: WORLD_ID });
+    await expect(
+      callTurn({ worldId: 'some-other-world', saveId: SAVE_ID, actionText: 'look around' })
+    ).rejects.toThrow(/worldId does not match/i);
+  });
+
+  it('rejects a worldId with no canon world defined', async () => {
+    await seedSave({ worldId: 'nonexistent-world' });
+    await expect(
+      callTurn({ worldId: 'nonexistent-world', saveId: SAVE_ID, actionText: 'look around' })
+    ).rejects.toThrow(/unknown world/i);
+  });
+});
+
+describe('loomPlayTurn — end-to-end happy path', () => {
+  it('returns the client contract shape for a seeded world', async () => {
+    await seedSave();
+    const result = await callTurn({
+      worldId: WORLD_ID,
+      saveId: SAVE_ID,
+      actionText: 'look around',
+    });
+
+    expect(typeof result.narration).toBe('string');
+    expect(result.narration.length).toBeGreaterThan(0);
+    expect(typeof result.stateSummary).toBe('string');
+    expect(Array.isArray(result.suggestedActions)).toBe(true);
+  });
+
+  it('appends exactly one loom_turns doc with index 0 on the first turn', async () => {
+    await seedSave();
+    await callTurn({ worldId: WORLD_ID, saveId: SAVE_ID, actionText: 'look around' });
+
+    const turnsSnap = await db.collection('loom_saves').doc(SAVE_ID).collection('loom_turns').get();
+    expect(turnsSnap.size).toBe(1);
+    expect(turnsSnap.docs[0].data().index).toBe(0);
+    expect(turnsSnap.docs[0].data().actionText).toBe('look around');
+  });
+
+  it('increments the turn index on a second turn', async () => {
+    await seedSave();
+    await callTurn({ worldId: WORLD_ID, saveId: SAVE_ID, actionText: 'look around' });
+    await callTurn({ worldId: WORLD_ID, saveId: SAVE_ID, actionText: 'check the hold' });
+
+    const turnsSnap = await db
+      .collection('loom_saves')
+      .doc(SAVE_ID)
+      .collection('loom_turns')
+      .orderBy('index', 'asc')
+      .get();
+    expect(turnsSnap.size).toBe(2);
+    expect(turnsSnap.docs.map((d) => d.data().index)).toEqual([0, 1]);
+  });
+
+  it('creates the loom_world_state doc on the first turn in a world', async () => {
+    await seedSave();
+    await callTurn({ worldId: WORLD_ID, saveId: SAVE_ID, actionText: 'look around' });
+
+    const worldStateSnap = await db.collection('loom_world_state').doc(WORLD_ID).get();
+    expect(worldStateSnap.exists).toBe(true);
+    expect(worldStateSnap.data().worldId).toBe(WORLD_ID);
+  });
+
+  it('reuses an existing loom_world_state doc rather than overwriting its worldClock', async () => {
+    await seedSave();
+    await db.collection('loom_world_state').doc(WORLD_ID).set({
+      worldId: WORLD_ID,
+      locations: {},
+      factions: {},
+      globalFlags: {},
+      worldClock: 42,
+    });
+
+    await callTurn({ worldId: WORLD_ID, saveId: SAVE_ID, actionText: 'look around' });
+
+    const worldStateSnap = await db.collection('loom_world_state').doc(WORLD_ID).get();
+    expect(worldStateSnap.data().worldClock).toBe(42);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds the `loomPlayTurn(worldId, saveId, actionText)` callable (`functions/index.js`), gated on auth + the `loom` app claim, with input validation (required fields, 2000-char action text cap).
- Adds `functions/loom-turn/`, the pipeline orchestrator implementing design doc §5's stage sequencing: `INTAKE → INTERPRET → ADJUDICATE → NARRATE → COMMIT`.
  - **INTAKE** (`index.js`) is real: loads the save + world state, enforces ownership (`ownerUid == auth.uid`), world/save consistency, and resolves the world against canon (L-103 / #296).
  - **INTERPRET** (`interpret.js`), **ADJUDICATE** (`adjudicate.js`), **NARRATE** (`narrate.js`) are stubs returning plausible placeholder output — same call signatures L-111 (#298) / L-112 (#299) / L-113 (#300) will fill in without reshaping the orchestrator. `adjudicate.js`'s `evaluate()` stub matches the exact L-140 seam signature (`evaluate(proposedAction, worldState, characterState, dice) → Resolution`) from the design doc, hence the unused-arg lint warnings (harmless, non-blocking).
  - **COMMIT** (`commit.js`) is a real minimal implementation: applies `state_mutations` (via the L-102 delta engine) inside a Firestore transaction that re-reads fresh state, appends a monotonically-indexed `loom_turns` doc, and upserts `loom_saves`/`loom_world_state`. L-114 (#301) hardens this further (soft-canon handoff, threshold-triggered summary regen) behind the same signature.
- Client-facing contract: `{ narration, stateSummary, suggestedActions }` — no raw state authority is ever returned.

Closes #297 (L-110).

## Test plan
- [x] `tests/loom-turn.test.js` — 15 new integration tests against the Firestore emulator + `firebase-functions-test`: auth/claim enforcement, input validation, save-not-found/wrong-owner/worldId-mismatch/unknown-world rejections, end-to-end contract shape, turn-index monotonicity across two turns, and `loom_world_state` create-vs-reuse behavior
- [x] `firebase emulators:exec --only firestore --project demo-loom-test "cd tests && npx jest loom-turn --verbose"` — 15/15 passing
- [x] Full suite: `firebase emulators:exec --only firestore --project demo-olympus-rules-test "cd tests && npm test"` — 190/190 passing (all prior suites + new)
- [x] `npm run lint` / `npm run format:check` clean (4 pre-noted warnings for the intentional `evaluate()` stub signature; warnings don't fail CI)


---
_Generated by [Claude Code](https://claude.ai/code/session_01XVNW1uHGnfWpM69kac16WF)_