### PR TITLE
feat(loom): Play UI — world/save routing, turn input, narration (L-120)

### DIFF
--- a/public/apps/loom/index.html
+++ b/public/apps/loom/index.html
@@ -35,7 +35,59 @@
       <div class="app-divider"></div>
 
       <div id="loom-root" class="loom-root">
-        <p class="loom-placeholder">The Loom is being woven. Play is coming soon.</p>
+        <!-- World selection -->
+        <div id="loom-view-worlds" class="loom-view">
+          <div id="loom-world-list" class="loom-world-list"></div>
+        </div>
+
+        <!-- Save selection -->
+        <div id="loom-view-saves" class="loom-view hidden">
+          <button class="loom-back-link" id="loom-back-to-worlds" type="button">
+            &larr; Choose a different world
+          </button>
+          <h2 class="loom-view-title" id="loom-save-select-title"></h2>
+
+          <div class="app-loading hidden" id="loom-saves-loading">
+            <div class="app-spinner"></div>
+          </div>
+          <p class="loom-error hidden" id="loom-saves-error"></p>
+          <p class="loom-empty-state hidden" id="loom-save-empty">
+            No saved adventures yet in this world.
+          </p>
+
+          <div id="loom-save-list" class="loom-save-list"></div>
+
+          <button class="app-btn" id="loom-new-save-btn" type="button">+ New Save</button>
+          <p class="loom-note hidden" id="loom-new-save-note">Creating new saves is coming soon.</p>
+        </div>
+
+        <!-- Play view -->
+        <div id="loom-view-play" class="loom-view hidden">
+          <button class="loom-back-link" id="loom-back-to-saves" type="button">&larr; Saves</button>
+
+          <div class="loom-summary hidden" id="loom-summary"></div>
+
+          <div class="loom-narration-log" id="loom-narration-log"></div>
+
+          <div class="loom-suggested-actions" id="loom-suggested-actions"></div>
+
+          <form id="loom-turn-form" class="loom-turn-form">
+            <textarea
+              class="loom-turn-input"
+              id="loom-turn-input"
+              placeholder="What do you do?"
+              rows="2"
+              maxlength="2000"
+            ></textarea>
+            <button class="app-btn" id="loom-turn-submit" type="submit">Act</button>
+          </form>
+
+          <div class="app-loading hidden" id="loom-turn-loading">
+            <div class="app-spinner"></div>
+            <p class="app-loading-text">The Loom weaves&hellip;</p>
+          </div>
+          <p class="loom-error hidden" id="loom-turn-error"></p>
+        </div>
       </div>
     </main>
 
@@ -44,6 +96,9 @@
 
     <!-- Loom modules (load order matters) -->
     <script src="/apps/loom/js/state.js"></script>
+    <script src="/apps/loom/js/worlds.js"></script>
+    <script src="/apps/loom/js/saves.js"></script>
+    <script src="/apps/loom/js/play.js"></script>
     <script src="/apps/loom/js/app.js"></script>
 
     <script>

--- a/public/apps/loom/js/app.js
+++ b/public/apps/loom/js/app.js
@@ -4,11 +4,65 @@
   var Loom = window.Loom;
   var state = Loom.state;
 
