### PR TITLE
feat(loom): Stage 2 INTERPRET — Flash structured-output intent parse (L-111)

### DIFF
--- a/functions/loom-turn/interpret.js
+++ b/functions/loom-turn/interpret.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { callGemini } = require('../gemini');
+
 /**
  * Stage 2 — INTERPRET (design doc §5).
  *
@@ -7,19 +9,128 @@
  * into a proposed action — fuzzy intent only, no authority over state or
  * legality. See ADJUDICATE (./adjudicate.js) for where legality is decided.
  *
- * STUB (L-110 / #297): returns a passthrough proposedAction so the pipeline
- * runs end-to-end. Replaced by L-111 (#298) with a real Flash call.
+ * Target strings the model returns are resolved against the world's known
+ * canon entities (fuzzy match on id/name); anything that doesn't resolve is
+ * passed through as raw text for ADJUDICATE to treat as unresolved rather
+ * than crashing the turn.
  *
+ * Any Gemini failure or malformed response falls back to a safe passthrough
+ * proposedAction — INTERPRET never blocks a turn from reaching ADJUDICATE.
+ */
+
+const MODEL_NAME = 'gemini-2.5-flash';
+const MAX_OUTPUT_TOKENS = 512;
+
+function buildSystemInstruction(knownEntities) {
+  const entityList = knownEntities
+    .map((e) => '- ' + e.id + ' (' + e.kind + '): ' + e.name)
+    .join('\n');
+
+  return (
+    'You are the INTERPRET stage of a text adventure turn pipeline. Your ONLY job is to ' +
+    "parse the player's free-text action into a structured intent. You do NOT decide " +
+    'whether the action succeeds, fails, or is legal — a separate deterministic system ' +
+    'decides that. Never invent outcomes, dice rolls, or state changes.\n\n' +
+    'Known entities in this world:\n' +
+    entityList +
+    '\n\n' +
+    'Extract from the player action:\n' +
+    '- verb: a short lowercase snake_case verb summarizing the intent (e.g. "look", ' +
+    '"move", "attack", "talk", "take", "use")\n' +
+    '- targets: an array of strings naming entities the action refers to. Use the exact ' +
+    'id from the known-entities list when the player clearly means one of them; ' +
+    'otherwise include the raw text mentioned.\n' +
+    '- params: an object of any other relevant details (e.g. {"item": "sword"}). Use an ' +
+    'empty object if there are none.\n\n' +
+    'Respond with ONLY a JSON object: { "verb": string, "targets": string[], "params": object }'
+  );
+}
+
+function buildKnownEntities(canonWorld) {
+  const entities = [];
+  Object.values(canonWorld.locations).forEach((location) => {
+    entities.push({ id: location.id, name: location.name, kind: 'location' });
+  });
+  Object.values(canonWorld.factions).forEach((faction) => {
+    entities.push({ id: faction.id, name: faction.name, kind: 'faction' });
+  });
+  Object.values(canonWorld.characters).forEach((character) => {
+    entities.push({ id: character.id, name: character.name, kind: 'character' });
+  });
+  return entities;
+}
+
+function normalize(text) {
+  return String(text)
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+/** Resolves a raw target string to a known entity id, or returns it unchanged if no match. */
+function resolveTarget(rawTarget, knownEntities) {
+  const normalized = normalize(rawTarget);
+
+  const byId = knownEntities.find((e) => e.id === normalized);
+  if (byId) return byId.id;
+
+  const byName = knownEntities.find((e) => normalize(e.name) === normalized);
+  if (byName) return byName.id;
+
+  const fuzzy = knownEntities.find((e) => {
+    const normalizedName = normalize(e.name);
+    return normalizedName.includes(normalized) || normalized.includes(normalizedName);
+  });
+  if (fuzzy) return fuzzy.id;
+
+  return rawTarget;
+}
+
+function isValidRawProposedAction(raw) {
+  return (
+    !!raw && typeof raw === 'object' && typeof raw.verb === 'string' && Array.isArray(raw.targets)
+  );
+}
+
+/** Safe passthrough used whenever the model call fails or returns something malformed. */
+function fallbackProposedAction(actionText) {
+  return { verb: 'unknown', targets: [], params: { raw: actionText } };
+}
+
+/**
  * @param {{ actionText: string, canonWorld: object, save: object, worldState: object }} params
  * @returns {Promise<{ verb: string, targets: string[], params: object }>}
  */
 async function interpretAction(params) {
-  const { actionText } = params;
+  const { actionText, canonWorld } = params;
+  const knownEntities = buildKnownEntities(canonWorld);
+
+  let raw;
+  try {
+    raw = await callGemini({
+      modelName: MODEL_NAME,
+      systemInstruction: buildSystemInstruction(knownEntities),
+      userMessage: actionText,
+      maxOutputTokens: MAX_OUTPUT_TOKENS,
+      jsonMode: true,
+      thinkingBudget: 0,
+    });
+  } catch (err) {
+    console.error('interpretAction: callGemini failed, falling back to passthrough', err);
+    return fallbackProposedAction(actionText);
+  }
+
+  if (!isValidRawProposedAction(raw)) {
+    console.error('interpretAction: malformed model output, falling back to passthrough', raw);
+    return fallbackProposedAction(actionText);
+  }
+
   return {
-    verb: 'unknown',
-    targets: [],
-    params: { raw: actionText },
+    verb: raw.verb.toLowerCase().slice(0, 50),
+    targets: raw.targets.map((t) => resolveTarget(t, knownEntities)),
+    params: raw.params && typeof raw.params === 'object' ? raw.params : {},
   };
 }
 
-module.exports = { interpretAction };
+module.exports = { interpretAction, resolveTarget, buildKnownEntities };

--- a/tests/loom-interpret.test.js
+++ b/tests/loom-interpret.test.js
@@ -1,0 +1,232 @@
+'use strict';
+
+/**
+ * Unit tests for functions/loom-turn/interpret.js (L-111).
+ *
+ * Mocks functions/gemini.js's callGemini to test INTERPRET in isolation.
+ * Does not require the Firestore emulator.
+ *
+ * Run: cd tests && npx jest loom-interpret --verbose
+ */
+
+const mockCallGemini = jest.fn();
+jest.mock('../functions/gemini', () => ({
+  callGemini: (...args) => mockCallGemini(...args),
+}));
+
+const {
+  interpretAction,
+  resolveTarget,
+  buildKnownEntities,
+} = require('../functions/loom-turn/interpret');
+const { getWorld } = require('../functions/loom-canon');
+
+const CANON_WORLD = getWorld('shattered-coast');
+
+const MINI_WORLD = {
+  locations: {
+    tavern: { id: 'tavern', name: 'The Rusty Anchor Tavern' },
+  },
+  factions: {
+    'pirate-brethren': { id: 'pirate-brethren', name: 'The Pirate Brethren' },
+  },
+  characters: {
+    'captain-orla-vance': { id: 'captain-orla-vance', name: 'Captain Orla Vance' },
+  },
+};
+
+beforeEach(() => {
+  mockCallGemini.mockReset();
+});
+
+describe('buildKnownEntities', () => {
+  it('includes locations, factions, and characters from the canon world', () => {
+    const entities = buildKnownEntities(MINI_WORLD);
+    expect(entities).toEqual(
+      expect.arrayContaining([
+        { id: 'tavern', name: 'The Rusty Anchor Tavern', kind: 'location' },
+        { id: 'pirate-brethren', name: 'The Pirate Brethren', kind: 'faction' },
+        { id: 'captain-orla-vance', name: 'Captain Orla Vance', kind: 'character' },
+      ])
+    );
+  });
+});
+
+describe('resolveTarget', () => {
+  const knownEntities = buildKnownEntities(MINI_WORLD);
+
+  it('resolves an exact id match', () => {
+    expect(resolveTarget('captain-orla-vance', knownEntities)).toBe('captain-orla-vance');
+  });
+
+  it('resolves a case/whitespace-insensitive name match', () => {
+    expect(resolveTarget('Captain Orla Vance', knownEntities)).toBe('captain-orla-vance');
+  });
+
+  it('resolves a fuzzy substring match', () => {
+    expect(resolveTarget('orla', knownEntities)).toBe('captain-orla-vance');
+  });
+
+  it('returns the raw text unchanged when nothing matches', () => {
+    expect(resolveTarget('a mysterious stranger', knownEntities)).toBe('a mysterious stranger');
+  });
+});
+
+describe('interpretAction', () => {
+  it('maps a well-formed model response, resolving targets to canon ids', async () => {
+    mockCallGemini.mockResolvedValueOnce({
+      verb: 'talk',
+      targets: ['Captain Orla Vance'],
+      params: { topic: 'the job' },
+    });
+
+    const result = await interpretAction({
+      actionText: 'talk to captain orla vance about the job',
+      canonWorld: MINI_WORLD,
+      save: {},
+      worldState: {},
+    });
+
+    expect(result).toEqual({
+      verb: 'talk',
+      targets: ['captain-orla-vance'],
+      params: { topic: 'the job' },
+    });
+  });
+
+  it('leaves an unresolvable target as raw text rather than dropping it', async () => {
+    mockCallGemini.mockResolvedValueOnce({
+      verb: 'talk',
+      targets: ['a passing stranger'],
+      params: {},
+    });
+
+    const result = await interpretAction({
+      actionText: 'talk to the stranger',
+      canonWorld: MINI_WORLD,
+      save: {},
+      worldState: {},
+    });
+
+    expect(result.targets).toEqual(['a passing stranger']);
+  });
+
+  it('lowercases and truncates an overly long verb', async () => {
+    mockCallGemini.mockResolvedValueOnce({
+      verb: 'A'.repeat(80),
+      targets: [],
+      params: {},
+    });
+
+    const result = await interpretAction({
+      actionText: 'do something',
+      canonWorld: MINI_WORLD,
+      save: {},
+      worldState: {},
+    });
+
+    expect(result.verb).toHaveLength(50);
+    expect(result.verb).toBe('a'.repeat(50));
+  });
+
+  it('defaults params to {} when the model omits it or returns a non-object', async () => {
+    mockCallGemini.mockResolvedValueOnce({ verb: 'look', targets: [] });
+
+    const result = await interpretAction({
+      actionText: 'look around',
+      canonWorld: MINI_WORLD,
+      save: {},
+      worldState: {},
+    });
+
+    expect(result.params).toEqual({});
+  });
+
+  it('falls back to a safe passthrough when callGemini throws', async () => {
+    mockCallGemini.mockRejectedValueOnce(new Error('AI unavailable'));
+
+    const result = await interpretAction({
+      actionText: 'set sail',
+      canonWorld: MINI_WORLD,
+      save: {},
+      worldState: {},
+    });
+
+    expect(result).toEqual({ verb: 'unknown', targets: [], params: { raw: 'set sail' } });
+  });
+
+  it('falls back to a safe passthrough when the model omits verb', async () => {
+    mockCallGemini.mockResolvedValueOnce({ targets: [] });
+
+    const result = await interpretAction({
+      actionText: 'set sail',
+      canonWorld: MINI_WORLD,
+      save: {},
+      worldState: {},
+    });
+
+    expect(result).toEqual({ verb: 'unknown', targets: [], params: { raw: 'set sail' } });
+  });
+
+  it('falls back to a safe passthrough when targets is not an array', async () => {
+    mockCallGemini.mockResolvedValueOnce({ verb: 'look', targets: 'everywhere' });
+
+    const result = await interpretAction({
+      actionText: 'look everywhere',
+      canonWorld: MINI_WORLD,
+      save: {},
+      worldState: {},
+    });
+
+    expect(result).toEqual({ verb: 'unknown', targets: [], params: { raw: 'look everywhere' } });
+  });
+
+  it('falls back to a safe passthrough when the model returns null', async () => {
+    mockCallGemini.mockResolvedValueOnce(null);
+
+    const result = await interpretAction({
+      actionText: 'wait',
+      canonWorld: MINI_WORLD,
+      save: {},
+      worldState: {},
+    });
+
+    expect(result).toEqual({ verb: 'unknown', targets: [], params: { raw: 'wait' } });
+  });
+
+  it('never returns an outcome or mutation-shaped field — intent only', async () => {
+    mockCallGemini.mockResolvedValueOnce({
+      verb: 'attack',
+      targets: ['captain-orla-vance'],
+      params: {},
+      outcome: 'success',
+      mutations: [{ op: 'increment', path: 'x', value: 1 }],
+    });
+
+    const result = await interpretAction({
+      actionText: 'attack orla',
+      canonWorld: MINI_WORLD,
+      save: {},
+      worldState: {},
+    });
+
+    expect(Object.keys(result).sort()).toEqual(['params', 'targets', 'verb']);
+  });
+
+  it('works against the real Shattered Coast canon world end-to-end', async () => {
+    mockCallGemini.mockResolvedValueOnce({
+      verb: 'move',
+      targets: ["Widow's Reach"],
+      params: {},
+    });
+
+    const result = await interpretAction({
+      actionText: 'head back to the cove',
+      canonWorld: CANON_WORLD,
+      save: {},
+      worldState: {},
+    });
+
+    expect(result.targets).toEqual(['widows-reach']);
+  });
+});


### PR DESCRIPTION
## Summary
- Replaces the L-110 passthrough stub in `functions/loom-turn/interpret.js` with a real Gemini 2.5 Flash call (`callGemini` with `jsonMode: true`, `thinkingBudget: 0`) that parses player free-text into `{ verb, targets[], params }`.
- The system prompt explicitly scopes the model to intent extraction only — no adjudication, no invented outcomes/dice/state changes — and lists the world's known canon entities (locations/factions/characters) so it can name them by id when it recognizes them.
- Target resolution happens server-side, not just via the model: `resolveTarget()` tries exact id match → normalized name match → substring fuzzy match against the canon entity list, so the model doesn't have to guess exact ids. Anything that still doesn't resolve is passed through as raw text rather than dropped, so ADJUDICATE (L-112 / #299) can treat it as an unresolved target instead of the turn crashing.
- Any `callGemini` failure or malformed/empty response (missing `verb`, non-array `targets`, `null`, etc.) falls back to the same safe passthrough action L-110 already established (`{ verb: 'unknown', targets: [], params: { raw: actionText } }`) — INTERPRET never blocks a turn from reaching ADJUDICATE.
- The orchestrator's call signature is unchanged, so this is a drop-in replacement for the stub.

Closes #298 (L-111).

## Test plan
- [x] `tests/loom-interpret.test.js` — 15 new unit tests (mocked `callGemini`): entity list construction, all three tiers of target resolution, well-formed-response mapping, verb lowercasing/truncation, params defaulting, every fallback path (API throws, missing verb, non-array targets, null response), a check that no outcome/mutation fields leak through, and an end-to-end pass against the real Shattered Coast canon world (L-103 / #296)
- [x] Full suite: `firebase emulators:exec --only firestore --project demo-olympus-rules-test "cd tests && npm test"` — 205/205 passing
- [x] `npm run lint:fix` / `npm run format` clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01XVNW1uHGnfWpM69kac16WF)_