### PR TITLE
test(loom): integration tests for loomPlayTurn with mocked AI (L-130)

### DIFF
--- a/tests/fixtures/loom.js
+++ b/tests/fixtures/loom.js
@@ -1,0 +1,109 @@
+'use strict';
+
+/**
+ * Fixture factories for Loom turn-pipeline tests (L-130 / #307).
+ *
+ * Mirrors the style of the removed tests/fixtures/void-odyssey.js factory
+ * pattern for this project's turn-test convention: small, override-friendly
+ * builders rather than hand-rolled literals scattered across test files.
+ */
+
+/** A minimal but structurally complete canon world (functions/loom-canon shape). */
+function makeWorld(overrides) {
+  var base = {
+    id: 'test-world',
+    name: 'Test World',
+    tagline: 'A test world.',
+    openingHook: 'You begin.',
+    locations: {
+      start: {
+        id: 'start',
+        name: 'Starting Point',
+        description: 'Where it all begins.',
+        connections: ['next'],
+        factionIds: [],
+        npcIds: [],
+        rules: {},
+      },
+      next: {
+        id: 'next',
+        name: 'Next Place',
+        description: 'Further along.',
+        connections: ['start'],
+        factionIds: [],
+        npcIds: [],
+        rules: {},
+      },
+    },
+    factions: {},
+    characters: {},
+    lore: {},
+    rules: { startingLocationId: 'start', startingAbilities: [] },
+  };
+  return Object.assign({}, base, overrides || {});
+}
+
+function makeCharacter(overrides) {
+  return Object.assign(
+    { name: 'Test Character', condition: 'healthy', inventory: [], abilities: [], goals: [] },
+    overrides || {}
+  );
+}
+
+/** A loom_saves-shaped document. Timestamps are left for the caller to fill in. */
+function makeSave(overrides) {
+  var base = {
+    ownerUid: 'test-uid',
+    worldId: 'test-world',
+    name: 'Test Save',
+    character: makeCharacter(),
+    location: 'start',
+    privateFlags: {},
+    relationships: {},
+    recentSummary: '',
+  };
+  return Object.assign({}, base, overrides || {});
+}
+
+/** A loom_turns-shaped document. */
+function makeTurn(overrides) {
+  return Object.assign(
+    {
+      index: 0,
+      actionText: 'look around',
+      proposedAction: { verb: 'look', targets: [], params: {} },
+      resolution: { outcome: 'acknowledged', mutations: [], constraints: [] },
+      narration: 'Nothing happens.',
+      entityRefs: [],
+    },
+    overrides || {}
+  );
+}
+
+/** An ADJUDICATE-shaped Resolution. */
+function makeResolution(overrides) {
+  return Object.assign({ outcome: 'success', mutations: [], constraints: [] }, overrides || {});
+}
+
+/** An INTERPRET-shaped proposedAction. */
+function makePlayerAction(overrides) {
+  return Object.assign({ verb: 'look', targets: [], params: {} }, overrides || {});
+}
+
+/** A mocked callGemini response for the NARRATE stage's JSON contract. */
+function makeAiResponse(overrides) {
+  return Object.assign(
+    { narration: 'Default narration.', inventedEntities: [], suggestedActions: [] },
+    overrides || {}
+  );
+}
+
+module.exports = {
+  makeWorld,
+  makeCharacter,
+  makeSave,
+  makeTurn,
+  makeResolution,
+  makePlayerAction,
+  makeAiResponse,
+};