+  function showView(view) {
+    state.currentView = view;
+    Loom.getRef('loom-view-worlds').classList.toggle('hidden', view !== 'worlds');
+    Loom.getRef('loom-view-saves').classList.toggle('hidden', view !== 'saves');
+    Loom.getRef('loom-view-play').classList.toggle('hidden', view !== 'play');
+  }
+
+  function showWorlds() {
+    state.worldId = null;
+    state.saveId = null;
+    showView('worlds');
+  }
+
+  function showSaves(worldId, worldName) {
+    state.worldId = worldId;
+    Loom.getRef('loom-save-select-title').textContent = worldName;
+    Loom.getRef('loom-new-save-note').classList.add('hidden');
+    showView('saves');
+    Loom.saves.loadSaves(worldId);
+  }
+
+  function showPlay(saveId, save) {
+    Loom.play.init(saveId, save);
+    showView('play');
+  }
+
   Loom.app = {
+    showWorlds: showWorlds,
+    showSaves: showSaves,
+    showPlay: showPlay,
+
     init: function (user) {
       state.db = firebase.firestore();
       state.functions = firebase.functions();
       state.uid = user.uid;
+
+      Loom.worlds.renderWorldList();
+      showWorlds();
+
+      Loom.getRef('loom-back-to-worlds').addEventListener('click', showWorlds);
+
+      Loom.getRef('loom-back-to-saves').addEventListener('click', function () {
+        var world = Loom.WORLDS.filter(function (w) {
+          return w.id === state.worldId;
+        })[0];
+        showSaves(state.worldId, world ? world.name : '');
+      });
+
+      Loom.getRef('loom-new-save-btn').addEventListener('click', function () {
+        Loom.getRef('loom-new-save-note').classList.remove('hidden');
+      });
+
+      Loom.getRef('loom-turn-form').addEventListener('submit', function (e) {
+        e.preventDefault();
+        var inputEl = Loom.getRef('loom-turn-input');
+        var actionText = inputEl.value;
+        inputEl.value = '';
+        Loom.play.submitTurn(actionText);
+      });
     },
   };
 })();

--- a/public/apps/loom/js/play.js
+++ b/public/apps/loom/js/play.js
@@ -1,0 +1,112 @@
+(function () {
+  'use strict';
+
+  var Loom = window.Loom;
+  var state = Loom.state;
+
+  function appendNarration(actionText, narration) {
+    var log = Loom.getRef('loom-narration-log');
+
+    if (actionText) {
+      var actionEl = document.createElement('p');
+      actionEl.className = 'loom-log-action';
+      actionEl.textContent = '> ' + actionText;
+      log.appendChild(actionEl);
+    }
+
+    var narrationEl = document.createElement('p');
+    narrationEl.className = 'loom-log-narration';
+    narrationEl.textContent = narration;
+    log.appendChild(narrationEl);
+
+    log.scrollTop = log.scrollHeight;
+  }
+
+  function renderSummary(summary) {
+    var el = Loom.getRef('loom-summary');
+    if (summary) {
+      el.textContent = summary;
+      el.classList.remove('hidden');
+    } else {
+      el.classList.add('hidden');
+    }
+  }
+
+  function renderSuggestedActions(actions) {
+    var container = Loom.getRef('loom-suggested-actions');
+    container.innerHTML = '';
+
+    (actions || []).forEach(function (action) {
+      var btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'loom-suggested-action-chip';
+      btn.textContent = action;
+      btn.addEventListener('click', function () {
+        submitTurn(action);
+      });
+      container.appendChild(btn);
+    });
+  }
+
+  function setLoading(isLoading) {
+    Loom.getRef('loom-turn-loading').classList.toggle('hidden', !isLoading);
+    Loom.getRef('loom-turn-submit').disabled = isLoading;
+    Loom.getRef('loom-turn-input').disabled = isLoading;
+  }
+
+  function showError(message) {
+    var errorEl = Loom.getRef('loom-turn-error');
+    if (message) {
+      errorEl.textContent = message;
+      errorEl.classList.remove('hidden');
+    } else {
+      errorEl.classList.add('hidden');
+    }
+  }
+
+  /**
+   * Submits a turn via the loomPlayTurn callable. The client only ever
+   * receives { narration, stateSummary, suggestedActions } — no raw state
+   * authority, per the design doc's turn pipeline contract.
+   */
+  function submitTurn(actionText) {
+    var trimmed = (actionText || '').trim();
+    if (!trimmed || state.turnInProgress) return;
+
+    state.turnInProgress = true;
+    setLoading(true);
+    showError(null);
+    renderSuggestedActions([]);
+
+    var loomPlayTurn = state.functions.httpsCallable('loomPlayTurn');
+    loomPlayTurn({ worldId: state.worldId, saveId: state.saveId, actionText: trimmed })
+      .then(function (result) {
+        state.turnInProgress = false;
+        setLoading(false);
+        appendNarration(trimmed, result.data.narration);
+        renderSummary(result.data.stateSummary);
+        renderSuggestedActions(result.data.suggestedActions);
+      })
+      .catch(function (err) {
+        state.turnInProgress = false;
+        setLoading(false);
+        showError('The Loom faltered: ' + (err.message || 'Unknown error'));
+      });
+  }
+
+  /** Resets the play view for a newly-selected save. */
+  function init(saveId, save) {
+    state.saveId = saveId;
+
+    Loom.getRef('loom-narration-log').innerHTML = '';
+    renderSummary(save.recentSummary || '');
+    renderSuggestedActions([]);
+    showError(null);
+    setLoading(false);
+
+    var inputEl = Loom.getRef('loom-turn-input');
+    inputEl.value = '';
+  }
+
+  Loom.play = { init: init, submitTurn: submitTurn };
+})();

