### PR TITLE
feat(loom): entity-keyed retrieval from the event log (L-117)

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -71,6 +71,14 @@
         { "fieldPath": "ownerUid", "order": "ASCENDING" },
         { "fieldPath": "worldId", "order": "ASCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "loom_turns",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "entityRefs", "arrayConfig": "CONTAINS" },
+        { "fieldPath": "index", "order": "DESCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/functions/loom-turn/retrieval.js
+++ b/functions/loom-turn/retrieval.js
@@ -1,0 +1,94 @@
+'use strict';
+
+/**
+ * Entity-keyed retrieval from the event log (design doc §4, §8; L-117 / #304).
+ *
+ * The differentiator vs. keyword Story Cards: because turns store structured
+ * `entityRefs[]`, retrieval is keyed on the actual entities in play. When an
+ * NPC re-enters a scene, their full history and disposition is pulled
+ * deterministically via a Firestore `array-contains` query — not hoped for
+ * via keyword matching.
+ *
+ * Feeds NARRATE's context assembly (L-113 / #300): given the entities
+ * relevant to the current proposed action/scene, returns each entity's
+ * recent turn history plus its current disposition from Character state.
+ * Bounded per entity (default 5 most-recent turns) so context stays small.
+ *
+ * Requires the composite index on `loom_turns` (entityRefs array-contains +
+ * index desc) declared in firestore.indexes.json (coordinated with L-101 /
+ * #294).
+ */
+
+const DEFAULT_LIMIT_PER_ENTITY = 5;
+
+/**
+ * Fetches the most recent turns referencing a given entity, oldest first.
+ *
+ * @param {{ saveRef: FirebaseFirestore.DocumentReference, entityId: string, limit?: number }} params
+ * @returns {Promise<object[]>}
+ */
+async function getEntityHistory(params) {
+  const { saveRef, entityId, limit = DEFAULT_LIMIT_PER_ENTITY } = params;
+
+  const snap = await saveRef
+    .collection('loom_turns')
+    .where('entityRefs', 'array-contains', entityId)
+    .orderBy('index', 'desc')
+    .limit(limit)
+    .get();
+
+  return snap.docs.map((doc) => doc.data()).reverse();
+}
+
+/** Reads an entity's current disposition from Character state (§8 loom_saves.relationships), or null. */
+function getEntityDisposition(save, entityId) {
+  return (save && save.relationships && save.relationships[entityId]) || null;
+}
+
+/**
+ * Retrieves history + disposition for a single entity.
+ *
+ * @param {{
+ *   saveRef: FirebaseFirestore.DocumentReference,
+ *   save: object,
+ *   entityId: string,
+ *   limit?: number,
+ * }} params
+ * @returns {Promise<{ entityId: string, turns: object[], disposition: string|null }>}
+ */
+async function retrieveEntityContext(params) {
+  const { saveRef, save, entityId, limit } = params;
+  const turns = await getEntityHistory({ saveRef, entityId, limit });
+  return { entityId, turns, disposition: getEntityDisposition(save, entityId) };
+}
+
+/**
+ * Retrieves history + disposition for a set of entities (e.g. the current
+ * proposed action's targets and/or the current location's presentEntities).
+ * Deduplicates ids and skips falsy entries so callers can pass raw lists
+ * without pre-filtering.
+ *
+ * @param {{
+ *   saveRef: FirebaseFirestore.DocumentReference,
+ *   save: object,
+ *   entityIds: string[],
+ *   limit?: number,
+ * }} params
+ * @returns {Promise<{ entityId: string, turns: object[], disposition: string|null }[]>}
+ */
+async function retrieveContextForEntities(params) {
+  const { saveRef, save, entityIds, limit } = params;
+  const uniqueIds = Array.from(new Set((entityIds || []).filter(Boolean)));
+
+  return Promise.all(
+    uniqueIds.map((entityId) => retrieveEntityContext({ saveRef, save, entityId, limit }))
+  );
+}
+
+module.exports = {
+  DEFAULT_LIMIT_PER_ENTITY,
+  getEntityHistory,
+  getEntityDisposition,
+  retrieveEntityContext,
+  retrieveContextForEntities,
+};

--- a/tests/loom-retrieval.test.js
+++ b/tests/loom-retrieval.test.js
@@ -1,0 +1,173 @@
+'use strict';
+
+/**
+ * Integration tests for functions/loom-turn/retrieval.js (L-117).
+ *
+ * Runs against the Firestore emulator to exercise the real array-contains
+ * query (the emulator auto-indexes locally; the production composite index
+ * is declared in firestore.indexes.json).
+ *
+ * Run: firebase emulators:exec --only firestore --project demo-loom-test "cd tests && npx jest loom-retrieval --verbose"
+ */
+
+process.env.FIRESTORE_EMULATOR_HOST = process.env.FIRESTORE_EMULATOR_HOST || 'localhost:8080';
+process.env.GCLOUD_PROJECT = 'demo-loom-test';
+
+const admin = require('firebase-admin');
+if (admin.apps.length === 0) {
+  admin.initializeApp({ projectId: 'demo-loom-test' });
+}
+const db = admin.firestore();
+
+const {
+  DEFAULT_LIMIT_PER_ENTITY,
+  getEntityHistory,
+  getEntityDisposition,
+  retrieveEntityContext,
+  retrieveContextForEntities,
+} = require('../functions/loom-turn/retrieval');
+
+const SAVE_ID = 'retrieval-test-save';
+
+function saveRef() {
+  return db.collection('loom_saves').doc(SAVE_ID);
+}
+
+function makeTurn(index, entityRefs, overrides) {
+  return Object.assign(
+    {
+      index,
+      actionText: 'do something turn ' + index,
+      proposedAction: { verb: 'look', targets: [], params: {} },
+      resolution: { outcome: 'success', mutations: [], constraints: [] },
+      narration: 'Narration for turn ' + index,
+      entityRefs,
+    },
+    overrides
+  );
+}
+
+async function seedTurns(turns) {
+  const batch = db.batch();
+  turns.forEach((turn) => {
+    batch.set(saveRef().collection('loom_turns').doc('turn-' + turn.index), turn);
+  });
+  await batch.commit();
+}
+
+async function clearTurns() {
+  const snap = await saveRef().collection('loom_turns').get();
+  const batch = db.batch();
+  snap.docs.forEach((doc) => batch.delete(doc.ref));
+  await batch.commit();
+}
+
+afterEach(async () => {
+  await clearTurns();
+});
+
+describe('getEntityHistory', () => {
+  it('returns only turns referencing the given entity, oldest first', async () => {
+    await seedTurns([
+      makeTurn(0, ['captain-orla-vance']),
+      makeTurn(1, ['old-mireille']),
+      makeTurn(2, ['captain-orla-vance', 'commandant-de-alva']),
+      makeTurn(3, ['old-mireille']),
+    ]);
+
+    const history = await getEntityHistory({ saveRef: saveRef(), entityId: 'captain-orla-vance' });
+
+    expect(history.map((t) => t.index)).toEqual([0, 2]);
+  });
+
+  it('returns an empty array when the entity has no history', async () => {
+    await seedTurns([makeTurn(0, ['old-mireille'])]);
+    const history = await getEntityHistory({ saveRef: saveRef(), entityId: 'nonexistent-npc' });
+    expect(history).toEqual([]);
+  });
+
+  it('bounds results to the requested limit, keeping the most recent turns', async () => {
+    const turns = [];
+    for (let i = 0; i < DEFAULT_LIMIT_PER_ENTITY + 3; i++) {
+      turns.push(makeTurn(i, ['recurring-npc']));
+    }
+    await seedTurns(turns);
+
+    const history = await getEntityHistory({ saveRef: saveRef(), entityId: 'recurring-npc' });
+
+    expect(history).toHaveLength(DEFAULT_LIMIT_PER_ENTITY);
+    // Oldest-first among the most recent N: the last DEFAULT_LIMIT_PER_ENTITY indices.
+    const expectedIndices = turns.slice(-DEFAULT_LIMIT_PER_ENTITY).map((t) => t.index);
+    expect(history.map((t) => t.index)).toEqual(expectedIndices);
+  });
+
+  it('respects a custom limit override', async () => {
+    await seedTurns([
+      makeTurn(0, ['npc']),
+      makeTurn(1, ['npc']),
+      makeTurn(2, ['npc']),
+    ]);
+
+    const history = await getEntityHistory({ saveRef: saveRef(), entityId: 'npc', limit: 2 });
+    expect(history.map((t) => t.index)).toEqual([1, 2]);
+  });
+});
+
+describe('getEntityDisposition', () => {
+  it('returns the stored disposition for a known entity', () => {
+    const save = { relationships: { 'old-mireille': 'trusted' } };
+    expect(getEntityDisposition(save, 'old-mireille')).toBe('trusted');
+  });
+
+  it('returns null when the entity has no recorded relationship', () => {
+    const save = { relationships: {} };
+    expect(getEntityDisposition(save, 'old-mireille')).toBeNull();
+  });
+
+  it('returns null when relationships is missing entirely', () => {
+    expect(getEntityDisposition({}, 'old-mireille')).toBeNull();
+  });
+});
+
+describe('retrieveEntityContext', () => {
+  it('combines turn history and disposition for one entity', async () => {
+    await seedTurns([makeTurn(0, ['old-mireille']), makeTurn(1, ['someone-else'])]);
+    const save = { relationships: { 'old-mireille': 'wary' } };
+
+    const context = await retrieveEntityContext({
+      saveRef: saveRef(),
+      save,
+      entityId: 'old-mireille',
+    });
+
+    expect(context.entityId).toBe('old-mireille');
+    expect(context.turns.map((t) => t.index)).toEqual([0]);
+    expect(context.disposition).toBe('wary');
+  });
+});
+
+describe('retrieveContextForEntities', () => {
+  it('returns a context entry per unique entity, deduplicating and skipping falsy ids', async () => {
+    await seedTurns([
+      makeTurn(0, ['captain-orla-vance']),
+      makeTurn(1, ['old-mireille']),
+    ]);
+    const save = { relationships: { 'captain-orla-vance': 'ally', 'old-mireille': 'wary' } };
+
+    const contexts = await retrieveContextForEntities({
+      saveRef: saveRef(),
+      save,
+      entityIds: ['captain-orla-vance', 'captain-orla-vance', null, 'old-mireille', ''],
+    });
+
+    expect(contexts).toHaveLength(2);
+    const byId = Object.fromEntries(contexts.map((c) => [c.entityId, c]));
+    expect(byId['captain-orla-vance'].disposition).toBe('ally');
+    expect(byId['old-mireille'].disposition).toBe('wary');
+  });
+
+  it('returns an empty array for an empty entity list', async () => {
+    const contexts = await retrieveContextForEntities({ saveRef: saveRef(), save: {}, entityIds: [] });
+    expect(contexts).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `functions/loom-turn/retrieval.js`: a Firestore `array-contains` query over a save's `loom_turns.entityRefs[]`, bounded to the 5 most-recent turns per entity by default (`DEFAULT_LIMIT_PER_ENTITY`), returned oldest-first.
- `getEntityDisposition()` reads the entity's current standing from Character state (`loom_saves.relationships`), so a re-entering NPC's full history *and* disposition come back together.
- `retrieveContextForEntities()` takes a raw list of entity ids (e.g. INTERPRET's resolved `targets`, or the current location's `presentEntities`), dedupes and drops falsy entries, and fetches context for each in parallel — this is the seam NARRATE (L-113 / #300) will call so an NPC's history is surfaced deterministically instead of hoped for via keyword matching.
- Adds the composite index `loom_turns` (`entityRefs` array-contains + `index` desc) to `firestore.indexes.json`, needed because Firestore requires a composite index when an `array-contains` clause is combined with an `orderBy` on a different field — coordinated with the L-101 (#294) rules/index work as noted in the issue.
- Standalone module, not yet wired into `narrate.js` — that integration is L-113's job.

Closes #304 (L-117).

## Test plan
- [x] `tests/loom-retrieval.test.js` — 10 new tests against the real Firestore emulator (validates actual `array-contains` query semantics, not a mock): correct entity filtering oldest-first, empty history for an untouched entity, bounding to the default and a custom limit (keeping the most recent turns), disposition lookup (present/absent/no-relationships-object), single-entity context combining both, and multi-entity retrieval with dedup + falsy-id skipping
- [x] Full suite: `firebase emulators:exec --only firestore --project demo-olympus-rules-test "cd tests && npm test"` — 244/244 passing
- [x] `npm run lint:fix` / `npm run format` clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01XVNW1uHGnfWpM69kac16WF)_