### PR TITLE
feat(loom): Stage 4 NARRATE — Flash narration constrained by Resolution (L-113)

### DIFF
--- a/functions/loom-turn/index.js
+++ b/functions/loom-turn/index.js
@@ -83,6 +83,7 @@ async function runTurnPipeline(params) {
     canonWorld,
     save,
     worldState,
+    saveRef,
   });
 
   return commitTurn({

--- a/functions/loom-turn/narrate.js
+++ b/functions/loom-turn/narrate.js
@@ -1,29 +1,159 @@
 'use strict';
 
+const { callGemini } = require('../gemini');
+const loomCanon = require('../loom-canon');
+const { buildKnownEntities } = require('./interpret');
+const { retrieveContextForEntities } = require('./retrieval');
+
 /**
  * Stage 4 — NARRATE (design doc §5).
  *
  * The LLM (Flash) receives a canon snippet + current state + the FIXED
  * Resolution + rolling summary and writes prose. It may color *how*
  * something happened, never *whether* — the Resolution from ADJUDICATE
- * (./adjudicate.js) is final.
+ * (./adjudicate.js) is final, and its outcome/constraints are supplied to
+ * the model as unchangeable hard facts, never as something to (re)decide.
  *
- * STUB (L-110 / #297): returns a minimal templated acknowledgment with no
- * new entities and no suggested actions. Replaced by L-113 (#300) with a
- * real Flash call assembling canon (L-103 / #296) + entity-keyed retrieval
- * (L-117 / #304) + rolling summary (L-116 / #303) context.
+ * Context assembly (design doc §5 stage 4, §4 memory layers):
+ *   - Canon snippets (L-103 / #296) for entities relevant to this scene
+ *   - Entity-keyed history + disposition (L-117 / #304) for those entities
+ *   - The rolling summary (L-116 / #303) — the dense recap of everything
+ *     older than the entity-keyed detail above
+ *   - The fixed Resolution's outcome + narrative_constraints
  *
- * `inventedEntities` (added L-114 / #301) is the seam COMMIT's soft-canon
- * handoff (L-115 / #302) consumes: names the model mentions that don't match
- * a known canon/state entity. Always empty until L-113 adds real detection.
+ * "Relevant entities" = the current location's default canon cast
+ * (npcIds/factionIds) union the proposed action's resolved targets,
+ * filtered to ids that actually resolve against canon.
  *
+ * Any name the model uses that isn't in the supplied known-entities list is
+ * returned in `inventedEntities` for COMMIT to hand off to soft-canon
+ * quarantine (L-115 / #302) — captured here, quarantined there.
+ *
+ * Any Gemini failure or malformed response falls back to a safe narration
+ * built directly from the Resolution's own constraints, so the client never
+ * sees an unresolved turn and the fallback still can't contradict the facts.
+ */
+
+const MODEL_NAME = 'gemini-2.5-flash';
+const MAX_OUTPUT_TOKENS = 1024;
+
+function buildSystemInstruction(knownEntities) {
+  const entityList = knownEntities
+    .map((e) => '- ' + e.id + ' (' + e.kind + '): ' + e.name)
+    .join('\n');
+
+  return (
+    'You are the narrator for a persistent text-adventure game world. You receive a FIXED ' +
+    'Resolution that has already been decided by a separate deterministic system. You may ' +
+    'color HOW something happened, but never WHETHER it happened — never contradict the ' +
+    "Resolution's outcome or any of its listed hard facts (narrative constraints).\n\n" +
+    'Write 1-3 short second-person paragraphs narrating the result, consistent with the ' +
+    'supplied canon, entity history, and rolling summary. Do not contradict established ' +
+    'facts.\n\n' +
+    'Known entities already established in this world:\n' +
+    entityList +
+    '\n\n' +
+    'If your narration names a character, place, or faction NOT in that list, list its exact ' +
+    'name in inventedEntities so it can be tracked as provisional. Most narration invents no ' +
+    'new named entities at all — leave this empty unless you actually named someone/somewhere ' +
+    'new.\n\n' +
+    'Optionally suggest 2-4 short next actions as plain phrases (e.g. "search the wreck"). ' +
+    'Leave empty if nothing obvious suggests itself.\n\n' +
+    'Respond with ONLY a JSON object: { "narration": string, "inventedEntities": string[], ' +
+    '"suggestedActions": string[] }'
+  );
+}
+
+function buildEntitySection(canonWorldId, context) {
+  const snippet = loomCanon.getEntitySnippet(canonWorldId, context.entityId);
+  const historyText = context.turns.length
+    ? context.turns.map((turn) => '  - ' + turn.narration).join('\n')
+    : '  (no prior history)';
+  const dispositionText = context.disposition
+    ? 'Disposition: ' + context.disposition
+    : 'Disposition: unknown';
+
+  return (
+    'Entity: ' +
+    context.entityId +
+    '\n' +
+    (snippet ? snippet + '\n' : '') +
+    dispositionText +
+    '\nRecent history:\n' +
+    historyText
+  );
+}
+
+function buildUserMessage(params) {
+  const { actionText, resolution, canonWorldId, entityContexts, recentSummary } = params;
+
+  const constraintsText =
+    (resolution.constraints || []).map((c) => '- ' + c).join('\n') || '(none)';
+  const entitySections =
+    entityContexts.map((ctx) => buildEntitySection(canonWorldId, ctx)).join('\n\n') || '(none)';
+
+  return (
+    'PLAYER ACTION:\n' +
+    actionText +
+    '\n\n' +
+    'RESOLUTION (final — do not contradict):\n' +
+    'Outcome: ' +
+    resolution.outcome +
+    '\n' +
+    'Hard facts:\n' +
+    constraintsText +
+    '\n\n' +
+    'ROLLING SUMMARY:\n' +
+    (recentSummary || '(none yet)') +
+    '\n\n' +
+    'RELEVANT ENTITIES:\n' +
+    entitySections
+  );
+}
+
+function isValidRawNarration(raw) {
+  return (
+    !!raw &&
+    typeof raw === 'object' &&
+    typeof raw.narration === 'string' &&
+    raw.narration.length > 0
+  );
+}
+
+function fallbackNarration(actionText, resolution) {
+  const constraintsText = (resolution.constraints || []).join(' ');
+  return {
+    narration: ('You ' + actionText + '. ' + constraintsText).trim(),
+    inventedEntities: [],
+    suggestedActions: [],
+  };
+}
+
+function sanitizeStringArray(value) {
+  return Array.isArray(value)
+    ? value.filter((v) => typeof v === 'string' && v.trim().length > 0)
+    : [];
+}
+
+/** Relevant entities for this scene: the location's default cast plus the action's resolved targets. */
+function resolveSceneEntityIds(canonWorld, save, proposedAction) {
+  const currentLocation = save.location && canonWorld.locations[save.location];
+  const sceneEntityIds = currentLocation
+    ? [].concat(currentLocation.npcIds || [], currentLocation.factionIds || [])
+    : [];
+  const candidateIds = Array.from(new Set(sceneEntityIds.concat(proposedAction.targets || [])));
+  return candidateIds.filter((id) => !!loomCanon.getEntity(canonWorld.id, id));
+}
+
+/**
  * @param {{
  *   actionText: string,
  *   proposedAction: object,
- *   resolution: object,
+ *   resolution: { outcome: string, mutations: object[], constraints: string[] },
  *   canonWorld: object,
  *   save: object,
  *   worldState: object,
+ *   saveRef: FirebaseFirestore.DocumentReference,
  * }} params
  * @returns {Promise<{
  *   narration: string,
@@ -33,14 +163,47 @@
  * }>}
  */
 async function narrateResolution(params) {
-  const { actionText } = params;
+  const { actionText, proposedAction, resolution, canonWorld, save, saveRef } = params;
+
+  const entityRefs = resolveSceneEntityIds(canonWorld, save, proposedAction);
+  const entityContexts = await retrieveContextForEntities({ saveRef, save, entityIds: entityRefs });
+  const knownEntities = buildKnownEntities(canonWorld);
+
+  let raw;
+  try {
+    raw = await callGemini({
+      modelName: MODEL_NAME,
+      systemInstruction: buildSystemInstruction(knownEntities),
+      userMessage: buildUserMessage({
+        actionText,
+        resolution,
+        canonWorldId: canonWorld.id,
+        entityContexts,
+        recentSummary: save.recentSummary,
+      }),
+      maxOutputTokens: MAX_OUTPUT_TOKENS,
+      jsonMode: true,
+      thinkingBudget: 0,
+    });
+  } catch (err) {
+    console.error('narrateResolution: callGemini failed, falling back to constraint recap', err);
+    return Object.assign({ entityRefs }, fallbackNarration(actionText, resolution));
+  }
+
+  if (!isValidRawNarration(raw)) {
+    console.error(
+      'narrateResolution: malformed model output, falling back to constraint recap',
+      raw
+    );
+    return Object.assign({ entityRefs }, fallbackNarration(actionText, resolution));
+  }
+
   return {
-    narration:
-      'You attempt to ' + actionText + '. The Loom takes note, but has little more to say — yet.',
-    entityRefs: [],
-    inventedEntities: [],
-    suggestedActions: [],
+    narration: raw.narration,
+    entityRefs,
+    inventedEntities: sanitizeStringArray(raw.inventedEntities),
+    suggestedActions: sanitizeStringArray(raw.suggestedActions),
   };
 }
 
-module.exports = { narrateResolution };
+module.exports = { narrateResolution, resolveSceneEntityIds };

--- a/tests/loom-narrate.test.js
+++ b/tests/loom-narrate.test.js
@@ -1,0 +1,219 @@
+'use strict';
+
+/**
+ * Unit tests for functions/loom-turn/narrate.js (L-113).
+ *
+ * Mocks functions/gemini.js's callGemini and functions/loom-turn/retrieval.js
+ * to test NARRATE's context assembly and fallback behavior in isolation.
+ * Uses the real Shattered Coast canon world (L-103) for realistic entity ids.
+ * Does not require the Firestore emulator.
+ *
+ * Run: cd tests && npx jest loom-narrate --verbose
+ */
+
+const mockCallGemini = jest.fn();
+jest.mock('../functions/gemini', () => ({
+  callGemini: (...args) => mockCallGemini(...args),
+}));
+
+const mockRetrieveContextForEntities = jest.fn();
+jest.mock('../functions/loom-turn/retrieval', () => ({
+  retrieveContextForEntities: (...args) => mockRetrieveContextForEntities(...args),
+}));
+
+const { narrateResolution, resolveSceneEntityIds } = require('../functions/loom-turn/narrate');
+const { getWorld } = require('../functions/loom-canon');
+
+const CANON_WORLD = getWorld('shattered-coast');
+
+function makeParams(overrides) {
+  return Object.assign(
+    {
+      actionText: 'look around',
+      proposedAction: { verb: 'look', targets: [], params: {} },
+      resolution: { outcome: 'acknowledged', mutations: [], constraints: [] },
+      canonWorld: CANON_WORLD,
+      save: { location: 'widows-reach', recentSummary: '' },
+      worldState: {},
+      saveRef: {},
+    },
+    overrides
+  );
+}
+
+beforeEach(() => {
+  mockCallGemini.mockReset();
+  mockRetrieveContextForEntities.mockReset();
+  mockRetrieveContextForEntities.mockResolvedValue([]);
+});
+
+describe('resolveSceneEntityIds', () => {
+  it("includes the current location's default cast", () => {
+    const ids = resolveSceneEntityIds(CANON_WORLD, { location: 'widows-reach' }, { targets: [] });
+    expect(ids).toEqual(expect.arrayContaining(['captain-orla-vance', 'pirate-brethren']));
+  });
+
+  it('includes resolved proposedAction targets', () => {
+    const ids = resolveSceneEntityIds(
+      CANON_WORLD,
+      { location: null },
+      { targets: ['commandant-de-alva'] }
+    );
+    expect(ids).toEqual(['commandant-de-alva']);
+  });
+
+  it('drops unresolved raw-text targets', () => {
+    const ids = resolveSceneEntityIds(
+      CANON_WORLD,
+      { location: null },
+      { targets: ['a mysterious stranger'] }
+    );
+    expect(ids).toEqual([]);
+  });
+
+  it('dedupes ids present in both the scene cast and targets', () => {
+    const ids = resolveSceneEntityIds(
+      CANON_WORLD,
+      { location: 'widows-reach' },
+      { targets: ['captain-orla-vance'] }
+    );
+    expect(ids.filter((id) => id === 'captain-orla-vance')).toHaveLength(1);
+  });
+});
+
+describe('narrateResolution', () => {
+  it('passes the resolution outcome and every constraint into the model prompt', async () => {
+    mockCallGemini.mockResolvedValueOnce({
+      narration: 'text',
+      inventedEntities: [],
+      suggestedActions: [],
+    });
+    await narrateResolution(
+      makeParams({
+        resolution: {
+          outcome: 'success',
+          mutations: [],
+          constraints: ['You arrive at Skeleton Cove.', 'The tide turns.'],
+        },
+      })
+    );
+
+    const callArgs = mockCallGemini.mock.calls[0][0];
+    expect(callArgs.userMessage).toContain('success');
+    expect(callArgs.userMessage).toContain('You arrive at Skeleton Cove.');
+    expect(callArgs.userMessage).toContain('The tide turns.');
+  });
+
+  it('returns the model narration, invented entities, and suggested actions', async () => {
+    mockCallGemini.mockResolvedValueOnce({
+      narration: 'The captain nods grimly.',
+      inventedEntities: ['a barkeep named Doral'],
+      suggestedActions: ['ask about the job'],
+    });
+
+    const result = await narrateResolution(makeParams());
+
+    expect(result.narration).toBe('The captain nods grimly.');
+    expect(result.inventedEntities).toEqual(['a barkeep named Doral']);
+    expect(result.suggestedActions).toEqual(['ask about the job']);
+  });
+
+  it('includes resolved scene entities in entityRefs', async () => {
+    mockCallGemini.mockResolvedValueOnce({
+      narration: 'text',
+      inventedEntities: [],
+      suggestedActions: [],
+    });
+    const result = await narrateResolution(makeParams({ save: { location: 'widows-reach' } }));
+    expect(result.entityRefs).toEqual(
+      expect.arrayContaining(['captain-orla-vance', 'pirate-brethren'])
+    );
+  });
+
+  it('falls back to a constraint-based narration when callGemini throws', async () => {
+    mockCallGemini.mockRejectedValueOnce(new Error('AI unavailable'));
+    const result = await narrateResolution(
+      makeParams({
+        resolution: {
+          outcome: 'blocked',
+          mutations: [],
+          constraints: ['You cannot get there directly from here.'],
+        },
+      })
+    );
+    expect(result.narration).toContain('You cannot get there directly from here.');
+    expect(result.inventedEntities).toEqual([]);
+    expect(result.suggestedActions).toEqual([]);
+  });
+
+  it('falls back to a constraint-based narration when the model returns malformed output', async () => {
+    mockCallGemini.mockResolvedValueOnce({ inventedEntities: [] }); // missing narration
+    const result = await narrateResolution(
+      makeParams({
+        resolution: { outcome: 'failure', mutations: [], constraints: ['The lock does not budge.'] },
+      })
+    );
+    expect(result.narration).toContain('The lock does not budge.');
+  });
+
+  it('sanitizes non-string entries out of inventedEntities and suggestedActions', async () => {
+    mockCallGemini.mockResolvedValueOnce({
+      narration: 'text',
+      inventedEntities: ['Real Name', 42, '', null],
+      suggestedActions: ['do a thing', 7],
+    });
+    const result = await narrateResolution(makeParams());
+    expect(result.inventedEntities).toEqual(['Real Name']);
+    expect(result.suggestedActions).toEqual(['do a thing']);
+  });
+
+  it('calls retrieveContextForEntities with the resolved scene entity ids', async () => {
+    mockCallGemini.mockResolvedValueOnce({
+      narration: 'text',
+      inventedEntities: [],
+      suggestedActions: [],
+    });
+    await narrateResolution(makeParams({ save: { location: 'widows-reach' } }));
+
+    const callArgs = mockRetrieveContextForEntities.mock.calls[0][0];
+    expect(callArgs.entityIds).toEqual(
+      expect.arrayContaining(['captain-orla-vance', 'pirate-brethren'])
+    );
+  });
+
+  it('includes entity canon snippets and history in the prompt', async () => {
+    mockRetrieveContextForEntities.mockResolvedValueOnce([
+      {
+        entityId: 'captain-orla-vance',
+        turns: [{ narration: 'She warned you once already.' }],
+        disposition: 'wary',
+      },
+    ]);
+    mockCallGemini.mockResolvedValueOnce({
+      narration: 'text',
+      inventedEntities: [],
+      suggestedActions: [],
+    });
+
+    await narrateResolution(makeParams());
+
+    const callArgs = mockCallGemini.mock.calls[0][0];
+    expect(callArgs.userMessage).toContain('Captain Orla Vance');
+    expect(callArgs.userMessage).toContain('She warned you once already.');
+    expect(callArgs.userMessage).toContain('wary');
+  });
+
+  it('includes the rolling summary in the prompt when present', async () => {
+    mockCallGemini.mockResolvedValueOnce({
+      narration: 'text',
+      inventedEntities: [],
+      suggestedActions: [],
+    });
+    await narrateResolution(
+      makeParams({ save: { location: 'widows-reach', recentSummary: 'Previously, chaos ensued.' } })
+    );
+
+    const callArgs = mockCallGemini.mock.calls[0][0];
+    expect(callArgs.userMessage).toContain('Previously, chaos ensued.');
+  });
+});


### PR DESCRIPTION
## Summary
- Replaces the L-110 templated stub in `functions/loom-turn/narrate.js` with a real Gemini 2.5 Flash call assembling the full context the design doc specifies for this stage: the fixed Resolution's `outcome` + `narrative_constraints` (supplied as unchangeable hard facts, never something to re-decide), canon snippets + entity-keyed history/disposition (L-117 / #304) for the scene's relevant entities, and the rolling summary (L-116 / #303).
- "Relevant entities" = the character's current location's default canon cast (`npcIds`/`factionIds`) union the proposed action's resolved targets, filtered to ids that actually resolve against canon — these become `entityRefs` on the turn log, closing the loop for future entity-keyed retrieval.
- Any name the model uses that isn't in the supplied known-entities list comes back in `inventedEntities` — the field COMMIT has routed to its soft-canon handoff seam since L-114 (#301), still a no-op there until L-115 (#302) lands.
- Any `callGemini` failure or malformed response falls back to a narration built directly from the Resolution's own constraints, so even the fallback path can't contradict the hard facts.
- The orchestrator (`functions/loom-turn/index.js`) now threads `saveRef` into `narrateResolution`'s params so it can call L-117's `retrieveContextForEntities`.

Closes #300 (L-113).

## Test plan
- [x] `tests/loom-narrate.test.js` — 13 new unit tests against the real Shattered Coast canon world (mocked `callGemini` + mocked `retrieveContextForEntities`, no emulator needed): scene-entity resolution (location cast, resolved targets, unresolved-target dropping, dedup), prompt assembly verified to contain the outcome/every constraint/rolling summary/entity snippets+history+disposition, well-formed-response mapping, both fallback paths (API throws, malformed output) producing constraint-derived narration, and sanitization of non-string entries in `inventedEntities`/`suggestedActions`
- [x] Full suite: `firebase emulators:exec --only firestore --project demo-olympus-rules-test "cd tests && npm test"` — 257/257 passing, including the existing end-to-end `loom-turn.test.js` integration tests
- [x] `npm run lint:fix` / `npm run format` clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01XVNW1uHGnfWpM69kac16WF)_