--- a/public/apps/loom/js/saves.js
+++ b/public/apps/loom/js/saves.js
@@ -1,0 +1,78 @@
+(function () {
+  'use strict';
+
+  var Loom = window.Loom;
+  var state = Loom.state;
+
+  /**
+   * Lists the current player's saves for a world. Read-only — loom_saves is
+   * server-write-only (L-101), so there is nothing to create/delete from the
+   * client yet; that lands with the real save-creation flow in L-121 (#306).
+   */
+  function loadSaves(worldId) {
+    var listEl = Loom.getRef('loom-save-list');
+    var emptyEl = Loom.getRef('loom-save-empty');
+    var loadingEl = Loom.getRef('loom-saves-loading');
+    var errorEl = Loom.getRef('loom-saves-error');
+
+    listEl.innerHTML = '';
+    emptyEl.classList.add('hidden');
+    errorEl.classList.add('hidden');
+    loadingEl.classList.remove('hidden');
+
+    state.db
+      .collection('loom_saves')
+      .where('ownerUid', '==', state.uid)
+      .where('worldId', '==', worldId)
+      .get()
+      .then(function (snap) {
+        loadingEl.classList.add('hidden');
+
+        if (snap.empty) {
+          emptyEl.classList.remove('hidden');
+          return;
+        }
+
+        snap.forEach(function (doc) {
+          listEl.appendChild(renderSaveCard(doc.id, doc.data()));
+        });
+      })
+      .catch(function (err) {
+        loadingEl.classList.add('hidden');
+        errorEl.textContent = 'Could not load saves: ' + (err.message || 'Unknown error');
+        errorEl.classList.remove('hidden');
+      });
+  }
+
+  function renderSaveCard(saveId, save) {
+    var card = document.createElement('div');
+    card.className = 'app-card loom-save-card';
+
+    var title = document.createElement('h3');
+    title.className = 'loom-card-title';
+    title.textContent = save.name || 'Unnamed Save';
+
+    if (save.character && save.character.name) {
+      var meta = document.createElement('p');
+      meta.className = 'loom-card-tagline';
+      meta.textContent = save.character.name;
+      card.appendChild(title);
+      card.appendChild(meta);
+    } else {
+      card.appendChild(title);
+    }
+
+    var btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'app-btn';
+    btn.textContent = 'Resume';
+    btn.addEventListener('click', function () {
+      Loom.app.showPlay(saveId, save);
+    });
+    card.appendChild(btn);
+
+    return card;
+  }
+
+  Loom.saves = { loadSaves: loadSaves };
+})();

--- a/public/apps/loom/js/state.js
+++ b/public/apps/loom/js/state.js
@@ -9,5 +9,29 @@
     db: null,
     functions: null,
     uid: null,
