### PR TITLE
feat(loom): rolling summary regeneration via Flash (L-116)

### DIFF
--- a/functions/loom-turn/summary.js
+++ b/functions/loom-turn/summary.js
@@ -1,5 +1,8 @@
 'use strict';
 
+const { FieldValue } = require('firebase-admin/firestore');
+const { callGemini } = require('../gemini');
+
 /**
  * Rolling summary regeneration (design doc §4, §5 stage 5, §6 batch; L-116 /
  * #303).
@@ -9,17 +12,83 @@
  * SUMMARY_REGEN_THRESHOLD. Triggering is fire-and-forget (not awaited by
  * COMMIT) so it adds no per-turn latency, per the design doc.
  *
- * STUB (L-114 / #301): the threshold check and trigger point exist and are
- * wired into COMMIT, but regeneration itself is a no-op. Replaced by L-116
- * (#303) with a real callGemini call condensing loom_turns into
- * loom_saves.recentSummary.
+ * Condenses the most recent turns plus the existing recap into an updated
+ * `loom_saves.recentSummary` via a single Flash call. The raw `loom_turns`
+ * log itself is never touched here — it stays append-only and complete;
+ * only the dense recap is ever regenerated/replaced.
  */
 
 const SUMMARY_REGEN_THRESHOLD = 10;
+const MODEL_NAME = 'gemini-2.5-flash';
+const MAX_OUTPUT_TOKENS = 1024;
+const MAX_SUMMARY_CHARS = 2000;
 
 /** True once the (0-indexed) turnIndex completes a multiple of the threshold. */
 function shouldRegenerateSummary(turnIndex) {
   return (turnIndex + 1) % SUMMARY_REGEN_THRESHOLD === 0;
+}
+
+function buildSystemInstruction() {
+  return (
+    'You are the summarizer for a persistent text-adventure game world. Condense the ' +
+    'provided turn log into a dense recap of important, ongoing facts: where the character ' +
+    'is, what they have done, who they have met, promises made, threats pending, and any ' +
+    'other detail future turns need to remember.\n\n' +
+    'Preserve hard facts exactly — never invent details, and never drop a fact that still ' +
+    'matters. You will be given the PREVIOUS SUMMARY (may be empty) and the RECENT TURNS ' +
+    'since. Merge them into a single updated summary that stays under ' +
+    MAX_SUMMARY_CHARS +
+    ' characters by trimming the least important older details first, never by dropping ' +
+    'recent hard facts.\n\n' +
+    'Respond with ONLY the updated summary as plain prose — no headings, no preamble, no ' +
+    'commentary about the task.'
+  );
+}
+
+function buildUserMessage(previousSummary, turns) {
+  const turnLines = turns
+    .map(
+      (turn) =>
+        '- Action: ' +
+        turn.actionText +
+        ' | Outcome: ' +
+        turn.resolution.outcome +
+        ' | Narration: ' +
+        turn.narration
+    )
+    .join('\n');
+
+  return (
+    'PREVIOUS SUMMARY:\n' + (previousSummary || '(none yet)') + '\n\nRECENT TURNS:\n' + turnLines
+  );
+}
+
+/** Calls Gemini to produce the updated summary text; falls back to the previous summary on failure. */
+async function regenerateSummaryText(previousSummary, turns) {
+  if (turns.length === 0) {
+    return previousSummary || '';
+  }
+
+  let raw;
+  try {
+    raw = await callGemini({
+      modelName: MODEL_NAME,
+      systemInstruction: buildSystemInstruction(),
+      userMessage: buildUserMessage(previousSummary, turns),
+      maxOutputTokens: MAX_OUTPUT_TOKENS,
+      jsonMode: false,
+      thinkingBudget: 0,
+    });
+  } catch (err) {
+    console.error('regenerateSummaryText: callGemini failed, keeping previous summary', err);
+    return previousSummary || '';
+  }
+
+  const text = String(raw || '').trim();
+  if (!text) {
+    return previousSummary || '';
+  }
+  return text.length > MAX_SUMMARY_CHARS ? text.slice(0, MAX_SUMMARY_CHARS) : text;
 }
 
 /**
@@ -31,7 +100,32 @@ function shouldRegenerateSummary(turnIndex) {
  * }} params
  */
 async function maybeRegenerateSummary(params) {
-  // L-116 (#303) will condense loom_turns into recentSummary here.
+  const { saveRef } = params;
+
+  const turnsSnap = await saveRef
+    .collection('loom_turns')
+    .orderBy('index', 'desc')
+    .limit(SUMMARY_REGEN_THRESHOLD)
+    .get();
+  if (turnsSnap.empty) {
+    return;
+  }
+  const turns = turnsSnap.docs.map((doc) => doc.data()).reverse();
+
+  const saveSnap = await saveRef.get();
+  if (!saveSnap.exists) {
+    return;
+  }
+  const previousSummary = saveSnap.data().recentSummary || '';
+
+  const recentSummary = await regenerateSummaryText(previousSummary, turns);
+
+  await saveRef.update({ recentSummary, updatedAt: FieldValue.serverTimestamp() });
 }
 
