### PR TITLE
feat(loom): harden COMMIT with soft-canon + summary-regen seams (L-114)

### DIFF
--- a/functions/loom-turn/commit.js
+++ b/functions/loom-turn/commit.js
@@ -2,19 +2,23 @@
 
 const { FieldValue } = require('firebase-admin/firestore');
 const { makeTurn, applyStateMutations } = require('../loom-models');
+const { quarantineEntities } = require('./soft-canon');
+const { shouldRegenerateSummary, maybeRegenerateSummary } = require('./summary');
 
 /**
  * Stage 5 — COMMIT (design doc §5, §8).
  *
  * Applies state_mutations to World/Character state, appends the turn to the
- * event log, and returns the client-facing contract. Runs inside a Firestore
- * transaction — re-reading fresh state and retrying on conflict — so a batch
- * tick (L-201) or another turn can never tear a write.
+ * event log, hands off model-invented entities to soft-canon quarantine, and
+ * triggers async summary regeneration past a threshold. Runs inside a
+ * Firestore transaction — re-reading fresh state and retrying on conflict —
+ * so a batch tick (L-201) or another turn can never tear a write.
  *
- * L-110 (#297) ships a minimal version: mutation application + append-only
- * turn log + updatedAt bookkeeping. L-114 (#301) hardens this with soft-canon
- * handoff (L-115 / #302) and threshold-triggered summary regeneration
- * (L-116 / #303) — same signature, richer body.
+ * L-110 (#297) shipped a minimal version (mutation application + append-only
+ * turn log + updatedAt bookkeeping). L-114 (#301) hardens it with the
+ * soft-canon handoff (L-115 / #302, still a no-op stub until that issue
+ * lands) and the summary-regen trigger (L-116 / #303, likewise still a
+ * no-op stub) — same signature, richer body.
  *
  * Mutations may carry a `target: 'save'` field to route them to Character
  * state instead of World State; anything else (the default) applies to World
@@ -31,6 +35,7 @@ const { makeTurn, applyStateMutations } = require('../loom-models');
  *   resolution: { outcome: string, mutations: object[], constraints: string[] },
  *   narration: string,
  *   entityRefs: string[],
+ *   inventedEntities: string[],
  *   suggestedActions: string[],
  * }} params
  * @returns {Promise<{ narration: string, stateSummary: string, suggestedActions: string[] }>}
@@ -46,10 +51,11 @@ async function commitTurn(params) {
     resolution,
     narration,
     entityRefs,
+    inventedEntities,
     suggestedActions,
   } = params;
 
-  return db.runTransaction(async (transaction) => {
+  const { contractResult, nextIndex } = await db.runTransaction(async (transaction) => {
     const turnsQuery = saveRef.collection('loom_turns').orderBy('index', 'desc').limit(1);
     const [saveSnap, worldStateSnap, lastTurnSnap] = await Promise.all([
       transaction.get(saveRef),
@@ -73,10 +79,10 @@ async function commitTurn(params) {
     applyStateMutations(save, saveMutations);
     applyStateMutations(worldState, worldMutations);
 
-    const nextIndex = lastTurnSnap.empty ? 0 : lastTurnSnap.docs[0].data().index + 1;
+    const turnIndex = lastTurnSnap.empty ? 0 : lastTurnSnap.docs[0].data().index + 1;
 
     const turn = makeTurn({
-      index: nextIndex,
+      index: turnIndex,
       actionText,
       proposedAction,
       resolution,
@@ -92,12 +98,31 @@ async function commitTurn(params) {
       Object.assign({}, worldState, { updatedAt: FieldValue.serverTimestamp() })
     );
 
+    await quarantineEntities({
+      transaction,
+      db,
+      worldId,
+      inventedEntities: inventedEntities || [],
+    });
+
     return {
-      narration,
-      stateSummary: save.recentSummary || '',
-      suggestedActions: suggestedActions || [],
+      nextIndex: turnIndex,
+      contractResult: {
+        narration,
+        stateSummary: save.recentSummary || '',
+        suggestedActions: suggestedActions || [],
+      },
     };
   });
+
+  if (shouldRegenerateSummary(nextIndex)) {
+    // Fire-and-forget: summary regen must not add per-turn latency.
+    maybeRegenerateSummary({ db, saveRef, worldId, turnIndex: nextIndex }).catch((err) => {
+      console.error('maybeRegenerateSummary failed:', err);
+    });
+  }
+
+  return contractResult;
 }
 
 module.exports = { commitTurn };

--- a/functions/loom-turn/index.js
+++ b/functions/loom-turn/index.js
@@ -76,7 +76,7 @@ async function runTurnPipeline(params) {
 
   const proposedAction = await interpretAction({ actionText, canonWorld, save, worldState });
   const resolution = await adjudicateAction({ proposedAction, canonWorld, save, worldState });
-  const { narration, entityRefs, suggestedActions } = await narrateResolution({
+  const { narration, entityRefs, inventedEntities, suggestedActions } = await narrateResolution({
     actionText,
     proposedAction,
     resolution,
@@ -95,6 +95,7 @@ async function runTurnPipeline(params) {
     resolution,
     narration,
     entityRefs,
+    inventedEntities,
     suggestedActions,
   });
 }

--- a/functions/loom-turn/narrate.js
+++ b/functions/loom-turn/narrate.js
@@ -13,6 +13,10 @@
  * real Flash call assembling canon (L-103 / #296) + entity-keyed retrieval
  * (L-117 / #304) + rolling summary (L-116 / #303) context.
  *
+ * `inventedEntities` (added L-114 / #301) is the seam COMMIT's soft-canon
+ * handoff (L-115 / #302) consumes: names the model mentions that don't match
+ * a known canon/state entity. Always empty until L-113 adds real detection.
+ *
  * @param {{
  *   actionText: string,
  *   proposedAction: object,
@@ -21,7 +25,12 @@
  *   save: object,
  *   worldState: object,
  * }} params
- * @returns {Promise<{ narration: string, entityRefs: string[], suggestedActions: string[] }>}
+ * @returns {Promise<{
+ *   narration: string,
+ *   entityRefs: string[],
+ *   inventedEntities: string[],
+ *   suggestedActions: string[],
+ * }>}
  */
 async function narrateResolution(params) {
   const { actionText } = params;
@@ -29,6 +38,7 @@ async function narrateResolution(params) {
     narration:
       'You attempt to ' + actionText + '. The Loom takes note, but has little more to say — yet.',
     entityRefs: [],
+    inventedEntities: [],
     suggestedActions: [],
   };
 }

