### PR TITLE
test(loom): Phase 1 exit-criterion verification harness (L-131)

### DIFF
--- a/planning/phase-1-signoff.md
+++ b/planning/phase-1-signoff.md
@@ -1,0 +1,56 @@
+# The Loom — Phase 1 (MVP) Exit-Criterion Sign-Off
+
+**Milestone:** The Loom — Phase 1: MVP
+**Gate (design doc §10):** "A multi-session adventure that, across a session gap, never forgets hard state, never breaks the seeded rules, and never silently contradicts canon. Resume works."
+
+## Verification method
+
+`tests/loom-verification.test.js` (L-131 / #308) is the automated, reproducible
+demonstration of the gate. It runs the real `loomCreateSave` / `loomPlayTurn` /
+`loomDeleteSave` callables against the Firestore emulator and the real
+shattered-coast canon world, with only `functions/gemini.js` mocked (so the
+scenario is deterministic and network-free while every other stage of the §5
+pipeline — INTERPRET, ADJUDICATE, NARRATE, COMMIT, soft-canon, retrieval,
+summary — runs for real).
+
+It scripts one continuous adventure across a simulated session gap:
+
+1. **Session 1** — the player talks to Captain Orla Vance (the model invents a
+   one-off NPC, "Bramwell," mentioned once) and then makes a legal move to
+   Skeleton Cove. This sets the hard fact under test: `save.location` and
+   `worldState.worldClock`.
+2. **Session gap** — the test re-reads the save and world state directly from
+   Firestore, standing in for the player closing the app and returning later.
+   Nothing is carried in process memory.
+3. **Session 2**:
+   - An illegal move (Skeleton Cove → Fort Augustine, not a direct
+     connection) is attempted; the mocked model's narration lies and claims
+     arrival. ADJUDICATE rejects it regardless — the seeded rule holds.
+   - The player rows back to Widow's Reach and talks to the captain again;
+     the NARRATE call for that turn is asserted to receive session 1's
+     narration about her, proving entity-keyed retrieval survives the gap.
+   - Bramwell is mentioned a second time. Only now is the entity promoted into
+     `worldState.globalFlags`. The frozen canon module (`functions/loom-canon`)
+     is snapshotted before the scenario and diffed after: it is byte-for-byte
+     identical, and no character named "Bramwell" exists in it — the invention
+     never became canon.
+4. Cleanup deletes the save via `loomDeleteSave`.
+
+## Result
+
+**PASS.** All four checks (hard state, seeded rules, canon integrity, resume)
+and the cleanup step pass. The scenario runs as part of the standard test
+suite (`cd tests && npm test`), which executes in CI on every push/PR to
+`main` via `.github/workflows/firestore-rules.yml`, so this sign-off is
+continuously re-verified rather than a one-time manual check.
+
+To reproduce locally:
+
+```bash
+firebase emulators:exec --only firestore --project demo-loom-test \
+  "cd tests && npx jest loom-verification --verbose"
+```
+
+This is the Phase 1 gate sign-off referenced by design doc §10. Phase 2 work
+should not begin until this file reflects a passing run against the current
+`main`.

--- a/tests/loom-verification.test.js
+++ b/tests/loom-verification.test.js
@@ -1,0 +1,236 @@
+'use strict';
+
+/**
+ * Phase 1 exit-criterion verification harness (L-131 / #308).
+ *
+ * This is the sign-off gate for The Loom's MVP milestone (design doc §10):
+ * a scripted multi-session scenario against the real shattered-coast canon
+ * world, exercising all three failure modes the whole project's thesis
+ * rests on, plus resume:
+ *
+ *   1. Hard state set early (a location change + world clock tick) survives
+ *      a simulated session gap untouched.
+ *   2. A seeded rule rejects an illegal move even when the mocked model's
+ *      narration lies about succeeding.
+ *   3. An NPC's prior-session history is retrieved and surfaced to NARRATE
+ *      when the player re-enters their scene after the gap.
+ *   4. A model-invented entity is quarantined in World State on its first
+ *      mention and only promoted on its second — it never silently becomes
+ *      canon, and the frozen canon module is provably untouched throughout.
+ *
+ * Uses the same mocked-functions/gemini.js + Firestore emulator harness as
+ * tests/loom-turn.test.js (L-130 / #307), but drives loomCreateSave for a
+ * realistic save and narrates one continuous adventure across a simulated
+ * session gap rather than isolated per-mechanism cases.
+ *
+ * Run: firebase emulators:exec --only firestore --project demo-loom-test "cd tests && npx jest loom-verification --verbose"
+ */
+
+process.env.FIRESTORE_EMULATOR_HOST = process.env.FIRESTORE_EMULATOR_HOST || 'localhost:8080';
+process.env.GCLOUD_PROJECT = 'demo-loom-test';
+
+const mockCallGemini = jest.fn();
+jest.mock('../functions/gemini', () => ({
+  callGemini: (...args) => mockCallGemini(...args),
+}));
+
+const functionsTest = require('firebase-functions-test')({ projectId: 'demo-loom-test' }, null);
+
+const admin = require('firebase-admin');
+if (admin.apps.length === 0) {
+  admin.initializeApp({ projectId: 'demo-loom-test' });
+}
+const db = admin.firestore();
+
+const { loomPlayTurn, loomCreateSave, loomDeleteSave } = require('../functions/index');
+const loomCanon = require('../functions/loom-canon');
+const { normalizeEntityName, softCanonDocId } = require('../functions/loom-turn/soft-canon');
+const { makePlayerAction, makeAiResponse } = require('./fixtures/loom');
+
+const TEST_UID = 'exit-criterion-player';
+const WORLD_ID = 'shattered-coast';
+const CAPTAIN_GREETING =
+  'Captain Orla Vance raises a scarred hand in greeting and mutters that her bosun, a ' +
+  "one-eyed hand named Bramwell, will see to the ship's papers.";
+
+function callCreate(data) {
+  return loomCreateSave.run({
+    data,
+    auth: { uid: TEST_UID, token: { apps: ['loom'], admin: false } },
+  });
+}
+
+function callTurn(data) {
+  return loomPlayTurn.run({
+    data,
+    auth: { uid: TEST_UID, token: { apps: ['loom'], admin: false } },
+  });
+}
+
+function callDelete(data) {
+  return loomDeleteSave.run({
+    data,
+    auth: { uid: TEST_UID, token: { apps: ['loom'], admin: false } },
+  });
+}
+
+/** Default mock: routes by system prompt content, same convention as loom-turn.test.js. */
+function defaultCallGeminiImplementation(options) {
+  if (options.systemInstruction.indexOf('INTERPRET stage') !== -1) {
+    return Promise.resolve(makePlayerAction());
+  }
+  if (options.systemInstruction.indexOf('summarizer') !== -1) {
+    return Promise.resolve('A summary of recent events.');
+  }
+  return Promise.resolve(makeAiResponse());
+}
+
+let saveId;
+
+beforeEach(() => {
+  mockCallGemini.mockReset();
+  mockCallGemini.mockImplementation(defaultCallGeminiImplementation);
+});
+
+afterAll(async () => {
+  if (saveId) {
+    const saveRef = db.collection('loom_saves').doc(saveId);
+    const turnsSnap = await saveRef.collection('loom_turns').get();
+    await Promise.all(turnsSnap.docs.map((d) => d.ref.delete()));
+    await saveRef.delete().catch(() => {});
+  }
+  await db
+    .collection('loom_world_state')
+    .doc(WORLD_ID)
+    .delete()
+    .catch(() => {});
+  await db
+    .collection('loom_softcanon')
+    .doc(softCanonDocId(WORLD_ID, normalizeEntityName('Bramwell')))
+    .delete()
+    .catch(() => {});
+  functionsTest.cleanup();
+});
+
+describe('Phase 1 exit criterion — hard state, seeded rules, canon integrity, and resume', () => {
+  // Snapshotted once, before the scenario runs, so the final check can prove
+  // nothing in the frozen canon module moved even by reference.
+  const canonBefore = JSON.stringify(loomCanon.getWorld(WORLD_ID));
+
+  it('Session 1 — establishes hard state and a first, unpromoted entity mention', async () => {
+    const created = await callCreate({
+      worldId: WORLD_ID,
+      name: 'Exit Criterion Run',
+      characterName: 'Ishmael',
+    });
+    saveId = created.saveId;
+
+    // Turn 1 — meet the captain in the starting scene; the model invents a
+    // one-off NPC that must NOT be promoted to World State on a single
+    // mention (failure mode: silently contradicting canon).
+    mockCallGemini
+      .mockImplementationOnce(() =>
+        makePlayerAction({ verb: 'talk', targets: ['captain-orla-vance'] })
+      )
+      .mockImplementationOnce(() =>
+        makeAiResponse({ narration: CAPTAIN_GREETING, inventedEntities: ['Bramwell'] })
+      );
+    await callTurn({ worldId: WORLD_ID, saveId, actionText: 'talk to the captain' });
+
+    const bramwellFlag = 'entity_' + normalizeEntityName('Bramwell');
+    let worldStateSnap = await db.collection('loom_world_state').doc(WORLD_ID).get();
+    expect(worldStateSnap.data().globalFlags[bramwellFlag]).toBeUndefined();
+
+    // Turn 2 — a legal move. This is the hard fact that must survive the gap
+    // (failure mode: forgetting hard state).
+    mockCallGemini.mockImplementationOnce(() =>
+      makePlayerAction({ verb: 'move', targets: ['skeleton-cove'] })
+    );
+    await callTurn({ worldId: WORLD_ID, saveId, actionText: 'row to skeleton cove' });
+
+    const saveSnap = await db.collection('loom_saves').doc(saveId).get();
+    expect(saveSnap.data().location).toBe('skeleton-cove');
+    worldStateSnap = await db.collection('loom_world_state').doc(WORLD_ID).get();
+    expect(worldStateSnap.data().worldClock).toBe(1);
+  });
+
+  it('Session gap — resume reads the same hard state back from storage, not process memory', async () => {
+    // Nothing in this test process is carried forward except the saveId
+    // string — every read below hits Firestore fresh, standing in for the
+    // player closing the app and coming back another day.
+    const saveSnap = await db.collection('loom_saves').doc(saveId).get();
+    expect(saveSnap.data().location).toBe('skeleton-cove');
+
+    const worldStateSnap = await db.collection('loom_world_state').doc(WORLD_ID).get();
+    expect(worldStateSnap.data().worldClock).toBe(1);
+  });
+
+  it('Session 2 — a seeded rule rejects an illegal move regardless of what the narration claims', async () => {
+    // Skeleton Cove only connects back to Widow's Reach — there is no direct
+    // path to Fort Augustine. The mocked model lies and claims arrival
+    // anyway; ADJUDICATE must still block it (failure mode: breaking the
+    // seeded rules).
+    mockCallGemini
+      .mockImplementationOnce(() => makePlayerAction({ verb: 'move', targets: ['fort-augustine'] }))
+      .mockImplementationOnce(() =>
+        makeAiResponse({ narration: 'You slip past the battery and arrive at Fort Augustine!' })
+      );
+    await callTurn({ worldId: WORLD_ID, saveId, actionText: 'sail straight for fort augustine' });
+
+    const saveSnap = await db.collection('loom_saves').doc(saveId).get();
+    expect(saveSnap.data().location).toBe('skeleton-cove');
+  });
+
+  it("Session 2 — re-entering a scene surfaces the NPC's prior-session history to NARRATE", async () => {
+    // Row back to Widow's Reach, where Captain Orla Vance is, and confirm
+    // this turn's NARRATE call actually receives session 1's narration about
+    // her — the memory the design doc calls entity-keyed retrieval.
+    mockCallGemini.mockImplementationOnce(() =>
+      makePlayerAction({ verb: 'move', targets: ['widows-reach'] })
+    );
+    await callTurn({ worldId: WORLD_ID, saveId, actionText: 'row back to widows reach' });
+
+    let sawPriorHistory = false;
+    mockCallGemini
+      .mockImplementationOnce(() =>
+        makePlayerAction({ verb: 'talk', targets: ['captain-orla-vance'] })
+      )
+      .mockImplementationOnce((options) => {
+        sawPriorHistory = options.userMessage.indexOf('raises a scarred hand in greeting') !== -1;
+        return makeAiResponse({ narration: 'She nods, recognizing you from before.' });
+      });
+    await callTurn({ worldId: WORLD_ID, saveId, actionText: 'talk to the captain again' });
+
+    expect(sawPriorHistory).toBe(true);
+  });
+
+  it('Session 2 — a second mention promotes the invented entity into World State, never into canon', async () => {
+    mockCallGemini
+      .mockImplementationOnce(() => makePlayerAction({ verb: 'talk', targets: ['Bramwell'] }))
+      .mockImplementationOnce(() =>
+        makeAiResponse({
+          narration: 'Bramwell the bosun nods at you from across the deck.',
+          inventedEntities: ['Bramwell'],
+        })
+      );
+    await callTurn({ worldId: WORLD_ID, saveId, actionText: 'greet bramwell' });
+
+    const bramwellFlag = 'entity_' + normalizeEntityName('Bramwell');
+    const worldStateSnap = await db.collection('loom_world_state').doc(WORLD_ID).get();
+    expect(worldStateSnap.data().globalFlags[bramwellFlag]).toBe('Bramwell');
+
+    // Promotion happened in World State only — the frozen canon module was
+    // never touched, and still has no idea Bramwell exists.
+    const canonAfter = JSON.stringify(loomCanon.getWorld(WORLD_ID));
+    expect(canonAfter).toBe(canonBefore);
+    expect(
+      Object.values(loomCanon.getWorld(WORLD_ID).characters).some((c) => c.name === 'Bramwell')
+    ).toBe(false);
+  });
+
+  it('cleans up the run', async () => {
+    await callDelete({ saveId });
+    const saveSnap = await db.collection('loom_saves').doc(saveId).get();
+    expect(saveSnap.exists).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Closes L-131 (#308) — the final issue in the Phase 1 (MVP) milestone.

This is the sign-off gate the whole project's thesis rests on (design doc §10):

> A multi-session adventure that, across a session gap, never forgets hard state, never breaks the seeded rules, and never silently contradicts canon. Resume works.

- Adds `tests/loom-verification.test.js`: a scripted, continuous adventure against the real `shattered-coast` canon world and the real `loomCreateSave` / `loomPlayTurn` / `loomDeleteSave` callables (only `functions/gemini.js` is mocked, same convention as L-130), scripted as one narrative across a simulated session gap rather than isolated per-mechanism tests:
  1. **Session 1** — talks to Captain Orla Vance (the model invents a one-off NPC, "Bramwell," mentioned once) then makes a legal move to Skeleton Cove, setting the hard fact under test (`save.location`, `worldState.worldClock`).
  2. **Session gap** — re-reads the save and world state directly from Firestore, standing in for the player closing the app and returning later; nothing is carried in process memory.
  3. **Session 2** — an illegal move (Skeleton Cove → Fort Augustine, not connected) is rejected even though the mocked narration lies about arriving; rowing back to Widow's Reach and talking to the captain again proves the NARRATE call receives session 1's narration about her; a second mention of "Bramwell" promotes the entity into `worldState.globalFlags`, with the frozen canon module snapshotted before and after to prove it was never touched and never learned of "Bramwell."
  4. Cleanup via the real `loomDeleteSave` callable.
- Adds `planning/phase-1-signoff.md` recording the result as the Phase 1 gate sign-off, with reproduction steps.

## A bug this surfaced

`functions/loom-turn/soft-canon.js` keys `loom_softcanon` docs by `worldId + '__' + normalizedName`, and neither this test nor the already-merged `tests/loom-turn.test.js` cleans up that collection. Both files originally used "Doral" as the invented entity name in the `shattered-coast` world, so whichever file ran first permanently promoted `shattered-coast__doral`, silently breaking the other file's "first mention shouldn't promote yet" assertion — reproduced consistently (3/3 runs) once both files existed together. Fixed by giving this test a distinct entity name ("Bramwell") and having it clean up its own `loom_softcanon` doc in `afterAll`.

## Test plan

- [x] `node --check` on the new test file
- [x] `npm run lint` / `npm run format:check`
- [x] `firebase emulators:exec --only firestore --project demo-loom-test "cd tests && npx jest loom-verification --verbose"` — 6/6 passing
- [x] Full suite (`firebase emulators:exec --only firestore --project demo-olympus-rules-test "cd tests && npm test"`) run three times after the fix — 288/288 passing all three times, no regressions or cross-file interference

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XVNW1uHGnfWpM69kac16WF

---
_Generated by [Claude Code](https://claude.ai/code/session_01XVNW1uHGnfWpM69kac16WF)_