-module.exports = { SUMMARY_REGEN_THRESHOLD, shouldRegenerateSummary, maybeRegenerateSummary };
+module.exports = {
+  SUMMARY_REGEN_THRESHOLD,
+  MAX_SUMMARY_CHARS,
+  shouldRegenerateSummary,
+  maybeRegenerateSummary,
+};

--- a/tests/loom-summary.test.js
+++ b/tests/loom-summary.test.js
@@ -1,17 +1,71 @@
 'use strict';
 
 /**
- * Unit tests for functions/loom-turn/summary.js (L-114 stub; L-116 fills in
- * the real regeneration).
+ * Unit tests for functions/loom-turn/summary.js (L-116).
+ *
+ * Mocks functions/gemini.js's callGemini and a minimal fake Firestore
+ * saveRef to test summary regeneration in isolation. Does not require the
+ * Firestore emulator (the end-to-end threshold-crossing path is covered by
+ * tests/loom-turn.test.js against the real emulator).
  *
  * Run: cd tests && npx jest loom-summary --verbose
  */
 
+const mockCallGemini = jest.fn();
+jest.mock('../functions/gemini', () => ({
+  callGemini: (...args) => mockCallGemini(...args),
+}));
+
 const {
   SUMMARY_REGEN_THRESHOLD,
+  MAX_SUMMARY_CHARS,
   shouldRegenerateSummary,
   maybeRegenerateSummary,
 } = require('../functions/loom-turn/summary');