--- a/functions/loom-turn/soft-canon.js
+++ b/functions/loom-turn/soft-canon.js
@@ -1,0 +1,34 @@
+'use strict';
+
+/**
+ * Soft-canon quarantine (design doc §5, §11 L-115 / L-141).
+ *
+ * When NARRATE (L-113 / #300) names an entity absent from canon/state, COMMIT
+ * hands it off here to be written to `loom_softcanon` as provisional — never
+ * promoted into Canon itself (L-141 / #310, decided: promotion targets World
+ * State only). This runs inside the same COMMIT transaction (functions/
+ * loom-turn/commit.js) so a turn either fully commits — state, turn log, and
+ * quarantined entities together — or not at all.
+ *
+ * STUB (L-114 / #301): the handoff point exists and is wired into COMMIT, but
+ * nothing is written yet — NARRATE doesn't produce `inventedEntities` until
+ * L-113 (#300) lands, so this always receives an empty list in practice.
+ * Replaced by L-115 (#302) with the real quarantine write and the
+ * promote-on-second-reference rule.
+ *
+ * @param {{
+ *   transaction: FirebaseFirestore.Transaction,
+ *   db: FirebaseFirestore.Firestore,
+ *   worldId: string,
+ *   inventedEntities: string[],
+ * }} params
+ */
+async function quarantineEntities(params) {
+  const { inventedEntities } = params;
+  if (!inventedEntities || inventedEntities.length === 0) {
+    return;
+  }
+  // L-115 (#302) will write each entry to loom_softcanon here.
+}
+
+module.exports = { quarantineEntities };