+    currentView: 'worlds', // 'worlds' | 'saves' | 'play'
+    worldId: null,
+    saveId: null,
+    turnInProgress: false,
+  };
+
+  // Display-only list of Phase 1 worlds. Canon itself lives server-side
+  // (functions/loom-canon/) — this is just enough metadata for the world
+  // picker; a Firestore-backed world list is a Phase 3 concern (L-300).
+  Loom.WORLDS = [
+    {
+      id: 'shattered-coast',
+      name: 'The Shattered Coast',
+      tagline: 'Where hidden coves and old scores meet the tide.',
+    },
+  ];
+
+  // ── Lazy-cached DOM ref helper ──────────────────
+  var refCache = {};
+  Loom.getRef = function (id) {
+    if (!refCache[id]) {
+      refCache[id] = document.getElementById(id);
+    }
+    return refCache[id];
   };
 })();

--- a/public/apps/loom/js/worlds.js
+++ b/public/apps/loom/js/worlds.js
@@ -1,0 +1,38 @@
+(function () {
+  'use strict';
+
+  var Loom = window.Loom;
+
+  function renderWorldList() {
+    var container = Loom.getRef('loom-world-list');
+    container.innerHTML = '';
+
+    Loom.WORLDS.forEach(function (world) {
+      var card = document.createElement('div');
+      card.className = 'app-card loom-world-card';
+
+      var title = document.createElement('h3');
+      title.className = 'loom-card-title';
+      title.textContent = world.name;
+
+      var tagline = document.createElement('p');
+      tagline.className = 'loom-card-tagline';
+      tagline.textContent = world.tagline;
+
+      var btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'app-btn';
+      btn.textContent = 'Enter';
+      btn.addEventListener('click', function () {
+        Loom.app.showSaves(world.id, world.name);
+      });
+
+      card.appendChild(title);
+      card.appendChild(tagline);
+      card.appendChild(btn);
+      container.appendChild(card);
+    });
+  }
+
+  Loom.worlds = { renderWorldList: renderWorldList };
+})();

--- a/public/apps/loom/loom.css
+++ b/public/apps/loom/loom.css
@@ -1,11 +1,149 @@
 .loom-root {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 40vh;
+  max-width: 640px;
+  margin: 0 auto;
 }
 
-.loom-placeholder {
+.loom-view.hidden {
+  display: none;
+}
+
+.loom-back-link {
+  display: inline-block;
+  background: none;
+  border: none;
+  color: #ffb74d;
+  font-size: 0.85rem;
+  cursor: pointer;
+  padding: 0;
+  margin-bottom: 1rem;
+}
+
+.loom-back-link:hover,
+.loom-back-link:focus-visible {
+  text-decoration: underline;
+}
+
+.loom-view-title {
+  margin: 0 0 1rem;
+  color: #e0e0e0;
+}
+
+.loom-card-title {
+  margin: 0 0 0.4rem;
+  color: #e0e0e0;
+}
+
+.loom-card-tagline {
+  margin: 0 0 1rem;
+  color: #90a4ae;
+  font-size: 0.9rem;
+  font-style: italic;
+}
+
+.loom-world-list,
+.loom-save-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-bottom: 1.25rem;
+}
+
+.loom-empty-state {
   color: #90a4ae;
   font-style: italic;
+}
+
+.loom-error {
+  color: #ff8a65;
+  font-size: 0.9rem;
+}
+
+.loom-note {
+  color: #90a4ae;
+  font-size: 0.85rem;
+  font-style: italic;
+  margin-top: 0.75rem;
+}
+
+.loom-summary {
+  background: rgba(17, 24, 39, 0.7);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 10px;
+  padding: 0.9rem 1.1rem;
+  margin-bottom: 1rem;
+  color: #90a4ae;
+  font-size: 0.85rem;
+  font-style: italic;
+}
+
+.loom-narration-log {
+  max-height: 50vh;
+  overflow-y: auto;
+  margin-bottom: 1rem;
+  padding-right: 0.25rem;
+}
+
+.loom-log-action {
+  color: #ffb74d;
+  font-weight: 600;
+  margin: 1rem 0 0.25rem;
+}
+
+.loom-log-action:first-child {
+  margin-top: 0;
+}
+
+.loom-log-narration {
+  color: #e0e0e0;
+  line-height: 1.6;
+  margin: 0;
+}
+
+.loom-suggested-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.loom-suggested-action-chip {
+  background: rgba(255, 183, 77, 0.12);
+  border: 1px solid rgba(255, 183, 77, 0.3);
+  border-radius: 999px;
+  color: #ffb74d;
+  cursor: pointer;
+  font-size: 0.8rem;
+  padding: 0.4rem 0.9rem;
+}
+
+.loom-suggested-action-chip:hover,
+.loom-suggested-action-chip:focus-visible {
+  background: rgba(255, 183, 77, 0.22);
+}
+
+.loom-turn-form {
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-end;
+}
+
+.loom-turn-input {
+  flex: 1;
+  background: rgba(17, 24, 39, 0.7);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 10px;
+  color: #e0e0e0;
+  font-family: inherit;
+  font-size: 0.95rem;
+  padding: 0.7rem 0.9rem;
+  resize: vertical;
+}
+
+.loom-turn-input:focus-visible {
+  outline: 2px solid rgba(255, 183, 77, 0.6);
+  outline-offset: 2px;
+}
+
+.loom-turn-input:disabled {
+  opacity: 0.6;
 }


