### PR TITLE
feat(loom): save & resume — game list, create, delete (L-121)

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -2,10 +2,12 @@
 
 const { initializeApp } = require('firebase-admin/app');
 const { getAuth } = require('firebase-admin/auth');
-const { getFirestore } = require('firebase-admin/firestore');
+const { getFirestore, FieldValue } = require('firebase-admin/firestore');
 const { onCall, HttpsError } = require('firebase-functions/v2/https');
 const { GoogleAuth } = require('google-auth-library');
 const { runTurnPipeline, LoomTurnError } = require('./loom-turn');
+const loomCanon = require('./loom-canon');
+const { makeSave } = require('./loom-models');
 
 initializeApp();
 
@@ -361,6 +363,21 @@ exports.inviteUser = onCall(async (request) => {
 });
 
 /**
+ * Validates the caller is signed in and holds the `loom` app claim. Returns
+ * the caller's uid, or throws HttpsError.
+ */
+function requireLoomAuth(request) {
+  if (!request.auth) {
+    throw new HttpsError('unauthenticated', 'You must be signed in to play The Loom.');
+  }
+  const tokenApps = request.auth.token.apps;
+  if (!Array.isArray(tokenApps) || !tokenApps.includes('loom')) {
+    throw new HttpsError('permission-denied', "You don't have access to The Loom.");
+  }
+  return request.auth.uid;
+}
+
+/**
  * loomPlayTurn — runs one turn of The Loom's turn pipeline (design doc §5,
  * §7). Callable by any signed-in user with the `loom` app claim who owns the
  * target save; the client only ever receives the narration/summary contract,
@@ -370,13 +387,7 @@ exports.inviteUser = onCall(async (request) => {
  * Returns: { narration: string, stateSummary: string, suggestedActions: string[] }
  */
 exports.loomPlayTurn = onCall(async (request) => {
-  if (!request.auth) {
-    throw new HttpsError('unauthenticated', 'You must be signed in to play The Loom.');
-  }
-  const tokenApps = request.auth.token.apps;
-  if (!Array.isArray(tokenApps) || !tokenApps.includes('loom')) {
-    throw new HttpsError('permission-denied', "You don't have access to The Loom.");
-  }
+  const uid = requireLoomAuth(request);
 
   const { worldId, saveId, actionText } = request.data || {};
 
@@ -396,7 +407,7 @@ exports.loomPlayTurn = onCall(async (request) => {
   try {
     return await runTurnPipeline({
       db: getFirestore(),
-      uid: request.auth.uid,
+      uid,
       worldId: worldId.trim(),
       saveId: saveId.trim(),
       actionText: actionText.trim(),
@@ -408,4 +419,106 @@ exports.loomPlayTurn = onCall(async (request) => {
     console.error('loomPlayTurn error:', err);
     throw new HttpsError('internal', 'Failed to process turn.');
   }
+});
+
+/**
+ * loomCreateSave — creates a new save for the caller in a given world,
+ * initializing the character from that world's canon defaults (starting
+ * location, starting abilities). Callable by any signed-in user with the
+ * `loom` app claim.
+ *
+ * Data: { worldId: string, name: string, characterName: string }
+ * Returns: { saveId: string }
+ */
+exports.loomCreateSave = onCall(async (request) => {
+  const uid = requireLoomAuth(request);
+
+  const { worldId, name, characterName } = request.data || {};
+
+  if (typeof worldId !== 'string' || worldId.trim().length === 0) {
+    throw new HttpsError('invalid-argument', 'worldId is required.');
+  }
+  if (typeof name !== 'string' || name.trim().length === 0) {
+    throw new HttpsError('invalid-argument', 'name is required.');
+  }
+  if (name.length > 200) {
+    throw new HttpsError('invalid-argument', 'name must be 200 characters or fewer.');
+  }
+  if (typeof characterName !== 'string' || characterName.trim().length === 0) {
+    throw new HttpsError('invalid-argument', 'characterName is required.');
+  }
+  if (characterName.length > 200) {
+    throw new HttpsError('invalid-argument', 'characterName must be 200 characters or fewer.');
+  }
+
+  const canonWorld = loomCanon.getWorld(worldId.trim());
+  if (!canonWorld) {
+    throw new HttpsError('not-found', 'Unknown world.');
+  }
+
+  const db = getFirestore();
+  const saveRef = db.collection('loom_saves').doc();
+
+  const save = makeSave({
+    ownerUid: uid,
+    worldId: worldId.trim(),
+    name: name.trim(),
+    character: {
+      name: characterName.trim(),
+      abilities: (canonWorld.rules && canonWorld.rules.startingAbilities) || [],
+    },
+    location: canonWorld.rules && canonWorld.rules.startingLocationId,
+    createdAt: FieldValue.serverTimestamp(),
+    updatedAt: FieldValue.serverTimestamp(),
+  });
+
+  try {
+    await saveRef.set(save);
+  } catch (err) {
+    console.error('loomCreateSave error:', err);
+    throw new HttpsError('internal', 'Failed to create save.');
+  }
+
+  return { saveId: saveRef.id };
+});
+
+/**
+ * loomDeleteSave — deletes one of the caller's own saves, including its
+ * loom_turns event log (Firestore does not cascade-delete subcollections).
+ * Callable by any signed-in user with the `loom` app claim who owns the save.
+ *
+ * Data: { saveId: string }
+ * Returns: { success: true }
+ */
+exports.loomDeleteSave = onCall(async (request) => {
+  const uid = requireLoomAuth(request);
+
+  const { saveId } = request.data || {};
+  if (typeof saveId !== 'string' || saveId.trim().length === 0) {
+    throw new HttpsError('invalid-argument', 'saveId is required.');
+  }
+
+  const db = getFirestore();
+  const saveRef = db.collection('loom_saves').doc(saveId.trim());
+  const saveSnap = await saveRef.get();
+
+  if (!saveSnap.exists) {
+    throw new HttpsError('not-found', 'Save not found.');
+  }
+  if (saveSnap.data().ownerUid !== uid) {
+    throw new HttpsError('permission-denied', 'This is not your save.');
+  }
+
+  try {
+    const turnsSnap = await saveRef.collection('loom_turns').get();
+    const batch = db.batch();
+    turnsSnap.docs.forEach((doc) => batch.delete(doc.ref));
+    batch.delete(saveRef);
+    await batch.commit();
+  } catch (err) {
+    console.error('loomDeleteSave error:', err);
+    throw new HttpsError('internal', 'Failed to delete save.');
+  }
+
+  return { success: true };
 });

--- a/public/apps/loom/index.html
+++ b/public/apps/loom/index.html
@@ -58,7 +58,36 @@
           <div id="loom-save-list" class="loom-save-list"></div>
 
           <button class="app-btn" id="loom-new-save-btn" type="button">+ New Save</button>
-          <p class="loom-note hidden" id="loom-new-save-note">Creating new saves is coming soon.</p>
+
+          <form id="loom-new-save-form" class="loom-new-save-form hidden">
+            <div class="loom-form-group">
+              <label class="loom-form-label" for="loom-new-save-name">Save name</label>
+              <input
+                class="loom-form-input"
+                id="loom-new-save-name"
+                type="text"
+                maxlength="200"
+                placeholder="e.g. First Voyage"
+                required
+              />
+            </div>
+            <div class="loom-form-group">
+              <label class="loom-form-label" for="loom-new-character-name">Character name</label>
+              <input
+                class="loom-form-input"
+                id="loom-new-character-name"
+                type="text"
+                maxlength="200"
+                placeholder="e.g. Ishmael"
+                required
+              />
+            </div>
+            <p class="loom-error hidden" id="loom-new-save-error"></p>
+            <div class="loom-form-actions">
+              <button class="app-btn" id="loom-new-save-submit" type="submit">Create</button>
+              <button class="loom-back-link" id="loom-new-save-cancel" type="button">Cancel</button>
+            </div>
+          </form>
         </div>
 
         <!-- Play view -->

--- a/public/apps/loom/js/app.js
+++ b/public/apps/loom/js/app.js
@@ -17,10 +17,17 @@
     showView('worlds');
   }
 
+  function hideNewSaveForm() {
+    Loom.getRef('loom-new-save-form').classList.add('hidden');
+    Loom.getRef('loom-new-save-name').value = '';
+    Loom.getRef('loom-new-character-name').value = '';
+    Loom.getRef('loom-new-save-error').classList.add('hidden');
+  }
+
   function showSaves(worldId, worldName) {
     state.worldId = worldId;
     Loom.getRef('loom-save-select-title').textContent = worldName;
-    Loom.getRef('loom-new-save-note').classList.add('hidden');
+    hideNewSaveForm();
     showView('saves');
     Loom.saves.loadSaves(worldId);
   }
@@ -53,7 +60,28 @@
       });
 
       Loom.getRef('loom-new-save-btn').addEventListener('click', function () {
-        Loom.getRef('loom-new-save-note').classList.remove('hidden');
+        Loom.getRef('loom-new-save-form').classList.remove('hidden');
+      });
+
+      Loom.getRef('loom-new-save-cancel').addEventListener('click', function () {
+        hideNewSaveForm();
+      });
+
+      Loom.getRef('loom-new-save-form').addEventListener('submit', function (e) {
+        e.preventDefault();
+        var name = Loom.getRef('loom-new-save-name').value.trim();
+        var characterName = Loom.getRef('loom-new-character-name').value.trim();
+        if (!name || !characterName) return;
+
+        Loom.saves
+          .createSave(state.worldId, name, characterName)
+          .then(function (saveId) {
+            hideNewSaveForm();
+            showPlay(saveId, { recentSummary: '' });
+          })
+          .catch(function () {
+            // Error already surfaced inline by createSave(); nothing more to do here.
+          });
       });
 
       Loom.getRef('loom-turn-form').addEventListener('submit', function (e) {

--- a/public/apps/loom/js/saves.js
+++ b/public/apps/loom/js/saves.js
@@ -5,9 +5,9 @@
   var state = Loom.state;
 
   /**
-   * Lists the current player's saves for a world. Read-only — loom_saves is
-   * server-write-only (L-101), so there is nothing to create/delete from the
-   * client yet; that lands with the real save-creation flow in L-121 (#306).
+   * Lists the current player's saves for a world. Read-only Firestore query —
+   * loom_saves is server-write-only (L-101), so create/delete below go
+   * through the loomCreateSave/loomDeleteSave callables (L-121).
    */
   function loadSaves(worldId) {
     var listEl = Loom.getRef('loom-save-list');
@@ -51,28 +51,79 @@
     var title = document.createElement('h3');
     title.className = 'loom-card-title';
     title.textContent = save.name || 'Unnamed Save';
+    card.appendChild(title);
 
     if (save.character && save.character.name) {
       var meta = document.createElement('p');
       meta.className = 'loom-card-tagline';
       meta.textContent = save.character.name;
-      card.appendChild(title);
       card.appendChild(meta);
-    } else {
-      card.appendChild(title);
     }
 
-    var btn = document.createElement('button');
-    btn.type = 'button';
-    btn.className = 'app-btn';
-    btn.textContent = 'Resume';
-    btn.addEventListener('click', function () {
+    var actions = document.createElement('div');
+    actions.className = 'loom-save-card-actions';
+
+    var resumeBtn = document.createElement('button');
+    resumeBtn.type = 'button';
+    resumeBtn.className = 'app-btn';
+    resumeBtn.textContent = 'Resume';
+    resumeBtn.addEventListener('click', function () {
       Loom.app.showPlay(saveId, save);
     });
-    card.appendChild(btn);
+    actions.appendChild(resumeBtn);
 
+    var deleteBtn = document.createElement('button');
+    deleteBtn.type = 'button';
+    deleteBtn.className = 'loom-delete-btn';
+    deleteBtn.textContent = 'Delete';
+    deleteBtn.addEventListener('click', function () {
+      deleteSave(saveId, save.name || 'Unnamed Save');
+    });
+    actions.appendChild(deleteBtn);
+
+    card.appendChild(actions);
     return card;
   }
 
-  Loom.saves = { loadSaves: loadSaves };
+  function deleteSave(saveId, saveName) {
+    if (!window.confirm('Delete "' + saveName + '"? This cannot be undone.')) {
+      return;
+    }
+
+    var errorEl = Loom.getRef('loom-saves-error');
+    errorEl.classList.add('hidden');
+
+    var loomDeleteSave = state.functions.httpsCallable('loomDeleteSave');
+    loomDeleteSave({ saveId: saveId })
+      .then(function () {
+        loadSaves(state.worldId);
+      })
+      .catch(function (err) {
+        errorEl.textContent = 'Could not delete save: ' + (err.message || 'Unknown error');
+        errorEl.classList.remove('hidden');
+      });
+  }
+
+  /** Creates a new save via the loomCreateSave callable. Returns a promise of the new saveId. */
+  function createSave(worldId, name, characterName) {
+    var errorEl = Loom.getRef('loom-new-save-error');
+    var submitBtn = Loom.getRef('loom-new-save-submit');
+    errorEl.classList.add('hidden');
+    submitBtn.disabled = true;
+
+    var loomCreateSave = state.functions.httpsCallable('loomCreateSave');
+    return loomCreateSave({ worldId: worldId, name: name, characterName: characterName })
+      .then(function (result) {
+        submitBtn.disabled = false;
+        return result.data.saveId;
+      })
+      .catch(function (err) {
+        submitBtn.disabled = false;
+        errorEl.textContent = 'Could not create save: ' + (err.message || 'Unknown error');
+        errorEl.classList.remove('hidden');
+        throw err;
+      });
+  }
+
+  Loom.saves = { loadSaves: loadSaves, createSave: createSave };
 })();

--- a/public/apps/loom/loom.css
+++ b/public/apps/loom/loom.css
@@ -58,11 +58,69 @@
   font-size: 0.9rem;
 }
 
-.loom-note {
+.loom-save-card-actions {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.loom-delete-btn {
+  background: none;
+  border: 1px solid rgba(255, 138, 101, 0.4);
+  border-radius: 8px;
+  color: #ff8a65;
+  cursor: pointer;
+  font-size: 0.8rem;
+  padding: 0.6rem 1.1rem;
+}
+
+.loom-delete-btn:hover,
+.loom-delete-btn:focus-visible {
+  background: rgba(255, 138, 101, 0.12);
+}
+
+.loom-new-save-form {
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.loom-new-save-form.hidden {
+  display: none;
+}
+
+.loom-form-group {
+  margin-bottom: 0.9rem;
+}
+
+.loom-form-label {
+  display: block;
   color: #90a4ae;
   font-size: 0.85rem;
-  font-style: italic;
-  margin-top: 0.75rem;
+  margin-bottom: 0.35rem;
+}
+
+.loom-form-input {
+  width: 100%;
+  background: rgba(17, 24, 39, 0.7);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  color: #e0e0e0;
+  font-family: inherit;
+  font-size: 0.95rem;
+  padding: 0.6rem 0.8rem;
+  box-sizing: border-box;
+}
+
+.loom-form-input:focus-visible {
+  outline: 2px solid rgba(255, 183, 77, 0.6);
+  outline-offset: 2px;
+}
+
+.loom-form-actions {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
 }
 
 .loom-summary {

--- a/tests/loom-save-management.test.js
+++ b/tests/loom-save-management.test.js
@@ -1,0 +1,186 @@
+'use strict';
+
+/**
+ * Integration tests for the loomCreateSave / loomDeleteSave callables (L-121).
+ *
+ * Runs against the Firestore emulator + firebase-functions-test, mirroring
+ * tests/loom-turn.test.js's pattern.
+ *
+ * Run: firebase emulators:exec --only firestore --project demo-loom-test "cd tests && npx jest loom-save-management --verbose"
+ */
+
+process.env.FIRESTORE_EMULATOR_HOST = process.env.FIRESTORE_EMULATOR_HOST || 'localhost:8080';
+process.env.GCLOUD_PROJECT = 'demo-loom-test';
+
+const functionsTest = require('firebase-functions-test')({ projectId: 'demo-loom-test' }, null);
+
+// Requiring functions/index.js triggers its single initializeApp() call.
+const { loomCreateSave, loomDeleteSave } = require('../functions/index');
+const path = require('path');
+const functionsFirestorePath = require.resolve('firebase-admin/firestore', {
+  paths: [path.resolve(__dirname, '../functions')],
+});
+const { getFirestore } = require(functionsFirestorePath);
+const db = getFirestore();
+
+const TEST_UID = 'player-001';
+const WORLD_ID = 'shattered-coast';
+
+function callCreate(data, authOverride) {
+  return loomCreateSave.run({
+    data,
+    auth:
+      authOverride !== undefined
+        ? authOverride
+        : { uid: TEST_UID, token: { apps: ['loom'], admin: false } },
+  });
+}
+
+function callDelete(data, authOverride) {
+  return loomDeleteSave.run({
+    data,
+    auth:
+      authOverride !== undefined
+        ? authOverride
+        : { uid: TEST_UID, token: { apps: ['loom'], admin: false } },
+  });
+}
+
+async function clearCreatedSaves() {
+  const snap = await db.collection('loom_saves').where('worldId', '==', WORLD_ID).get();
+  for (const doc of snap.docs) {
+    const turnsSnap = await doc.ref.collection('loom_turns').get();
+    const batch = db.batch();
+    turnsSnap.docs.forEach((turnDoc) => batch.delete(turnDoc.ref));
+    batch.delete(doc.ref);
+    await batch.commit();
+  }
+}
+
+afterEach(async () => {
+  await clearCreatedSaves();
+});
+
+afterAll(async () => {
+  functionsTest.cleanup();
+});
+
+describe('loomCreateSave', () => {
+  it('rejects an unauthenticated caller', async () => {
+    await expect(
+      callCreate({ worldId: WORLD_ID, name: 'My Save', characterName: 'Ishmael' }, null)
+    ).rejects.toThrow(/signed in/i);
+  });
+
+  it('rejects a caller without the loom claim', async () => {
+    await expect(
+      callCreate(
+        { worldId: WORLD_ID, name: 'My Save', characterName: 'Ishmael' },
+        { uid: TEST_UID, token: { apps: ['other-app'], admin: false } }
+      )
+    ).rejects.toThrow(/access to the loom/i);
+  });
+
+  it('rejects a missing worldId', async () => {
+    await expect(callCreate({ name: 'My Save', characterName: 'Ishmael' })).rejects.toThrow(
+      /worldId/
+    );
+  });
+
+  it('rejects a missing name', async () => {
+    await expect(
+      callCreate({ worldId: WORLD_ID, characterName: 'Ishmael' })
+    ).rejects.toThrow(/name/);
+  });
+
+  it('rejects a missing characterName', async () => {
+    await expect(callCreate({ worldId: WORLD_ID, name: 'My Save' })).rejects.toThrow(
+      /characterName/
+    );
+  });
+
+  it('rejects an unknown world', async () => {
+    await expect(
+      callCreate({ worldId: 'nonexistent-world', name: 'My Save', characterName: 'Ishmael' })
+    ).rejects.toThrow(/unknown world/i);
+  });
+
+  it('creates a save initialized from canon defaults', async () => {
+    const result = await callCreate({
+      worldId: WORLD_ID,
+      name: 'My Save',
+      characterName: 'Ishmael',
+    });
+
+    expect(typeof result.saveId).toBe('string');
+    expect(result.saveId.length).toBeGreaterThan(0);
+
+    const snap = await db.collection('loom_saves').doc(result.saveId).get();
+    expect(snap.exists).toBe(true);
+
+    const save = snap.data();
+    expect(save.ownerUid).toBe(TEST_UID);
+    expect(save.worldId).toBe(WORLD_ID);
+    expect(save.name).toBe('My Save');
+    expect(save.character.name).toBe('Ishmael');
+    expect(save.character.condition).toBe('healthy');
+    expect(save.character.abilities).toEqual(['seaworthy-vessel']);
+    expect(save.location).toBe('widows-reach');
+    expect(save.recentSummary).toBe('');
+  });
+});
+
+describe('loomDeleteSave', () => {
+  async function seedSave() {
+    const result = await callCreate({
+      worldId: WORLD_ID,
+      name: 'Save To Delete',
+      characterName: 'Ishmael',
+    });
+    return result.saveId;
+  }
+
+  it('rejects an unauthenticated caller', async () => {
+    const saveId = await seedSave();
+    await expect(callDelete({ saveId }, null)).rejects.toThrow(/signed in/i);
+  });
+
+  it('rejects a missing saveId', async () => {
+    await expect(callDelete({})).rejects.toThrow(/saveId/);
+  });
+
+  it('rejects deleting a save that does not exist', async () => {
+    await expect(callDelete({ saveId: 'nonexistent-save' })).rejects.toThrow(/not found/i);
+  });
+
+  it('rejects deleting a save owned by a different user', async () => {
+    const saveId = await seedSave();
+    await expect(
+      callDelete({ saveId }, { uid: 'someone-else', token: { apps: ['loom'], admin: false } })
+    ).rejects.toThrow(/not your save/i);
+
+    const snap = await db.collection('loom_saves').doc(saveId).get();
+    expect(snap.exists).toBe(true);
+  });
+
+  it('deletes the save and its turn log', async () => {
+    const saveId = await seedSave();
+    await db.collection('loom_saves').doc(saveId).collection('loom_turns').doc('turn-0').set({
+      index: 0,
+      actionText: 'look around',
+    });
+
+    const result = await callDelete({ saveId });
+    expect(result).toEqual({ success: true });
+
+    const saveSnap = await db.collection('loom_saves').doc(saveId).get();
+    expect(saveSnap.exists).toBe(false);
+
+    const turnsSnap = await db
+      .collection('loom_saves')
+      .doc(saveId)
+      .collection('loom_turns')
+      .get();
+    expect(turnsSnap.empty).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `loomCreateSave(worldId, name, characterName)`: creates a new `loom_saves` doc with the character initialized from the world's canon defaults (`startingLocationId`, `startingAbilities`). Returns `{ saveId }`. Required because `loom_saves` is server-write-only (L-101 / #294) — there's no client write path at all, including creates, so L-120's (#305) game-list UI had a stubbed "coming soon" placeholder for this.
- Adds `loomDeleteSave(saveId)`: owner-checked delete of a save **and** its `loom_turns` event log in one batch (Firestore doesn't cascade-delete subcollections).
- Both share a small `requireLoomAuth(request)` helper extracted from `loomPlayTurn`'s existing auth/claim check.
- Frontend: the "+ New Save" button now opens an inline form (save name + character name) instead of the placeholder note, calls `loomCreateSave`, and routes straight into the new save's play view. Each save card gets a "Delete" button (`window.confirm` guard, matching the existing Symposium delete-confirmation pattern) wired to `loomDeleteSave`.
- Resume itself was already real as of L-120 (owner-scoped Firestore read into the play view, `recentSummary` restored) — this issue specifically closes the create/delete gap L-120 left as a stub.

Closes #306 (L-121).

## Test plan
- [x] `tests/loom-save-management.test.js` — 12 new integration tests against the Firestore emulator + `firebase-functions-test`: auth/claim enforcement and input validation for both callables, unknown-world rejection, correct canon-default initialization (character name/condition/abilities, starting location, empty summary), not-found/wrong-owner rejections for delete, and confirmation that delete removes both the save doc and its full turn log
- [x] Full suite: `firebase emulators:exec --only firestore --project demo-olympus-rules-test "cd tests && npm test"` — 274/274 passing, clean exit
- [x] `npm run lint` / `npm run format:check` clean
- [x] `node --check` on all changed JS files


---
_Generated by [Claude Code](https://claude.ai/code/session_01XVNW1uHGnfWpM69kac16WF)_