--- a/functions/loom-turn/summary.js
+++ b/functions/loom-turn/summary.js
@@ -1,0 +1,37 @@
+'use strict';
+
+/**
+ * Rolling summary regeneration (design doc §4, §5 stage 5, §6 batch; L-116 /
+ * #303).
+ *
+ * The event log is summarized, never dropped. COMMIT (functions/loom-turn/
+ * commit.js) triggers this whenever the turn count crosses
+ * SUMMARY_REGEN_THRESHOLD. Triggering is fire-and-forget (not awaited by
+ * COMMIT) so it adds no per-turn latency, per the design doc.
+ *
+ * STUB (L-114 / #301): the threshold check and trigger point exist and are
+ * wired into COMMIT, but regeneration itself is a no-op. Replaced by L-116
+ * (#303) with a real callGemini call condensing loom_turns into
+ * loom_saves.recentSummary.
+ */
+
+const SUMMARY_REGEN_THRESHOLD = 10;
+
+/** True once the (0-indexed) turnIndex completes a multiple of the threshold. */
+function shouldRegenerateSummary(turnIndex) {
+  return (turnIndex + 1) % SUMMARY_REGEN_THRESHOLD === 0;
+}
+
+/**
+ * @param {{
+ *   db: FirebaseFirestore.Firestore,
+ *   saveRef: FirebaseFirestore.DocumentReference,
+ *   worldId: string,
+ *   turnIndex: number,
+ * }} params
+ */
+async function maybeRegenerateSummary(params) {
+  // L-116 (#303) will condense loom_turns into recentSummary here.
+}
+
+module.exports = { SUMMARY_REGEN_THRESHOLD, shouldRegenerateSummary, maybeRegenerateSummary };