--- a/tests/loom-turn.test.js
+++ b/tests/loom-turn.test.js
@@ -1,19 +1,30 @@
 'use strict';
 
 /**
- * Integration tests for the loomPlayTurn callable orchestrator (L-110).
+ * Integration tests for the loomPlayTurn callable orchestrator (L-110, L-130
+ * / #307).
  *
- * Runs against the Firestore emulator with the real (stubbed) pipeline —
- * INTERPRET/ADJUDICATE/NARRATE are stubs until L-111/112/113 land, so these
- * tests exercise INTAKE, stage sequencing, auth/ownership enforcement, and
- * the real COMMIT write path. The fuller emulator + mocked-AI integration
- * suite (fixtures, per-stage assertions) is L-130 (#307).
+ * Runs the full §5 pipeline against the Firestore emulator with a mocked
+ * functions/gemini.js — deterministic, no network calls — so tests can
+ * assert on actual AI-driven behavior (not just the fallback paths a real,
+ * uncredentialed callGemini would take). Server dice (functions/loom-turn/
+ * adjudicate.js) are already deterministic given a fixed proposedAction, so
+ * the whole pipeline is reproducible run to run.
  *
  * Run: firebase emulators:exec --only firestore --project demo-loom-test "cd tests && npx jest loom-turn --verbose"
  */
 
 process.env.FIRESTORE_EMULATOR_HOST = process.env.FIRESTORE_EMULATOR_HOST || 'localhost:8080';
 process.env.GCLOUD_PROJECT = 'demo-loom-test';
+
+// Mock callGemini before requiring functions/index.js (and anything that
+// transitively requires functions/gemini.js) so every INTERPRET/NARRATE/
+// summary-regen call in the pipeline goes through this mock, never the
+// network.
+const mockCallGemini = jest.fn();
+jest.mock('../functions/gemini', () => ({
+  callGemini: (...args) => mockCallGemini(...args),
+}));
 
 const functionsTest = require('firebase-functions-test')({ projectId: 'demo-loom-test' }, null);
 
