### PR TITLE
feat(loom): Stage 3 ADJUDICATE — rules engine + server dice (L-112)

### DIFF
--- a/functions/loom-turn/adjudicate.js
+++ b/functions/loom-turn/adjudicate.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const crypto = require('crypto');
+
 /**
  * Stage 3 — ADJUDICATE (design doc §5, §11 L-140).
  *
@@ -11,35 +13,132 @@
  *   evaluate(proposedAction, worldState, characterState, dice) → Resolution
  *
  * so a data-driven rules engine (Phase 2, L-202) can later replace the body
- * of evaluate() without reshaping the pipeline.
+ * of evaluate() without reshaping the pipeline. evaluate() is a pure
+ * function — dice is an already-rolled value, not a source of randomness —
+ * so behavior is fully reproducible in tests; only adjudicateAction() (the
+ * orchestrator-facing wrapper) touches the RNG.
  *
- * STUB (L-110 / #297): evaluate() always returns a no-op acknowledgment with
- * no mutations and no constraints. Replaced by L-112 (#299) with the real
- * hand-coded rules engine + server dice.
- *
- * @param {object} proposedAction
- * @param {object} worldState
- * @param {object} characterState
- * @param {*} dice
- * @returns {{ outcome: string, mutations: object[], constraints: string[] }}
+ * MVP rule set (hand-coded per world, per L-140): a movement-legality check
+ * — "can this character reach that location?" — against the canon
+ * connections graph and the requiresAbility rule hook (L-103 / #296),
+ * mirroring the design doc's own "can the character fly?" example. Anything
+ * else falls back to a simple d20-vs-difficulty-class check so server dice
+ * are exercised uniformly. Richer per-verb rules are Phase 2 (L-202 / #313).
  */