### PR DESCRIPTION
## Summary
- Builds the three-view client-side router (world select → save select → play view) inside the single Loom app, per the design doc's "single app with mode routing" principle — no separate apps per world/scenario.
- `worlds.js`: lists Phase 1's world(s) from a small display-only `Loom.WORLDS` constant. Canon itself stays entirely server-side (`functions/loom-canon/`); a Firestore-backed world list is explicitly a Phase 3 (L-300) concern, not built here.
- `saves.js`: lists the current player's existing saves for the selected world via an owner-scoped Firestore read (`ownerUid == uid && worldId == worldId`), matching L-101's rules and the composite index L-102 added. Save *creation* has no backend yet (`loom_saves` is server-write-only per L-101, and no creation callable exists until L-121 / #306) — the "+ New Save" button surfaces a "coming soon" note rather than attempting a write that would just get rejected.
- `play.js`: turn input box, an append-only narration log for the session, the rolling state summary, and suggested-action chips — all driven entirely by the `loomPlayTurn` callable (L-110–117). Loading state disables input during a call; errors surface inline without crashing the view. Only the client-facing contract fields (`narration`, `stateSummary`, `suggestedActions`) are ever rendered — no raw state authority reaches the browser, per the design doc.
- `app.js`: wires the router + event listeners; `state.js` gains the routing/session state plus a `getRef` DOM-cache helper (Symposium's existing pattern).

Closes #305 (L-120).

## Test plan
- [x] `npm run lint:fix` / `npm run format:check` clean
- [x] `node --check` on all new/changed JS files (syntax valid)
- [x] Hosting-emulator asset verification — `/apps/loom/`, all five JS modules, and `loom.css` all serve 200
- [x] Verified the Firestore query shape (`where('ownerUid','==',uid).where('worldId','==',worldId)`) matches both the L-101 security rule and the L-102 composite index exactly
- [ ] Full authenticated click-through (world → save → turn submission) — **not possible in this sandbox**: `/__/firebase/init.js` needs outbound network access to fetch the real Firebase project config, which this environment doesn't have, so `firebase.initializeApp()` never actually runs here even with all emulators up (confirmed by inspecting the served init script — same root-cause limitation noted in the L-100 PR, #329). This needs a manual click-through in a real environment (e.g. the preview deploy) before/after merge.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XVNW1uHGnfWpM69kac16WF)_