@@ -30,7 +41,10 @@ if (admin.apps.length === 0) {
 const db = admin.firestore();
 
 const { loomPlayTurn } = require('../functions/index');
-const { makeSave } = require('../functions/loom-models');
+const { makeSave: makeSaveDoc } = require('../functions/loom-models');
+const loomCanon = require('../functions/loom-canon');
+const { normalizeEntityName } = require('../functions/loom-turn/soft-canon');
+const { makeWorld, makeSave, makePlayerAction, makeAiResponse } = require('./fixtures/loom');
 
 const TEST_UID = 'player-001';
 const WORLD_ID = 'shattered-coast';
@@ -47,7 +61,7 @@ function callTurn(data, authOverride) {
 }
 
 async function seedSave(overrides) {
-  const save = makeSave(
+  const save = makeSaveDoc(
     Object.assign(
       {
         ownerUid: TEST_UID,
@@ -69,11 +83,28 @@ async function clearAll() {
   const turnsSnap = await saveRef.collection('loom_turns').get();
   await Promise.all(turnsSnap.docs.map((d) => d.ref.delete()));
   await saveRef.delete().catch(() => {});
-  await db.collection('loom_world_state').doc(WORLD_ID).delete().catch(() => {});
+  await db
+    .collection('loom_world_state')
+    .doc(WORLD_ID)
+    .delete()
+    .catch(() => {});
+}
+
+/** Default mock: routes by system prompt content so unrelated tests don't need per-call setup. */
+function defaultCallGeminiImplementation(options) {
+  if (options.systemInstruction.indexOf('INTERPRET stage') !== -1) {
+    return Promise.resolve(makePlayerAction());
+  }
+  if (options.systemInstruction.indexOf('summarizer') !== -1) {
+    return Promise.resolve('A summary of recent events.');
+  }
+  return Promise.resolve(makeAiResponse());
 }
 
 beforeEach(async () => {
   await clearAll();
+  mockCallGemini.mockReset();
+  mockCallGemini.mockImplementation(defaultCallGeminiImplementation);
 });
 
 afterAll(async () => {
@@ -216,25 +247,217 @@ describe('loomPlayTurn — end-to-end happy path', () => {
     const worldStateSnap = await db.collection('loom_world_state').doc(WORLD_ID).get();
     expect(worldStateSnap.data().worldClock).toBe(42);
   });
+});
 
-  it('survives crossing the summary-regen threshold (L-114 fire-and-forget trigger)', async () => {
+describe('control invariants — the model proposes, the server disposes', () => {
+  it('rejects an illegal move even when narration falsely claims success', async () => {
+    await seedSave({ location: 'widows-reach' });
+
+    // widows-reach has no direct connection to fort-augustine.
+    mockCallGemini
+      .mockImplementationOnce(() => makePlayerAction({ verb: 'move', targets: ['fort-augustine'] }))
+      .mockImplementationOnce(() =>
+        makeAiResponse({ narration: 'You arrive at Fort Augustine triumphantly!' })
+      );
+
+    const result = await callTurn({
+      worldId: WORLD_ID,
+      saveId: SAVE_ID,
+      actionText: 'sail straight to fort augustine',
+    });
+
+    // The model's prose is whatever it said — that's just flavor text.
+    expect(result.narration).toContain('Fort Augustine');
+
+    // But the persisted hard state must NOT reflect the model's claim.
+    const saveSnap = await db.collection('loom_saves').doc(SAVE_ID).get();
+    expect(saveSnap.data().location).toBe('widows-reach');
+  });
+
+  it('rejects a move requiring an ability the character lacks', async () => {
+    await seedSave({ location: 'widows-reach', character: { name: 'Test', abilities: [] } });
+
+    mockCallGemini.mockImplementationOnce(() =>
+      makePlayerAction({ verb: 'move', targets: ['the-drowned-shoals'] })
+    );
+
+    await callTurn({ worldId: WORLD_ID, saveId: SAVE_ID, actionText: 'row into the shoals' });
+
+    const saveSnap = await db.collection('loom_saves').doc(SAVE_ID).get();
+    expect(saveSnap.data().location).toBe('widows-reach');
+  });
+
+  it('applies the correct mutation for a legal move', async () => {
+    await seedSave({ location: 'widows-reach' });
+
+    mockCallGemini.mockImplementationOnce(() =>
+      makePlayerAction({ verb: 'move', targets: ['skeleton-cove'] })
+    );
+
+    await callTurn({ worldId: WORLD_ID, saveId: SAVE_ID, actionText: 'row to skeleton cove' });
+
+    const saveSnap = await db.collection('loom_saves').doc(SAVE_ID).get();
+    expect(saveSnap.data().location).toBe('skeleton-cove');
+
+    const worldStateSnap = await db.collection('loom_world_state').doc(WORLD_ID).get();
+    expect(worldStateSnap.data().worldClock).toBe(1);
+  });
+
+  it('never lets INTERPRET or NARRATE output smuggle in a state_mutations-shaped field', async () => {
+    await seedSave({ location: 'widows-reach' });
+
+    mockCallGemini
+      .mockImplementationOnce(() =>
+        Object.assign(makePlayerAction({ verb: 'look' }), {
+          outcome: 'success',
+          mutations: [{ op: 'set-flag', path: 'location', value: 'fort-augustine' }],
+        })
+      )
+      .mockImplementationOnce(() => makeAiResponse());
+
+    await callTurn({ worldId: WORLD_ID, saveId: SAVE_ID, actionText: 'look around' });
+
+    const saveSnap = await db.collection('loom_saves').doc(SAVE_ID).get();
+    expect(saveSnap.data().location).toBe('widows-reach');
+  });
+});
+
+describe('soft-canon quarantine — end-to-end', () => {
+  it('promotes an invented entity into World State on the second mention', async () => {
+    await seedSave();
+
+    mockCallGemini
+      .mockImplementationOnce(() => makePlayerAction({ verb: 'look' }))
+      .mockImplementationOnce(() =>
+        makeAiResponse({
+          narration: 'A barkeep named Doral greets you.',
+          inventedEntities: ['Doral'],
+        })
+      );
+    await callTurn({ worldId: WORLD_ID, saveId: SAVE_ID, actionText: 'look around' });
+
+    let worldStateSnap = await db.collection('loom_world_state').doc(WORLD_ID).get();
+    const flagKey = 'entity_' + normalizeEntityName('Doral');
+    expect(worldStateSnap.data().globalFlags[flagKey]).toBeUndefined();
+
+    mockCallGemini
+      .mockImplementationOnce(() => makePlayerAction({ verb: 'talk', targets: ['Doral'] }))
+      .mockImplementationOnce(() =>
+        makeAiResponse({ narration: 'Doral nods at you again.', inventedEntities: ['Doral'] })
+      );
+    await callTurn({ worldId: WORLD_ID, saveId: SAVE_ID, actionText: 'greet doral again' });
+
+    worldStateSnap = await db.collection('loom_world_state').doc(WORLD_ID).get();
+    expect(worldStateSnap.data().globalFlags[flagKey]).toBe('Doral');
+  });
+});
+
+describe('entity-keyed retrieval — end-to-end', () => {
+  it("surfaces an NPC's prior turn narration to NARRATE when they re-enter a scene", async () => {
+    await seedSave({ location: 'widows-reach' });
+
+    mockCallGemini
+      .mockImplementationOnce(() =>
+        makePlayerAction({ verb: 'talk', targets: ['captain-orla-vance'] })
+      )
+      .mockImplementationOnce(() =>
+        makeAiResponse({ narration: 'Captain Orla Vance warns you about the patrol.' })
+      );
+    await callTurn({ worldId: WORLD_ID, saveId: SAVE_ID, actionText: 'talk to the captain' });
+
+    let secondNarrateSawHistory = false;
+    mockCallGemini
+      .mockImplementationOnce(() =>
+        makePlayerAction({ verb: 'talk', targets: ['captain-orla-vance'] })
+      )
+      .mockImplementationOnce((options) => {
+        secondNarrateSawHistory = options.userMessage.indexOf('warns you about the patrol') !== -1;
+        return makeAiResponse({ narration: 'She nods again.' });
+      });
+    await callTurn({ worldId: WORLD_ID, saveId: SAVE_ID, actionText: 'talk to her again' });
+
+    expect(secondNarrateSawHistory).toBe(true);
+  });
+});
+
+describe('rolling summary regeneration — end-to-end', () => {
+  it('regenerates recentSummary once the turn count crosses the threshold', async () => {
     await seedSave();
 
     // SUMMARY_REGEN_THRESHOLD is 10 — the 10th turn (index 9) crosses it.
     for (let i = 0; i < 10; i++) {
-      const result = await callTurn({
-        worldId: WORLD_ID,
-        saveId: SAVE_ID,
-        actionText: 'wait quietly turn ' + i,
-      });
-      expect(typeof result.narration).toBe('string');
+      await callTurn({ worldId: WORLD_ID, saveId: SAVE_ID, actionText: 'wait quietly turn ' + i });
+    }
+
+    // Summary regen is fire-and-forget (COMMIT does not await it) — give it a
+    // moment to land before asserting.
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    const saveSnap = await db.collection('loom_saves').doc(SAVE_ID).get();
+    expect(saveSnap.data().recentSummary).toBe('A summary of recent events.');
+  });
+});
+
+describe('hard state persistence', () => {
+  it('never truncates or overwrites earlier turns as new ones are appended', async () => {
+    await seedSave();
+
+    for (let i = 0; i < 5; i++) {
+      await callTurn({ worldId: WORLD_ID, saveId: SAVE_ID, actionText: 'action number ' + i });
     }
 
     const turnsSnap = await db
       .collection('loom_saves')
       .doc(SAVE_ID)
       .collection('loom_turns')
+      .orderBy('index', 'asc')
       .get();
-    expect(turnsSnap.size).toBe(10);
+
+    expect(turnsSnap.size).toBe(5);
+    turnsSnap.docs.forEach((doc, i) => {
+      expect(doc.data().index).toBe(i);
+      expect(doc.data().actionText).toBe('action number ' + i);
+    });
+  });
+});
+
+describe('loomPlayTurn — works against a fully synthetic world', () => {
+  const FIXTURE_WORLD_ID = 'test-world';
+  const FIXTURE_SAVE_ID = 'fixture-save-001';
+
+  afterEach(async () => {
+    const saveRef = db.collection('loom_saves').doc(FIXTURE_SAVE_ID);
+    await saveRef.delete().catch(() => {});
+    await db
+      .collection('loom_world_state')
+      .doc(FIXTURE_WORLD_ID)
+      .delete()
+      .catch(() => {});
+  });
+
+  it('completes a turn end-to-end against a minimal fixture world (not just shattered-coast)', async () => {
+    jest.spyOn(loomCanon, 'getWorld').mockReturnValueOnce(makeWorld());
+
+    const save = makeSaveDoc(
+      makeSave({
+        ownerUid: TEST_UID,
+        worldId: FIXTURE_WORLD_ID,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      })
+    );
+    await db.collection('loom_saves').doc(FIXTURE_SAVE_ID).set(save);
+
+    const result = await callTurn({
+      worldId: FIXTURE_WORLD_ID,
+      saveId: FIXTURE_SAVE_ID,
+      actionText: 'look around',
+    });
+
+    expect(typeof result.narration).toBe('string');
+    expect(result.narration.length).toBeGreaterThan(0);
+
+    const worldStateSnap = await db.collection('loom_world_state').doc(FIXTURE_WORLD_ID).get();
+    expect(worldStateSnap.exists).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Closes L-130 (#307).

- Mocks `functions/gemini.js` so `tests/loom-turn.test.js` exercises the full `loomPlayTurn` pipeline against the Firestore emulator without live model calls. A `defaultCallGeminiImplementation` routes canned responses by system-prompt content (INTERPRET stage, summarizer, or NARRATE), so every stage of the real pipeline runs, not a stubbed one.
- Adds `tests/fixtures/loom.js` with shared factory functions (`makeWorld`, `makeCharacter`, `makeSave`, `makeTurn`, `makeResolution`, `makePlayerAction`, `makeAiResponse`) so tests build fixtures instead of hand-rolling literals.
- Preserves all existing auth/ownership/happy-path coverage from L-110 and adds new coverage required by the issue:
  - **Control invariants** — an illegal move is rejected even when the mocked narration falsely claims success; ability-gated moves (e.g. requiring `seaworthy-vessel`) are enforced; a legal move applies the correct mutation; INTERPRET/NARRATE output can't smuggle in an `outcome`/`mutations` field that bypasses ADJUDICATE.
  - **Soft-canon quarantine** — an invented entity is promoted into World State only after its second mention across two real `loomPlayTurn` calls.
  - **Entity-keyed retrieval** — a second turn's NARRATE prompt receives the first turn's narration about a recurring NPC.
  - **Rolling summary regeneration** — `recentSummary` updates after the turn count crosses the regeneration threshold.
  - **Hard state persistence** — turn history remains complete and correctly ordered across multiple turns.
  - **Synthetic world** — the pipeline is exercised against a minimal fixture world (via `jest.spyOn(loomCanon, 'getWorld')`), proving it isn't hardcoded to Shattered Coast.

## Test plan

- [x] `node --check` on both new/changed files
- [x] `npm run lint:fix` / `npm run format`
- [x] `firebase emulators:exec --only firestore --project demo-loom-test "cd tests && npx jest loom-turn --verbose"` — 24/24 passing
- [x] Full suite (`firebase emulators:exec --only firestore --project demo-olympus-rules-test "cd tests && npm test"`) run twice — 282/282 passing both times, no regressions

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XVNW1uHGnfWpM69kac16WF

---
_Generated by [Claude Code](https://claude.ai/code/session_01XVNW1uHGnfWpM69kac16WF)_