-function evaluate(proposedAction, worldState, characterState, dice) {
+
+const DEFAULT_DIFFICULTY_CLASS = 10;
+
+/** Server-side d20, generated fresh per call — never client- or model-supplied. */
+function rollDie() {
+  return crypto.randomInt(1, 21);
+}
+
+function evaluateMove(proposedAction, worldState, characterState, canonWorld) {
+  const targetId = proposedAction.targets[0];
+  const currentId = characterState.location;
+
+  if (!currentId || !canonWorld.locations[currentId]) {
+    return {
+      outcome: 'blocked',
+      mutations: [],
+      constraints: ['You have nowhere established to move from yet.'],
+    };
+  }
+
+  if (!targetId || !canonWorld.locations[targetId]) {
+    return {
+      outcome: 'invalid_target',
+      mutations: [],
+      constraints: ["There's no such place to go."],
+    };
+  }
+
+  if (targetId === currentId) {
+    return {
+      outcome: 'no_op',
+      mutations: [],
+      constraints: ["You're already there."],
+    };
+  }
+
+  const currentLocation = canonWorld.locations[currentId];
+  if (currentLocation.connections.indexOf(targetId) === -1) {
+    return {
+      outcome: 'blocked',
+      mutations: [],
+      constraints: ["You can't get there directly from here."],
+    };
+  }
+
+  const targetLocation = canonWorld.locations[targetId];
+  const requiredAbility = targetLocation.rules && targetLocation.rules.requiresAbility;
+  const abilities = characterState.abilities || [];
+  if (requiredAbility && abilities.indexOf(requiredAbility) === -1) {
+    return {
+      outcome: 'blocked',
+      mutations: [],
+      constraints: [
+        'You lack what it takes to make that crossing (requires: ' + requiredAbility + ').',
+      ],
+    };
+  }
+
   return {
-    outcome: 'acknowledged',
+    outcome: 'success',
+    mutations: [
+      { target: 'save', op: 'set-flag', path: 'location', value: targetId },
+      { op: 'increment', path: 'worldClock', value: 1 },
+    ],
+    constraints: ['You arrive at ' + targetLocation.name + '.'],
+  };
+}
+
+function evaluateGeneric(proposedAction, dice) {
+  const success = dice >= DEFAULT_DIFFICULTY_CLASS;
+  return {
+    outcome: success ? 'success' : 'failure',
     mutations: [],
-    constraints: [],
+    constraints: [
+      success
+        ? 'The attempt to ' + proposedAction.verb + ' succeeds.'
+        : 'The attempt to ' + proposedAction.verb + ' does not succeed.',
+    ],
   };
 }
 
 /**
- * @param {{ proposedAction: object, canonWorld: object, save: object, worldState: object }} params
- * @returns {Promise<{ outcome: string, mutations: object[], constraints: string[] }>}
+ * @param {object} proposedAction - { verb, targets[], params } from INTERPRET (L-111 / #298)
+ * @param {object} worldState
+ * @param {object} characterState
+ * @param {number} dice - an already-rolled d20 value (1-20)
+ * @param {object} canonWorld - read-only canon (L-103 / #296)
+ * @returns {{ outcome: string, mutations: object[], constraints: string[] }}
  */
-async function adjudicateAction(params) {
-  const { proposedAction, save, worldState } = params;
-  // Server-side dice belongs here once real rules land (L-112); none needed yet.
-  const dice = null;
-  return evaluate(proposedAction, worldState, save, dice);
+function evaluate(proposedAction, worldState, characterState, dice, canonWorld) {
+  let resolution;
+  if (proposedAction.verb === 'move') {
+    resolution = evaluateMove(proposedAction, worldState, characterState, canonWorld);
+  } else {
+    resolution = evaluateGeneric(proposedAction, dice);
+  }
+
+  // Resolution is immutable once produced — NARRATE (L-113) can color it, never change it.
+  return Object.freeze({
+    outcome: resolution.outcome,
+    mutations: Object.freeze(resolution.mutations),
+    constraints: Object.freeze(resolution.constraints),
+  });
 }
 
-module.exports = { evaluate, adjudicateAction };
+/**
+ * @param {{ proposedAction: object, canonWorld: object, save: object, worldState: object }} params
+ * @param {() => number} [rollFn] - override for tests; defaults to the real server-side die
+ * @returns {Promise<{ outcome: string, mutations: object[], constraints: string[] }>}
+ */
+async function adjudicateAction(params, rollFn = rollDie) {
+  const { proposedAction, canonWorld, save, worldState } = params;
+  const dice = rollFn();
+  return evaluate(proposedAction, worldState, save, dice, canonWorld);
+}
+
+module.exports = { evaluate, adjudicateAction, rollDie, DEFAULT_DIFFICULTY_CLASS };

--- a/tests/loom-adjudicate.test.js
+++ b/tests/loom-adjudicate.test.js
@@ -1,0 +1,224 @@
+'use strict';
+
+/**
+ * Unit tests for functions/loom-turn/adjudicate.js (L-112).
+ *
+ * evaluate() is a pure function (dice is an already-rolled value), so these
+ * tests are fully deterministic without mocking randomness. No Firestore
+ * emulator required.
+ *
+ * Run: cd tests && npx jest loom-adjudicate --verbose
+ */
+
+const {
+  evaluate,
+  adjudicateAction,
+  rollDie,
+  DEFAULT_DIFFICULTY_CLASS,
+} = require('../functions/loom-turn/adjudicate');
+const { getWorld } = require('../functions/loom-canon');
+
+const CANON_WORLD = getWorld('shattered-coast');
+
+function makeProposedAction(overrides) {
+  return Object.assign({ verb: 'look', targets: [], params: {} }, overrides);
+}
+
+function makeCharacterState(overrides) {
+  return Object.assign({ location: 'widows-reach', abilities: [] }, overrides);
+}
+
+describe('rollDie', () => {
+  it('always returns an integer between 1 and 20 inclusive', () => {
+    for (let i = 0; i < 200; i++) {
+      const value = rollDie();
+      expect(Number.isInteger(value)).toBe(true);
+      expect(value).toBeGreaterThanOrEqual(1);
+      expect(value).toBeLessThanOrEqual(20);
+    }
+  });
+});
+
+describe('evaluate — move verb', () => {
+  it('rejects a move with no established current location', () => {
+    const resolution = evaluate(
+      makeProposedAction({ verb: 'move', targets: ['skeleton-cove'] }),
+      {},
+      makeCharacterState({ location: null }),
+      10,
+      CANON_WORLD
+    );
+    expect(resolution.outcome).toBe('blocked');
+  });
+
+  it('rejects a move to an unknown location', () => {
+    const resolution = evaluate(
+      makeProposedAction({ verb: 'move', targets: ['nonexistent-place'] }),
+      {},
+      makeCharacterState(),
+      10,
+      CANON_WORLD
+    );
+    expect(resolution.outcome).toBe('invalid_target');
+    expect(resolution.mutations).toHaveLength(0);
+  });
+
+  it('treats moving to the current location as a no-op', () => {
+    const resolution = evaluate(
+      makeProposedAction({ verb: 'move', targets: ['widows-reach'] }),
+      {},
+      makeCharacterState({ location: 'widows-reach' }),
+      10,
+      CANON_WORLD
+    );
+    expect(resolution.outcome).toBe('no_op');
+  });
+
+  it('rejects a move to a location with no direct connection', () => {
+    // widows-reach connects to skeleton-cove and the-drowned-shoals, not fort-augustine directly
+    const resolution = evaluate(
+      makeProposedAction({ verb: 'move', targets: ['fort-augustine'] }),
+      {},
+      makeCharacterState({ location: 'widows-reach' }),
+      10,
+      CANON_WORLD
+    );
+    expect(resolution.outcome).toBe('blocked');
+    expect(resolution.mutations).toHaveLength(0);
+  });
+
+  it('rejects a move requiring an ability the character lacks', () => {
+    // the-drowned-shoals requires the 'seaworthy-vessel' ability
+    const resolution = evaluate(
+      makeProposedAction({ verb: 'move', targets: ['the-drowned-shoals'] }),
+      {},
+      makeCharacterState({ location: 'widows-reach', abilities: [] }),
+      10,
+      CANON_WORLD
+    );
+    expect(resolution.outcome).toBe('blocked');
+    expect(resolution.constraints[0]).toMatch(/seaworthy-vessel/);
+    expect(resolution.mutations).toHaveLength(0);
+  });
+
+  it('allows a legal move with the required ability and produces the expected mutations', () => {
+    const resolution = evaluate(
+      makeProposedAction({ verb: 'move', targets: ['the-drowned-shoals'] }),
+      {},
+      makeCharacterState({ location: 'widows-reach', abilities: ['seaworthy-vessel'] }),
+      10,
+      CANON_WORLD
+    );
+    expect(resolution.outcome).toBe('success');
+    expect(resolution.mutations).toEqual([
+      { target: 'save', op: 'set-flag', path: 'location', value: 'the-drowned-shoals' },
+      { op: 'increment', path: 'worldClock', value: 1 },
+    ]);
+  });
+
+  it('allows a legal move to a location with no ability requirement', () => {
+    const resolution = evaluate(
+      makeProposedAction({ verb: 'move', targets: ['skeleton-cove'] }),
+      {},
+      makeCharacterState({ location: 'widows-reach', abilities: [] }),
+      10,
+      CANON_WORLD
+    );
+    expect(resolution.outcome).toBe('success');
+  });
+});
+
+describe('evaluate — generic (dice) verbs', () => {
+  it('succeeds when the roll meets the difficulty class', () => {
+    const resolution = evaluate(
+      makeProposedAction({ verb: 'search' }),
+      {},
+      makeCharacterState(),
+      DEFAULT_DIFFICULTY_CLASS,
+      CANON_WORLD
+    );
+    expect(resolution.outcome).toBe('success');
+    expect(resolution.mutations).toHaveLength(0);
+  });
+
+  it('fails when the roll is below the difficulty class', () => {
+    const resolution = evaluate(
+      makeProposedAction({ verb: 'search' }),
+      {},
+      makeCharacterState(),
+      DEFAULT_DIFFICULTY_CLASS - 1,
+      CANON_WORLD
+    );
+    expect(resolution.outcome).toBe('failure');
+    expect(resolution.mutations).toHaveLength(0);
+  });
+
+  it('never mutates state for a generic action, win or lose', () => {
+    [1, 20].forEach((dice) => {
+      const resolution = evaluate(
+        makeProposedAction({ verb: 'attack', targets: ['commandant-de-alva'] }),
+        {},
+        makeCharacterState(),
+        dice,
+        CANON_WORLD
+      );
+      expect(resolution.mutations).toEqual([]);
+    });
+  });
+});
+
+describe('evaluate — resolution immutability', () => {
+  it('freezes the returned resolution and its arrays', () => {
+    const resolution = evaluate(
+      makeProposedAction({ verb: 'look' }),
+      {},
+      makeCharacterState(),
+      10,
+      CANON_WORLD
+    );
+    expect(Object.isFrozen(resolution)).toBe(true);
+    expect(Object.isFrozen(resolution.mutations)).toBe(true);
+    expect(Object.isFrozen(resolution.constraints)).toBe(true);
+
+    expect(() => {
+      'use strict';
+      resolution.outcome = 'hacked';
+    }).toThrow();
+    expect(resolution.outcome).toBe('success');
+  });
+});
+
+describe('adjudicateAction', () => {
+  it('uses the injected roll function instead of the real RNG', async () => {
+    const resolution = await adjudicateAction(
+      {
+        proposedAction: makeProposedAction({ verb: 'search' }),
+        canonWorld: CANON_WORLD,
+        save: makeCharacterState(),
+        worldState: {},
+      },
+      () => DEFAULT_DIFFICULTY_CLASS
+    );
+    expect(resolution.outcome).toBe('success');
+  });
+
+  it('defaults to the real server die when no roll function is provided', async () => {
+    const resolution = await adjudicateAction({
+      proposedAction: makeProposedAction({ verb: 'search' }),
+      canonWorld: CANON_WORLD,
+      save: makeCharacterState(),
+      worldState: {},
+    });
+    expect(['success', 'failure']).toContain(resolution.outcome);
+  });
+
+  it('routes a move proposedAction through evaluateMove via the same wrapper', async () => {
+    const resolution = await adjudicateAction({
+      proposedAction: makeProposedAction({ verb: 'move', targets: ['skeleton-cove'] }),
+      canonWorld: CANON_WORLD,
+      save: makeCharacterState({ location: 'widows-reach' }),
+      worldState: {},
+    });
+    expect(resolution.outcome).toBe('success');
+  });
+});


### PR DESCRIPTION
## Summary
- Replaces the L-110 no-op stub in `functions/loom-turn/adjudicate.js` with the real rules engine behind the L-140 seam: `evaluate(proposedAction, worldState, characterState, dice, canonWorld) → Resolution`.
- `evaluate()` is a pure function — `dice` is an already-rolled value, not a randomness source — so its behavior is fully reproducible in tests. Only the new `adjudicateAction()` wrapper touches the RNG, via an injectable `rollFn` parameter that defaults to a real `crypto.randomInt`-based d20 (`rollDie()`).
- MVP rule set (hand-coded, per L-140): a **movement-legality check** against the canon connections graph and the `requiresAbility` rule hook seeded in L-103 (#296) — this is the design doc's own "can the character fly before flying across the chasm?" example, applied to ship travel. Illegal moves (unknown target, no direct connection, missing required ability, no established current location) are rejected with **no mutations** rather than silently narrated as success. A legal move sets the character's location (`target: 'save'` mutation) and ticks the world clock.
- Any non-`move` verb falls back to a simple d20-vs-DC10 check with no mutations, so server dice get exercised uniformly across all actions. Richer per-verb rules are explicitly Phase 2 (L-202 / #313), not in scope here.
- The returned `Resolution` is deep-frozen, so NARRATE (L-113 / #300) can color it in prose but cannot mutate the outcome, mutations, or constraints it was given.
- Orchestrator call signature is unchanged (`adjudicateAction({ proposedAction, canonWorld, save, worldState })`) — drop-in replacement for the stub.

Closes #299 (L-112).

## Test plan
- [x] `tests/loom-adjudicate.test.js` — 15 new unit tests: `rollDie()` range, every move-legality branch (no current location, unknown target, no-op, unconnected, missing ability, legal-with-ability, legal-without-requirement) with exact mutation-shape assertions, the generic dice-vs-DC path (success/failure/no-mutations), resolution immutability (frozen, mutation attempts throw and don't stick), and the `adjudicateAction` wrapper (injected roll function, default real die, move routing)
- [x] Full suite: `firebase emulators:exec --only firestore --project demo-olympus-rules-test "cd tests && npm test"` — 220/220 passing, including the existing `loom-turn.test.js` end-to-end integration tests (confirms the real ADJUDICATE stage doesn't break the orchestrator wiring or the INTERPRET fallback path)
- [x] `npm run lint:fix` / `npm run format` clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01XVNW1uHGnfWpM69kac16WF)_