+
+function makeTurn(overrides) {
+  return Object.assign(
+    { index: 0, actionText: 'look around', resolution: { outcome: 'success' }, narration: 'x' },
+    overrides
+  );
+}
+
+/** Minimal fake Firestore DocumentReference supporting the calls summary.js makes. */
+function makeFakeSaveRef({ turns, save }) {
+  const updateCalls = [];
+  const ref = {
+    collection() {
+      return {
+        orderBy() {
+          return {
+            limit() {
+              return {
+                async get() {
+                  return {
+                    empty: turns.length === 0,
+                    docs: turns.map((t) => ({ data: () => t })),
+                  };
+                },
+              };
+            },
+          };
+        },
+      };
+    },
+    async get() {
+      return { exists: save !== null, data: () => save };
+    },
+    async update(fields) {
+      updateCalls.push(fields);
+      Object.assign(save, fields);
+    },
+  };
+  return { ref, updateCalls, save };
+}
+
+beforeEach(() => {
+  mockCallGemini.mockReset();
+});
 
 describe('shouldRegenerateSummary', () => {
   it('is false for turn indices before the threshold', () => {
@@ -30,10 +84,77 @@ describe('shouldRegenerateSummary', () => {
   });
 });
 
-describe('maybeRegenerateSummary (stub)', () => {
-  it('resolves without throwing', async () => {
-    await expect(
-      maybeRegenerateSummary({ db: {}, saveRef: {}, worldId: 'shattered-coast', turnIndex: 9 })
-    ).resolves.toBeUndefined();
+describe('maybeRegenerateSummary', () => {
+  it('does nothing when there are no turns yet', async () => {
+    const { ref, updateCalls } = makeFakeSaveRef({ turns: [], save: { recentSummary: '' } });
+    await maybeRegenerateSummary({ saveRef: ref, worldId: 'shattered-coast', turnIndex: 9 });
+    expect(updateCalls).toHaveLength(0);
+    expect(mockCallGemini).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the save no longer exists', async () => {
+    const { ref, updateCalls } = makeFakeSaveRef({ turns: [makeTurn()], save: null });
+    await maybeRegenerateSummary({ saveRef: ref, worldId: 'shattered-coast', turnIndex: 9 });
+    expect(updateCalls).toHaveLength(0);
+  });
+
+  it('writes the model-produced summary to recentSummary', async () => {
+    mockCallGemini.mockResolvedValueOnce('A condensed recap of the last ten turns.');
+    const { ref, save } = makeFakeSaveRef({
+      turns: [makeTurn({ index: 0 }), makeTurn({ index: 1 })],
+      save: { recentSummary: 'old summary' },
+    });
+
+    await maybeRegenerateSummary({ saveRef: ref, worldId: 'shattered-coast', turnIndex: 9 });
+
+    expect(save.recentSummary).toBe('A condensed recap of the last ten turns.');
+  });
+
+  it('passes the previous summary and turn log to the model call', async () => {
+    mockCallGemini.mockResolvedValueOnce('updated');
+    const { ref } = makeFakeSaveRef({
+      turns: [makeTurn({ actionText: 'talk to Doran', index: 0 })],
+      save: { recentSummary: 'previously on the Loom...' },
+    });
+
+    await maybeRegenerateSummary({ saveRef: ref, worldId: 'shattered-coast', turnIndex: 9 });
+
+    const callArgs = mockCallGemini.mock.calls[0][0];
+    expect(callArgs.userMessage).toContain('previously on the Loom...');
+    expect(callArgs.userMessage).toContain('talk to Doran');
+    expect(callArgs.jsonMode).toBe(false);
+  });
+
+  it('truncates an overly long summary to MAX_SUMMARY_CHARS', async () => {
+    mockCallGemini.mockResolvedValueOnce('x'.repeat(MAX_SUMMARY_CHARS + 500));
+    const { ref, save } = makeFakeSaveRef({ turns: [makeTurn()], save: { recentSummary: '' } });
+
+    await maybeRegenerateSummary({ saveRef: ref, worldId: 'shattered-coast', turnIndex: 9 });
+
+    expect(save.recentSummary).toHaveLength(MAX_SUMMARY_CHARS);
+  });
+
+  it('falls back to the previous summary when callGemini throws', async () => {
+    mockCallGemini.mockRejectedValueOnce(new Error('AI unavailable'));
+    const { ref, save } = makeFakeSaveRef({
+      turns: [makeTurn()],
+      save: { recentSummary: 'keep me' },
+    });
+
+    await maybeRegenerateSummary({ saveRef: ref, worldId: 'shattered-coast', turnIndex: 9 });
+
+    expect(save.recentSummary).toBe('keep me');
+  });
+
+  it('falls back to the previous summary when the model returns empty text', async () => {
+    mockCallGemini.mockResolvedValueOnce('   ');
+    const { ref, save } = makeFakeSaveRef({
+      turns: [makeTurn()],
+      save: { recentSummary: 'keep me too' },
+    });
+
+    await maybeRegenerateSummary({ saveRef: ref, worldId: 'shattered-coast', turnIndex: 9 });
+
+    expect(save.recentSummary).toBe('keep me too');
   });
 });


### PR DESCRIPTION
## Summary
- Replaces the L-114 no-op stub in `functions/loom-turn/summary.js` with a real implementation: condenses the most recent turns (up to `SUMMARY_REGEN_THRESHOLD` = 10) plus the existing `recentSummary` into an updated recap via a single Gemini 2.5 Flash call (`functions/gemini.js` → `callGemini`, `jsonMode: false`, `thinkingBudget: 0`).
- The raw `loom_turns` log is never touched by this — it stays append-only and complete; only the dense recap in `loom_saves.recentSummary` is ever regenerated/replaced.
- The summary is bounded to `MAX_SUMMARY_CHARS` (2000) — truncated if the model overruns it.
- Any `callGemini` failure or empty/whitespace-only response falls back to keeping the previous summary unchanged, rather than corrupting it with garbage.
- Call signature is unchanged from L-114's stub (`maybeRegenerateSummary({ db, saveRef, worldId, turnIndex })`), and the fire-and-forget trigger point in COMMIT is untouched — this is a drop-in replacement for the stub body.

Closes #303 (L-116).

## Test plan
- [x] `tests/loom-summary.test.js` — extended to 10 tests total (mocked `callGemini` + a minimal fake Firestore `saveRef`, no emulator needed): no-op when there are no turns yet or the save no longer exists, correct write of the model's summary, previous-summary + turn-log content correctly passed to the prompt, truncation at `MAX_SUMMARY_CHARS`, and fallback-to-previous-summary on both API failure and empty model output
- [x] Full suite: `firebase emulators:exec --only firestore --project demo-olympus-rules-test "cd tests && npm test"` — 234/234 passing, including the existing `loom-turn.test.js` 10-turn threshold-crossing integration test (still passes since Gemini calls fail gracefully to the fallback path in this sandbox, same as INTERPRET already does)
- [x] `npm run lint:fix` / `npm run format` clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01XVNW1uHGnfWpM69kac16WF)_