--- a/tests/loom-soft-canon.test.js
+++ b/tests/loom-soft-canon.test.js
@@ -1,0 +1,40 @@
+'use strict';
+
+/**
+ * Unit tests for functions/loom-turn/soft-canon.js (L-114 stub; L-115 fills
+ * in the real quarantine write).
+ *
+ * Run: cd tests && npx jest loom-soft-canon --verbose
+ */
+
+const { quarantineEntities } = require('../functions/loom-turn/soft-canon');
+
+describe('quarantineEntities (stub)', () => {
+  it('resolves without throwing when inventedEntities is empty', async () => {
+    await expect(
+      quarantineEntities({
+        transaction: {},
+        db: {},
+        worldId: 'shattered-coast',
+        inventedEntities: [],
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it('resolves without throwing when inventedEntities is omitted', async () => {
+    await expect(
+      quarantineEntities({ transaction: {}, db: {}, worldId: 'shattered-coast' })
+    ).resolves.toBeUndefined();
+  });
+
+  it('resolves without throwing when inventedEntities is non-empty (still a no-op)', async () => {
+    await expect(
+      quarantineEntities({
+        transaction: {},
+        db: {},
+        worldId: 'shattered-coast',
+        inventedEntities: ['a barkeep named Doral'],
+      })
+    ).resolves.toBeUndefined();
+  });
+});

--- a/tests/loom-summary.test.js
+++ b/tests/loom-summary.test.js
@@ -1,0 +1,39 @@
+'use strict';
+
+/**
+ * Unit tests for functions/loom-turn/summary.js (L-114 stub; L-116 fills in
+ * the real regeneration).
+ *
+ * Run: cd tests && npx jest loom-summary --verbose
+ */
+
+const {
+  SUMMARY_REGEN_THRESHOLD,
+  shouldRegenerateSummary,
+  maybeRegenerateSummary,
+} = require('../functions/loom-turn/summary');
+
+describe('shouldRegenerateSummary', () => {
+  it('is false for turn indices before the threshold', () => {
+    for (let i = 0; i < SUMMARY_REGEN_THRESHOLD - 1; i++) {
+      expect(shouldRegenerateSummary(i)).toBe(false);
+    }
+  });
+
+  it('is true exactly when the turn count completes a multiple of the threshold', () => {
+    expect(shouldRegenerateSummary(SUMMARY_REGEN_THRESHOLD - 1)).toBe(true);
+    expect(shouldRegenerateSummary(2 * SUMMARY_REGEN_THRESHOLD - 1)).toBe(true);
+  });
+
+  it('is false for turn indices between threshold multiples', () => {
+    expect(shouldRegenerateSummary(SUMMARY_REGEN_THRESHOLD)).toBe(false);
+  });
+});
+
+describe('maybeRegenerateSummary (stub)', () => {
+  it('resolves without throwing', async () => {
+    await expect(
+      maybeRegenerateSummary({ db: {}, saveRef: {}, worldId: 'shattered-coast', turnIndex: 9 })
+    ).resolves.toBeUndefined();
+  });
+});

--- a/tests/loom-turn.test.js
+++ b/tests/loom-turn.test.js
@@ -216,4 +216,25 @@ describe('loomPlayTurn — end-to-end happy path', () => {
     const worldStateSnap = await db.collection('loom_world_state').doc(WORLD_ID).get();
     expect(worldStateSnap.data().worldClock).toBe(42);
   });
+
+  it('survives crossing the summary-regen threshold (L-114 fire-and-forget trigger)', async () => {
+    await seedSave();
+
+    // SUMMARY_REGEN_THRESHOLD is 10 — the 10th turn (index 9) crosses it.
+    for (let i = 0; i < 10; i++) {
+      const result = await callTurn({
+        worldId: WORLD_ID,
+        saveId: SAVE_ID,
+        actionText: 'wait quietly turn ' + i,
+      });
+      expect(typeof result.narration).toBe('string');
+    }
+
+    const turnsSnap = await db
+      .collection('loom_saves')
+      .doc(SAVE_ID)
+      .collection('loom_turns')
+      .get();
+    expect(turnsSnap.size).toBe(10);
+  });
 });


### PR DESCRIPTION
## Summary
- Extends COMMIT (`functions/loom-turn/commit.js`) with the two hooks the design doc assigns to this stage beyond L-110's minimal version:
  - **Soft-canon handoff** (`functions/loom-turn/soft-canon.js`): a stub `quarantineEntities()` called *inside* the same COMMIT transaction, so a turn commits state + turn log + quarantined entities atomically, or not at all. Replaced by L-115 (#302) with the real quarantine write + promote-on-second-reference rule.
  - **Summary-regen trigger** (`functions/loom-turn/summary.js`): a stub `maybeRegenerateSummary()`, fired (not awaited) once the turn count crosses `SUMMARY_REGEN_THRESHOLD` (10), so it adds no per-turn latency per the design doc. Replaced by L-116 (#303) with the real `callGemini`-backed regeneration.
- NARRATE's stub contract (`functions/loom-turn/narrate.js`) gains an `inventedEntities` field (always `[]` until L-113 / #300 adds real detection) — this is the seam soft-canon quarantine will consume once wired end-to-end.
- Both hooks are intentionally no-ops today — this issue is about the seams existing and being exercised correctly (transaction placement, fire-and-forget timing, threshold math), not the real implementations, which are separate later issues.
- The already-solid parts of COMMIT from L-110 (transactional mutation application, monotonic turn indexing, atomic partial-failure safety) are unchanged.

Closes #301 (L-114).

## Test plan
- [x] `tests/loom-soft-canon.test.js` — 3 new unit tests: the stub resolves cleanly for empty/omitted/non-empty `inventedEntities`
- [x] `tests/loom-summary.test.js` — 4 new unit tests: `shouldRegenerateSummary` threshold math (before/at/between multiples) + the stub resolves cleanly
- [x] Extended `tests/loom-turn.test.js` with a 10-turn integration test that crosses `SUMMARY_REGEN_THRESHOLD`, asserting the fire-and-forget trigger doesn't throw or corrupt the turn log (exactly 10 `loom_turns` docs afterward)
- [x] Full suite: `firebase emulators:exec --only firestore --project demo-olympus-rules-test "cd tests && npm test"` — 228/228 passing
- [x] `npm run lint:fix` / `npm run format:check` clean (1 pre-existing-pattern harmless warning for the `summary.js` stub's unused param, consistent with `adjudicate.js`'s earlier stub warnings; doesn't fail CI)


---
_Generated by [Claude Code](https://claude.ai/code/session_01XVNW1uHGnfWpM69kac16WF)_