### PR TITLE
feat(mcp): Initiative 1 foundation — inbound MCP transport, discovery, and OAuth 2.1 AS (1a–1c)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -12,7 +12,9 @@ export default [
         __filename: "readonly",
         console: "readonly",
         process: "readonly",
-        fetch: "readonly"
+        fetch: "readonly",
+        Buffer: "readonly",
+        URL: "readonly"
       }
     },
     rules: {

--- a/firebase.json
+++ b/firebase.json
@@ -38,6 +38,8 @@
     "rewrites": [
       { "source": "/mcp", "function": "mcpServer" },
       { "source": "/mcp/**", "function": "mcpServer" },
+      { "source": "/authorize", "function": "mcpServer" },
+      { "source": "/token", "function": "mcpServer" },
       { "source": "/.well-known/oauth-authorization-server", "function": "mcpServer" },
       { "source": "/.well-known/oauth-protected-resource", "function": "mcpServer" },
       { "source": "/.well-known/oauth-protected-resource/**", "function": "mcpServer" },

--- a/firebase.json
+++ b/firebase.json
@@ -36,6 +36,11 @@
       }
     ],
     "rewrites": [
+      { "source": "/mcp", "function": "mcpServer" },
+      { "source": "/mcp/**", "function": "mcpServer" },
+      { "source": "/.well-known/oauth-authorization-server", "function": "mcpServer" },
+      { "source": "/.well-known/oauth-protected-resource", "function": "mcpServer" },
+      { "source": "/.well-known/oauth-protected-resource/**", "function": "mcpServer" },
       {
         "source": "**",
         "destination": "/index.html"

--- a/functions/index.js
+++ b/functions/index.js
@@ -11,6 +11,11 @@ const { makeSave } = require('./loom-models');
 
 initializeApp();
 
+// ── Inbound MCP (Initiative 1) ─────────────────────────
+// Streamable HTTP MCP server + OAuth discovery, served on the primary origin
+// via Hosting rewrites. See planning/initiative-1-mcp-foundation.md.
+exports.mcpServer = require('./mcp').mcpServer;
+
 // Reused across invitations to avoid per-call overhead.
 const googleAuth = new GoogleAuth({
   scopes: ['https://www.googleapis.com/auth/cloud-platform'],

--- a/functions/mcp/auth.js
+++ b/functions/mcp/auth.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const { isEmulator, originFromRequest } = require('./config');
+
+// TEMPORARY dev/testing shim — NOT a product auth path.
+//
+// Inbound auth for MCP is the OAuth 2.1 authorization server built in phases
+// 1c–1e. Until that exists, the MCP endpoint is reachable only under the
+// emulator, so the transport can be exercised with MCP Inspector without wiring
+// up a full OAuth flow first:
+//   - In the emulator: if MCP_DEV_TOKEN is set, the request's bearer token must
+//     match it; if unset, calls are allowed so Inspector works with zero config.
+//   - In any deployed environment: always deny, with an RFC 9728 pointer to the
+//     protected-resource metadata so a compliant client knows where to look.
+//
+// Returns true when the request may proceed; otherwise writes a 401 and returns
+// false.
+function checkDevAuth(req, res) {
+  if (!isEmulator()) {
+    denyUnauthorized(req, res, 'MCP is not yet enabled in this environment.');
+    return false;
+  }
+
+  const expected = process.env.MCP_DEV_TOKEN;
+  if (!expected) return true; // open in the emulator for Inspector convenience
+
+  if (bearerFrom(req) === expected) return true;
+
+  denyUnauthorized(req, res, 'Invalid or missing dev bearer token.');
+  return false;
+}
+
+function bearerFrom(req) {
+  const header = req.headers.authorization || '';
+  const match = /^Bearer\s+(.+)$/i.exec(header);
+  return match ? match[1].trim() : null;
+}
+
+function denyUnauthorized(req, res, message) {
+  const origin = originFromRequest(req);
+  // RFC 9728: point the client at this resource's protected-resource metadata.
+  const resourceMetadata = `${origin}/.well-known/oauth-protected-resource${req.path}`;
+  res.set('WWW-Authenticate', `Bearer resource_metadata="${resourceMetadata}"`);
+  res.status(401).json({ error: 'unauthorized', message });
+}
+
+module.exports = { checkDevAuth };

--- a/functions/mcp/auth.js
+++ b/functions/mcp/auth.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { isEmulator, originFromRequest } = require('./config');
+const { isEmulator, resolveOrigin } = require('./config');
 
 // TEMPORARY dev/testing shim — NOT a product auth path.
 //
@@ -37,7 +37,7 @@ function bearerFrom(req) {
 }
 
 function denyUnauthorized(req, res, message) {
-  const origin = originFromRequest(req);
+  const origin = resolveOrigin(req);
   // RFC 9728: point the client at this resource's protected-resource metadata.
   const resourceMetadata = `${origin}/.well-known/oauth-protected-resource${req.path}`;
   res.set('WWW-Authenticate', `Bearer resource_metadata="${resourceMetadata}"`);

--- a/functions/mcp/config.js
+++ b/functions/mcp/config.js
@@ -10,7 +10,7 @@
 // whose RFC 8707 audience points at their own host and publish discovery docs
 // pointing at it — defeating the cross-app confinement audience binding exists
 // to provide. Override via OLYMPUS_ORIGIN for a different canonical domain.
-const PRIMARY_ORIGIN = process.env.OLYMPUS_ORIGIN || 'https://olympus-dfa00.web.app';
+const PRIMARY_ORIGIN = process.env.OLYMPUS_ORIGIN || 'https://bcoletech.com';
 
 // The host-level diagnostic MCP endpoint used by the 1a transport spike.
 // Per-app resource servers mount at /mcp/<appId> later (phases 1e–1f).

--- a/functions/mcp/config.js
+++ b/functions/mcp/config.js
@@ -3,10 +3,14 @@
 // Shared configuration for the inbound MCP layer (Initiative 1). See
 // planning/initiative-1-mcp-foundation.md §5 (architecture) and §6 (OAuth).
 
-// Fallback origin when the request carries no usable Host header. Discovery
-// docs and token audiences must be origin-matching, so we prefer the live
-// request origin (originFromRequest) and only fall back to this.
-const PRIMARY_ORIGIN = 'https://olympus-dfa00.web.app';
+// The single canonical origin all issued tokens and discovery docs are pinned
+// to in production. It is NEVER derived from the request Host header: mcpServer
+// is directly invocable at its *.run.app / cloudfunctions.net URL where the
+// caller controls Host, so reflecting it would let an attacker mint tokens
+// whose RFC 8707 audience points at their own host and publish discovery docs
+// pointing at it — defeating the cross-app confinement audience binding exists
+// to provide. Override via OLYMPUS_ORIGIN for a different canonical domain.
+const PRIMARY_ORIGIN = process.env.OLYMPUS_ORIGIN || 'https://olympus-dfa00.web.app';
 
 // The host-level diagnostic MCP endpoint used by the 1a transport spike.
 // Per-app resource servers mount at /mcp/<appId> later (phases 1e–1f).
@@ -24,10 +28,10 @@ function isEmulator() {
   return process.env.FUNCTIONS_EMULATOR === 'true';
 }
 
-// Derives the request's own origin so discovery URLs and audiences match the
-// host the client actually reached (web.app, firebaseapp.com, a custom domain,
-// or the local emulator). Behind Hosting rewrites the original Host header is
-// preserved.
+// Derives the origin from the request Host header. Used ONLY under the emulator
+// (via resolveOrigin), where the request host is trusted and must be honored so
+// local discovery URLs and audiences are actually reachable (localhost). Never
+// used to build tokens/metadata in a deployed environment.
 function originFromRequest(req) {
   const proto = String(req.headers['x-forwarded-proto'] || req.protocol || 'https')
     .split(',')[0]
@@ -37,10 +41,18 @@ function originFromRequest(req) {
   return `${proto}://${host}`;
 }
 
+// The origin used to build discovery docs, token issuers, and token audiences.
+// In production this is the fixed canonical origin (Host header ignored); under
+// the emulator it is the request origin so local dev works end to end.
+function resolveOrigin(req) {
+  return isEmulator() ? originFromRequest(req) : PRIMARY_ORIGIN;
+}
+
 module.exports = {
   PRIMARY_ORIGIN,
   HOST_RESOURCE_PATH,
   KNOWN_RESOURCE_PATHS,
   isEmulator,
   originFromRequest,
+  resolveOrigin,
 };

--- a/functions/mcp/config.js
+++ b/functions/mcp/config.js
@@ -1,0 +1,46 @@
+'use strict';
+
+// Shared configuration for the inbound MCP layer (Initiative 1). See
+// planning/initiative-1-mcp-foundation.md §5 (architecture) and §6 (OAuth).
+
+// Fallback origin when the request carries no usable Host header. Discovery
+// docs and token audiences must be origin-matching, so we prefer the live
+// request origin (originFromRequest) and only fall back to this.
+const PRIMARY_ORIGIN = 'https://olympus-dfa00.web.app';
+
+// The host-level diagnostic MCP endpoint used by the 1a transport spike.
+// Per-app resource servers mount at /mcp/<appId> later (phases 1e–1f).
+const HOST_RESOURCE_PATH = '/mcp';
+
+// Resources that currently exist as reachable MCP endpoints. Per-app resource
+// servers register here as they land; discovery docs (RFC 9728) are served
+// only for known resources so we never advertise a connector that 404s.
+const KNOWN_RESOURCE_PATHS = new Set([HOST_RESOURCE_PATH]);
+
+// True when running under the Firebase emulator suite. The 1a dev bearer shim
+// only relaxes auth in this mode; deployed environments stay closed until the
+// OAuth 2.1 authorization server lands (phases 1c–1e).
+function isEmulator() {
+  return process.env.FUNCTIONS_EMULATOR === 'true';
+}
+
+// Derives the request's own origin so discovery URLs and audiences match the
+// host the client actually reached (web.app, firebaseapp.com, a custom domain,
+// or the local emulator). Behind Hosting rewrites the original Host header is
+// preserved.
+function originFromRequest(req) {
+  const proto = String(req.headers['x-forwarded-proto'] || req.protocol || 'https')
+    .split(',')[0]
+    .trim();
+  const host = req.headers['x-forwarded-host'] || req.headers.host;
+  if (!host) return PRIMARY_ORIGIN;
+  return `${proto}://${host}`;
+}
+
+module.exports = {
+  PRIMARY_ORIGIN,
+  HOST_RESOURCE_PATH,
+  KNOWN_RESOURCE_PATHS,
+  isEmulator,
+  originFromRequest,
+};

--- a/functions/mcp/discovery.js
+++ b/functions/mcp/discovery.js
@@ -1,0 +1,67 @@
+'use strict';
+
+const { originFromRequest, KNOWN_RESOURCE_PATHS } = require('./config');
+
+const WELL_KNOWN_AS = '/.well-known/oauth-authorization-server';
+const WELL_KNOWN_PR_PREFIX = '/.well-known/oauth-protected-resource';
+
+// RFC 8414 — OAuth 2.0 Authorization Server Metadata.
+//
+// One shared authorization server backs every Olympus MCP connector. The
+// endpoints are advertised now; they are implemented in later phases —
+// /authorize and /token in 1c, /register (Dynamic Client Registration, RFC
+// 7591) in 1d. PKCE with S256 is mandatory and public clients (auth method
+// "none") are the only supported client type (design §6, §10).
+function authorizationServerMetadata(req, res) {
+  const origin = originFromRequest(req);
+  res.set('Cache-Control', 'public, max-age=3600');
+  res.json({
+    issuer: origin,
+    authorization_endpoint: `${origin}/authorize`,
+    token_endpoint: `${origin}/token`,
+    registration_endpoint: `${origin}/register`,
+    revocation_endpoint: `${origin}/revoke`,
+    response_types_supported: ['code'],
+    grant_types_supported: ['authorization_code', 'refresh_token'],
+    token_endpoint_auth_methods_supported: ['none'],
+    code_challenge_methods_supported: ['S256'],
+  });
+}
+
+// RFC 9728 — OAuth 2.0 Protected Resource Metadata (path-based).
+//
+// The protected resource is the MCP endpoint URL itself (e.g. .../mcp, and
+// later .../mcp/<appId>). The doc names the shared authorization server and the
+// scope required for that resource. It is served only for resources that
+// actually exist (KNOWN_RESOURCE_PATHS) so we never advertise a phantom
+// connector; per-app resources light up automatically as they register
+// (design §5.3).
+function protectedResourceMetadata(req, res) {
+  const resourcePath = req.path.slice(WELL_KNOWN_PR_PREFIX.length) || '/';
+  if (!KNOWN_RESOURCE_PATHS.has(resourcePath)) {
+    res.status(404).json({ error: 'not_found', message: 'Unknown MCP resource.' });
+    return;
+  }
+  const origin = originFromRequest(req);
+  res.set('Cache-Control', 'public, max-age=3600');
+  res.json({
+    resource: `${origin}${resourcePath}`,
+    authorization_servers: [origin],
+    bearer_methods_supported: ['header'],
+    scopes_supported: scopesForResource(resourcePath),
+  });
+}
+
+// One scope per app: /mcp/<appId> requires scope mcp:<appId> (design §6). The
+// host diagnostic resource (/mcp) carries no app scope.
+function scopesForResource(resourcePath) {
+  const parts = resourcePath.split('/').filter(Boolean); // ['mcp'] or ['mcp', appId]
+  return parts.length >= 2 ? [`mcp:${parts[1]}`] : [];
+}
+
+module.exports = {
+  authorizationServerMetadata,
+  protectedResourceMetadata,
+  WELL_KNOWN_AS,
+  WELL_KNOWN_PR_PREFIX,
+};

--- a/functions/mcp/discovery.js
+++ b/functions/mcp/discovery.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { originFromRequest, KNOWN_RESOURCE_PATHS } = require('./config');
+const { resolveOrigin, KNOWN_RESOURCE_PATHS } = require('./config');
 
 const WELL_KNOWN_AS = '/.well-known/oauth-authorization-server';
 const WELL_KNOWN_PR_PREFIX = '/.well-known/oauth-protected-resource';
@@ -13,7 +13,7 @@ const WELL_KNOWN_PR_PREFIX = '/.well-known/oauth-protected-resource';
 // 7591) in 1d. PKCE with S256 is mandatory and public clients (auth method
 // "none") are the only supported client type (design §6, §10).
 function authorizationServerMetadata(req, res) {
-  const origin = originFromRequest(req);
+  const origin = resolveOrigin(req);
   res.set('Cache-Control', 'public, max-age=3600');
   res.json({
     issuer: origin,
@@ -42,7 +42,7 @@ function protectedResourceMetadata(req, res) {
     res.status(404).json({ error: 'not_found', message: 'Unknown MCP resource.' });
     return;
   }
-  const origin = originFromRequest(req);
+  const origin = resolveOrigin(req);
   res.set('Cache-Control', 'public, max-age=3600');
   res.json({
     resource: `${origin}${resourcePath}`,

--- a/functions/mcp/host.js
+++ b/functions/mcp/host.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const { loadSdk } = require('./sdk');
+
+const SERVER_INFO = { name: 'olympus-mcp', version: '0.1.0' };
+
+// Builds the host-level diagnostic MCP server for the transport spike (phase
+// 1a). It exposes a single hardcoded `ping` tool so MCP Inspector can prove the
+// list + call round-trip end to end. Per-app tool modules mount their own
+// servers via the registry seam later (phase 1e / design §8); nothing here is
+// app-specific.
+async function buildHostServer() {
+  const { McpServer } = await loadSdk('server/mcp.js');
+  const server = new McpServer(SERVER_INFO);
+
+  server.registerTool(
+    'ping',
+    {
+      title: 'Ping',
+      description: 'Connectivity health check. Returns "pong" and the current server time.',
+    },
+    async () => ({
+      content: [{ type: 'text', text: `pong @ ${new Date().toISOString()}` }],
+    })
+  );
+
+  return server;
+}
+
+module.exports = { buildHostServer, SERVER_INFO };

--- a/functions/mcp/index.js
+++ b/functions/mcp/index.js
@@ -30,9 +30,16 @@ function oauthHandlers() {
       const decoded = await getAuth().verifyIdToken(idToken);
       return { uid: decoded.uid, sub: decoded.sub, apps: decoded.apps };
     };
+    // Current app entitlements for a uid, re-checked on refresh so a revoked
+    // claim stops working within the access-token TTL.
+    const getEntitlements = async (uid) => {
+      const user = await getAuth().getUser(uid);
+      const apps = user.customClaims && user.customClaims.apps;
+      return Array.isArray(apps) ? apps : [];
+    };
     _oauth = {
       authorize: createAuthorizeHandler({ store, verifyIdToken }),
-      token: createTokenHandler({ store }),
+      token: createTokenHandler({ store, getEntitlements }),
     };
   }
   return _oauth;

--- a/functions/mcp/index.js
+++ b/functions/mcp/index.js
@@ -11,6 +11,32 @@ const {
   WELL_KNOWN_PR_PREFIX,
 } = require('./discovery');
 const { HOST_RESOURCE_PATH } = require('./config');
+const { MCP_JWT_SECRET } = require('./oauth/config');
+
+// OAuth authorization-server handlers (/authorize, /token). Built lazily on
+// first use so Firebase Admin is initialized (by functions/index.js) first, and
+// cached across warm invocations.
+let _oauth;
+function oauthHandlers() {
+  if (!_oauth) {
+    const { getFirestore } = require('firebase-admin/firestore');
+    const { getAuth } = require('firebase-admin/auth');
+    const { createFirestoreStore } = require('./oauth/store');
+    const { createAuthorizeHandler } = require('./oauth/authorize');
+    const { createTokenHandler } = require('./oauth/token');
+
+    const store = createFirestoreStore(getFirestore());
+    const verifyIdToken = async (idToken) => {
+      const decoded = await getAuth().verifyIdToken(idToken);
+      return { uid: decoded.uid, sub: decoded.sub, apps: decoded.apps };
+    };
+    _oauth = {
+      authorize: createAuthorizeHandler({ store, verifyIdToken }),
+      token: createTokenHandler({ store }),
+    };
+  }
+  return _oauth;
+}
 
 // CORS for browser-based MCP clients (e.g. the claude.ai web connector). The
 // MCP session and protocol-version headers must be allowed on requests and
@@ -52,6 +78,16 @@ async function route(req, res) {
     return;
   }
 
+  // OAuth 2.1 authorization server (phase 1c). /register + /revoke land in 1d/1h.
+  if (path === '/authorize') {
+    await oauthHandlers().authorize(req, res);
+    return;
+  }
+  if (path === '/token') {
+    await oauthHandlers().token(req, res);
+    return;
+  }
+
   // MCP transport. For the 1a spike this is the host diagnostic endpoint only;
   // '/' covers hitting the function directly on the emulator (no Hosting
   // rewrite in front). Per-app mounts (/mcp/<appId>) arrive in phase 1e.
@@ -64,15 +100,18 @@ async function route(req, res) {
   res.status(404).json({ error: 'not_found', message: 'No MCP resource at this path.' });
 }
 
-const mcpServer = onRequest({ region: 'us-central1', cors: false }, async (req, res) => {
-  try {
-    await route(req, res);
-  } catch (err) {
-    console.error('mcpServer error:', err);
-    if (!res.headersSent) {
-      res.status(500).json({ error: 'internal', message: 'MCP server error.' });
+const mcpServer = onRequest(
+  { region: 'us-central1', cors: false, secrets: [MCP_JWT_SECRET] },
+  async (req, res) => {
+    try {
+      await route(req, res);
+    } catch (err) {
+      console.error('mcpServer error:', err);
+      if (!res.headersSent) {
+        res.status(500).json({ error: 'internal', message: 'MCP server error.' });
+      }
     }
   }
-});
+);
 
 module.exports = { mcpServer, route };

--- a/functions/mcp/index.js
+++ b/functions/mcp/index.js
@@ -1,0 +1,78 @@
+'use strict';
+
+const { onRequest } = require('firebase-functions/v2/https');
+const { handleMcpRequest } = require('./transport');
+const { buildHostServer } = require('./host');
+const { checkDevAuth } = require('./auth');
+const {
+  authorizationServerMetadata,
+  protectedResourceMetadata,
+  WELL_KNOWN_AS,
+  WELL_KNOWN_PR_PREFIX,
+} = require('./discovery');
+const { HOST_RESOURCE_PATH } = require('./config');
+
+// CORS for browser-based MCP clients (e.g. the claude.ai web connector). The
+// MCP session and protocol-version headers must be allowed on requests and
+// exposed on responses. Non-browser clients (iOS, desktop, Inspector proxy)
+// ignore these but they are harmless.
+function applyCors(req, res) {
+  const origin = req.headers.origin;
+  if (origin) {
+    res.set('Access-Control-Allow-Origin', origin);
+    res.set('Vary', 'Origin');
+  }
+  res.set('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
+  res.set(
+    'Access-Control-Allow-Headers',
+    'Authorization, Content-Type, Mcp-Session-Id, Mcp-Protocol-Version, Last-Event-ID'
+  );
+  res.set('Access-Control-Expose-Headers', 'Mcp-Session-Id, WWW-Authenticate');
+}
+
+// Dispatches a request routed here by Hosting rewrites (/mcp/**,
+// /.well-known/**). Exported for local testing; the deployed entry point is the
+// `mcpServer` function below.
+async function route(req, res) {
+  applyCors(req, res);
+  if (req.method === 'OPTIONS') {
+    res.status(204).end();
+    return;
+  }
+
+  const path = req.path || '/';
+
+  // Discovery documents (RFC 8414 / RFC 9728) — unauthenticated by spec.
+  if (path === WELL_KNOWN_AS) {
+    authorizationServerMetadata(req, res);
+    return;
+  }
+  if (path === WELL_KNOWN_PR_PREFIX || path.startsWith(`${WELL_KNOWN_PR_PREFIX}/`)) {
+    protectedResourceMetadata(req, res);
+    return;
+  }
+
+  // MCP transport. For the 1a spike this is the host diagnostic endpoint only;
+  // '/' covers hitting the function directly on the emulator (no Hosting
+  // rewrite in front). Per-app mounts (/mcp/<appId>) arrive in phase 1e.
+  if (path === HOST_RESOURCE_PATH || path === '/' || path === '') {
+    if (!checkDevAuth(req, res)) return;
+    await handleMcpRequest(req, res, buildHostServer);
+    return;
+  }
+
+  res.status(404).json({ error: 'not_found', message: 'No MCP resource at this path.' });
+}
+
+const mcpServer = onRequest({ region: 'us-central1', cors: false }, async (req, res) => {
+  try {
+    await route(req, res);
+  } catch (err) {
+    console.error('mcpServer error:', err);
+    if (!res.headersSent) {
+      res.status(500).json({ error: 'internal', message: 'MCP server error.' });
+    }
+  }
+});
+
+module.exports = { mcpServer, route };

--- a/functions/mcp/oauth/authorize.js
+++ b/functions/mcp/oauth/authorize.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { originFromRequest } = require('../config');
+const { resolveOrigin } = require('../config');
 const { renderConsentPage } = require('./consent-page');
 const { redirectError, oauthError, escapeHtml } = require('./respond');
 const { generateAuthCode } = require('./tokens');
@@ -134,12 +134,15 @@ function createAuthorizeHandler(deps) {
 
     res.set('Cache-Control', 'no-store');
     res.set('Content-Type', 'text/html; charset=utf-8');
+    // Anti-clickjacking: the consent screen is a security-decision surface, so
+    // it must never be framed and bait-overlaid to trick an approval click.
+    res.set('X-Frame-Options', 'DENY');
+    res.set('Content-Security-Policy', "frame-ancestors 'none'");
     res.status(200).send(
       renderConsentPage({
         appId: scopeResult.appId,
         appName: appNameFromId(scopeResult.appId),
         clientName: client.clientName,
-        redirectUri: params.redirectUri,
         oauthParams: echoParams(params),
       })
     );
@@ -171,7 +174,8 @@ function createAuthorizeHandler(deps) {
 
     // Resource indicator (RFC 8707): if supplied it must match this app's
     // endpoint; otherwise we derive it. The token's audience is bound to it.
-    const origin = originFromRequest(req);
+    // origin is the pinned canonical origin in production (never the Host header).
+    const origin = resolveOrigin(req);
     const audience = `${origin}/mcp/${appId}`;
     if (params.resource !== undefined && params.resource !== audience) {
       return oauthError(res, 'invalid_target', 'resource does not match the requested app.');
@@ -206,6 +210,7 @@ function createAuthorizeHandler(deps) {
       appId,
       scope: scopeForAppId(appId),
       audience,
+      issuer: origin,
       codeChallenge: params.codeChallenge,
       codeChallengeMethod: CODE_CHALLENGE_METHOD,
       createdAtMs: nowMs,

--- a/functions/mcp/oauth/authorize.js
+++ b/functions/mcp/oauth/authorize.js
@@ -1,0 +1,231 @@
+'use strict';
+
+const { originFromRequest } = require('../config');
+const { renderConsentPage } = require('./consent-page');
+const { redirectError, oauthError, escapeHtml } = require('./respond');
+const { generateAuthCode } = require('./tokens');
+const { appIdFromScope, scopeForAppId, AUTH_CODE_TTL_SECONDS } = require('./config');
+const { CODE_CHALLENGE_METHOD, isValidChallenge } = require('./pkce');
+
+// Parses the OAuth request parameters we care about from query (GET) or JSON
+// body (POST). Only these fields are ever echoed back to the client.
+function readParams(source) {
+  return {
+    responseType: source.response_type,
+    clientId: source.client_id,
+    redirectUri: source.redirect_uri,
+    scope: source.scope,
+    state: source.state,
+    codeChallenge: source.code_challenge,
+    codeChallengeMethod: source.code_challenge_method,
+    resource: source.resource,
+  };
+}
+
+// The subset re-sent by the consent page on approval (everything but the
+// decision/idToken). Kept minimal and re-validated server-side on POST.
+function echoParams(p) {
+  const out = {
+    client_id: p.clientId,
+    redirect_uri: p.redirectUri,
+    scope: p.scope,
+    code_challenge: p.codeChallenge,
+    code_challenge_method: p.codeChallengeMethod,
+  };
+  if (p.state !== undefined) out.state = p.state;
+  if (p.resource !== undefined) out.resource = p.resource;
+  return out;
+}
+
+function appNameFromId(appId) {
+  return appId.charAt(0).toUpperCase() + appId.slice(1);
+}
+
+// Extracts the single mcp:<appId> scope. Returns { appId } or { error }.
+// Exactly one app scope is required — one connector = one app (design §3).
+function resolveAppScope(scope) {
+  if (typeof scope !== 'string' || scope.trim() === '') {
+    return { error: 'scope is required' };
+  }
+  const appIds = scope.trim().split(/\s+/).map(appIdFromScope).filter(Boolean);
+  if (appIds.length !== 1) {
+    return { error: 'exactly one mcp:<appId> scope is required' };
+  }
+  return { appId: appIds[0] };
+}
+
+function errorPage(res, status, message) {
+  res
+    .status(status)
+    .set('Content-Type', 'text/html; charset=utf-8')
+    .send(
+      `<!doctype html><meta charset="utf-8"><body style="background:#0a0e1a;color:#e0e0e0;
+     font-family:system-ui,sans-serif;display:flex;min-height:100vh;align-items:center;
+     justify-content:center"><div style="max-width:420px;text-align:center;padding:2rem">
+     <h1 style="color:#ff8a65">Authorization error</h1><p style="color:#90a4ae">${escapeHtml(
+       message
+     )}</p></div></body>`
+    );
+}
+
+// Validates client_id + redirect_uri against the registered client. These two
+// must be validated before any redirect-based error, because we must never
+// redirect to an unverified URI (RFC 6749 §4.1.2.1 / §10.6). Returns
+// { client } or { fail } (fail already written as an error page).
+async function validateClientAndRedirect(store, params, res) {
+  if (!params.clientId) {
+    errorPage(res, 400, 'Missing client_id.');
+    return { fail: true };
+  }
+  const client = await store.getClient(params.clientId);
+  if (!client) {
+    errorPage(res, 400, 'Unknown client_id.');
+    return { fail: true };
+  }
+  const registered = Array.isArray(client.redirectUris) ? client.redirectUris : [];
+  if (!params.redirectUri || !registered.includes(params.redirectUri)) {
+    errorPage(res, 400, 'redirect_uri does not match a registered value for this client.');
+    return { fail: true };
+  }
+  return { client };
+}
+
+function createAuthorizeHandler(deps) {
+  const { store, verifyIdToken, now = () => Date.now() } = deps;
+
+  // GET /authorize — render the consent screen after validating the request.
+  async function handleGet(req, res) {
+    const params = readParams(req.query || {});
+    const { client, fail } = await validateClientAndRedirect(store, params, res);
+    if (fail) return;
+
+    // From here redirect_uri is trusted, so remaining errors go back to the client.
+    if (params.responseType !== 'code') {
+      return redirectError(
+        res,
+        params.redirectUri,
+        'unsupported_response_type',
+        null,
+        params.state
+      );
+    }
+    if (
+      params.codeChallengeMethod !== CODE_CHALLENGE_METHOD ||
+      !isValidChallenge(params.codeChallenge)
+    ) {
+      return redirectError(
+        res,
+        params.redirectUri,
+        'invalid_request',
+        'PKCE with a valid S256 code_challenge is required',
+        params.state
+      );
+    }
+    const scopeResult = resolveAppScope(params.scope);
+    if (scopeResult.error) {
+      return redirectError(
+        res,
+        params.redirectUri,
+        'invalid_scope',
+        scopeResult.error,
+        params.state
+      );
+    }
+
+    res.set('Cache-Control', 'no-store');
+    res.set('Content-Type', 'text/html; charset=utf-8');
+    res.status(200).send(
+      renderConsentPage({
+        appId: scopeResult.appId,
+        appName: appNameFromId(scopeResult.appId),
+        clientName: client.clientName,
+        redirectUri: params.redirectUri,
+        oauthParams: echoParams(params),
+      })
+    );
+  }
+
+  // POST /authorize — the consent page's approval: verify the user, confirm app
+  // entitlement, and mint a single-use, PKCE-bound authorization code.
+  async function handlePost(req, res) {
+    const body = req.body || {};
+    const params = readParams(body);
+
+    // Re-validate everything; never trust the page.
+    if (!params.clientId) return oauthError(res, 'invalid_request', 'Missing client_id.');
+    const client = await store.getClient(params.clientId);
+    if (!client) return oauthError(res, 'invalid_client', 'Unknown client_id.');
+    const registered = Array.isArray(client.redirectUris) ? client.redirectUris : [];
+    if (!params.redirectUri || !registered.includes(params.redirectUri)) {
+      return oauthError(res, 'invalid_request', 'redirect_uri mismatch.');
+    }
+    if (
+      params.codeChallengeMethod !== CODE_CHALLENGE_METHOD ||
+      !isValidChallenge(params.codeChallenge)
+    ) {
+      return oauthError(res, 'invalid_request', 'PKCE S256 code_challenge required.');
+    }
+    const scopeResult = resolveAppScope(params.scope);
+    if (scopeResult.error) return oauthError(res, 'invalid_scope', scopeResult.error);
+    const appId = scopeResult.appId;
+
+    // Resource indicator (RFC 8707): if supplied it must match this app's
+    // endpoint; otherwise we derive it. The token's audience is bound to it.
+    const origin = originFromRequest(req);
+    const audience = `${origin}/mcp/${appId}`;
+    if (params.resource !== undefined && params.resource !== audience) {
+      return oauthError(res, 'invalid_target', 'resource does not match the requested app.');
+    }
+
+    // Verify the Firebase ID token — this is the human login (design §6).
+    let decoded;
+    try {
+      decoded = await verifyIdToken(body.idToken);
+    } catch {
+      return oauthError(res, 'access_denied', 'Sign-in required.', 401);
+    }
+
+    // Entitlement: the mcp:<appId> scope maps to hasApp(appId) (design §6).
+    const apps = Array.isArray(decoded.apps) ? decoded.apps : [];
+    if (!apps.includes(appId)) {
+      return oauthError(
+        res,
+        'access_denied',
+        `You do not have access to ${appNameFromId(appId)}.`,
+        403
+      );
+    }
+
+    const code = generateAuthCode();
+    const nowMs = now();
+    await store.putCode({
+      code,
+      clientId: params.clientId,
+      redirectUri: params.redirectUri,
+      uid: decoded.uid || decoded.sub,
+      appId,
+      scope: scopeForAppId(appId),
+      audience,
+      codeChallenge: params.codeChallenge,
+      codeChallengeMethod: CODE_CHALLENGE_METHOD,
+      createdAtMs: nowMs,
+      expiresAtMs: nowMs + AUTH_CODE_TTL_SECONDS * 1000,
+    });
+
+    const redirect = new URL(params.redirectUri);
+    redirect.searchParams.set('code', code);
+    if (params.state !== undefined && params.state !== null && params.state !== '') {
+      redirect.searchParams.set('state', params.state);
+    }
+    res.set('Cache-Control', 'no-store');
+    res.status(200).json({ redirect: redirect.toString() });
+  }
+
+  return async function handleAuthorize(req, res) {
+    if (req.method === 'GET') return handleGet(req, res);
+    if (req.method === 'POST') return handlePost(req, res);
+    return oauthError(res, 'invalid_request', 'Unsupported method.', 405);
+  };
+}
+
+module.exports = { createAuthorizeHandler, resolveAppScope, readParams };

--- a/functions/mcp/oauth/config.js
+++ b/functions/mcp/oauth/config.js
@@ -22,11 +22,6 @@ function getSigningSecret() {
   throw new Error('MCP_JWT_SECRET is not configured.');
 }
 
-// Token issuer identifier for JWTs. Access tokens are self-validating: the
-// resource server (phase 1e) verifies signature + audience locally, avoiding a
-// datastore read on the hot path.
-const TOKEN_ISSUER = 'https://olympus-dfa00.web.app';
-
 const ACCESS_TOKEN_TTL_SECONDS = 3600; // 1 hour — short-lived; clients refresh
 const AUTH_CODE_TTL_SECONDS = 300; // 5 minutes, single-use (OAuth 2.1 guidance)
 const REFRESH_TOKEN_TTL_SECONDS = 60 * 60 * 24 * 30; // 30 days, rotated on use
@@ -52,7 +47,6 @@ function scopeForAppId(appId) {
 module.exports = {
   MCP_JWT_SECRET,
   getSigningSecret,
-  TOKEN_ISSUER,
   ACCESS_TOKEN_TTL_SECONDS,
   AUTH_CODE_TTL_SECONDS,
   REFRESH_TOKEN_TTL_SECONDS,

--- a/functions/mcp/oauth/config.js
+++ b/functions/mcp/oauth/config.js
@@ -1,0 +1,63 @@
+'use strict';
+
+const { defineSecret } = require('firebase-functions/params');
+const { isEmulator } = require('../config');
+
+// Symmetric signing key for MCP access-token JWTs (design §6: "Functions secret
+// for MVP (symmetric)"). Must be created before this reaches production:
+//   firebase functions:secrets:set MCP_JWT_SECRET
+// The mcpServer function binds it via its `secrets` option so it is injected as
+// an env var at runtime.
+const MCP_JWT_SECRET = defineSecret('MCP_JWT_SECRET');
+
+// Emulator-only fallback so the OAuth flow can be exercised locally without
+// Secret Manager. NEVER used in a deployed environment (getSigningSecret throws
+// there if the secret is unset).
+const DEV_SIGNING_SECRET = 'dev-only-insecure-mcp-signing-secret-change-me';
+
+function getSigningSecret() {
+  const value = MCP_JWT_SECRET.value();
+  if (value) return value;
+  if (isEmulator()) return DEV_SIGNING_SECRET;
+  throw new Error('MCP_JWT_SECRET is not configured.');
+}
+
+// Token issuer identifier for JWTs. Access tokens are self-validating: the
+// resource server (phase 1e) verifies signature + audience locally, avoiding a
+// datastore read on the hot path.
+const TOKEN_ISSUER = 'https://olympus-dfa00.web.app';
+
+const ACCESS_TOKEN_TTL_SECONDS = 3600; // 1 hour — short-lived; clients refresh
+const AUTH_CODE_TTL_SECONDS = 300; // 5 minutes, single-use (OAuth 2.1 guidance)
+const REFRESH_TOKEN_TTL_SECONDS = 60 * 60 * 24 * 30; // 30 days, rotated on use
+
+const COLLECTIONS = {
+  clients: 'mcp_oauth_clients',
+  codes: 'mcp_oauth_codes',
+  tokens: 'mcp_oauth_tokens',
+};
+
+// One scope per app: mcp:<appId> maps to the hasApp(appId) requirement
+// (design §6). These helpers are the single place that mapping lives.
+const SCOPE_PREFIX = 'mcp:';
+
+function appIdFromScope(scope) {
+  return scope.startsWith(SCOPE_PREFIX) ? scope.slice(SCOPE_PREFIX.length) : null;
+}
+
+function scopeForAppId(appId) {
+  return `${SCOPE_PREFIX}${appId}`;
+}
+
+module.exports = {
+  MCP_JWT_SECRET,
+  getSigningSecret,
+  TOKEN_ISSUER,
+  ACCESS_TOKEN_TTL_SECONDS,
+  AUTH_CODE_TTL_SECONDS,
+  REFRESH_TOKEN_TTL_SECONDS,
+  COLLECTIONS,
+  SCOPE_PREFIX,
+  appIdFromScope,
+  scopeForAppId,
+};

--- a/functions/mcp/oauth/consent-page.js
+++ b/functions/mcp/oauth/consent-page.js
@@ -1,0 +1,195 @@
+'use strict';
+
+const { escapeHtml } = require('./respond');
+
+// The consent screen served by GET /authorize. It reuses Firebase Auth exactly
+// as the Grand Hall does (compat SDK from the Hosting-reserved /__/firebase/
+// path), so there is no parallel login system (design §4, §6). After the user
+// signs in and approves, the page POSTs their Firebase ID token plus the
+// original OAuth parameters back to /authorize; the server verifies the token,
+// confirms app entitlement, and issues the authorization code.
+//
+// `oauthParams` are echoed back on approval; every reflected value is
+// HTML-escaped and re-validated server-side on POST (the page is never trusted).
+function renderConsentPage({ appId, appName, clientName, redirectUri, oauthParams }) {
+  const safeAppName = escapeHtml(appName || appId);
+  const safeClientName = escapeHtml(clientName || 'an MCP client');
+  const paramsJson = JSON.stringify(oauthParams).replace(/</g, '\\u003c');
+  const safeRedirect = escapeHtml(redirectUri);
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Connect ${safeAppName} — Olympus</title>
+<script defer src="/__/firebase/12.9.0/firebase-app-compat.js"></script>
+<script defer src="/__/firebase/12.9.0/firebase-auth-compat.js"></script>
+<script defer src="/__/firebase/init.js?useEmulator=true"></script>
+<style>
+  *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+  body{background:#0a0e1a;color:#e0e0e0;font-family:'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+    min-height:100vh;display:flex;align-items:center;justify-content:center;padding:1rem}
+  .card{width:100%;max-width:420px;background:#111827;border:1px solid rgba(255,183,77,.2);
+    border-radius:16px;padding:2.25rem 2rem;text-align:center}
+  .icon{font-size:2.25rem;margin-bottom:.5rem}
+  h1{font-size:1.4rem;letter-spacing:.06em;text-transform:uppercase;margin-bottom:.35rem;
+    background:linear-gradient(135deg,#ffd54f,#ffb74d,#ff8a65);-webkit-background-clip:text;
+    background-clip:text;-webkit-text-fill-color:transparent}
+  .sub{font-size:.9rem;color:#90a4ae;font-style:italic;margin-bottom:1.5rem}
+  .grant{background:rgba(255,255,255,.04);border:1px solid rgba(255,255,255,.08);
+    border-radius:10px;padding:1rem;margin-bottom:1.5rem;font-size:.9rem;line-height:1.6;text-align:left}
+  .grant b{color:#ffd54f}
+  .form-group{margin-bottom:.85rem;text-align:left}
+  label{display:block;font-size:.72rem;color:#9ca3af;text-transform:uppercase;
+    letter-spacing:.08em;margin-bottom:.35rem}
+  input{width:100%;padding:.7rem .9rem;font-size:.95rem;color:#e0e0e0;
+    background:rgba(255,255,255,.05);border:1px solid rgba(255,255,255,.1);border-radius:8px;outline:none}
+  input:focus{border-color:rgba(255,183,77,.5)}
+  button{font-family:inherit;cursor:pointer;border:none;border-radius:8px}
+  .btn-primary{width:100%;padding:.8rem;margin-top:.5rem;font-size:.95rem;font-weight:600;
+    letter-spacing:.06em;text-transform:uppercase;color:#0a0e1a;
+    background:linear-gradient(135deg,#ffd54f,#ffb74d,#ff8a65)}
+  .btn-primary:disabled{opacity:.6;cursor:not-allowed}
+  .btn-google{width:100%;padding:.7rem;margin-top:.75rem;font-size:.9rem;color:#e0e0e0;
+    background:transparent;border:1px solid rgba(255,255,255,.15)}
+  .row{display:flex;gap:.75rem;margin-top:.5rem}
+  .row button{flex:1;padding:.8rem;font-size:.9rem;font-weight:600;text-transform:uppercase;letter-spacing:.05em}
+  .btn-deny{background:transparent;border:1px solid rgba(255,255,255,.15);color:#90a4ae}
+  .who{font-size:.82rem;color:#6b7280;margin-bottom:1rem}
+  .who b{color:#e0e0e0}
+  .error{margin-top:1rem;padding:.7rem .9rem;font-size:.85rem;color:#fca5a5;
+    background:rgba(220,38,38,.1);border:1px solid rgba(220,38,38,.2);border-radius:8px;font-style:italic}
+  .hidden{display:none!important}
+</style>
+</head>
+<body>
+<div class="card">
+  <div class="icon">&#128273;</div>
+  <h1>Connect ${safeAppName}</h1>
+  <p class="sub">${safeClientName} wants to connect to Olympus</p>
+
+  <div class="grant">
+    This will let the connected client access <b>${safeAppName}</b> in Olympus on your
+    behalf, using your granted permissions. You can revoke access at any time.
+  </div>
+
+  <!-- Sign-in (shown when logged out) -->
+  <div id="signin">
+    <form id="login-form" novalidate>
+      <div class="form-group">
+        <label for="email">Email</label>
+        <input id="email" type="email" autocomplete="email" placeholder="your@email.com" required />
+      </div>
+      <div class="form-group">
+        <label for="password">Password</label>
+        <input id="password" type="password" autocomplete="current-password" placeholder="Password" required />
+      </div>
+      <button class="btn-primary" id="signin-btn" type="submit">Sign in</button>
+    </form>
+    <button class="btn-google" id="google-btn" type="button">Continue with Google</button>
+  </div>
+
+  <!-- Approval (shown when logged in) -->
+  <div id="approve" class="hidden">
+    <p class="who">Signed in as <b id="who-email"></b></p>
+    <div class="row">
+      <button class="btn-deny" id="deny-btn" type="button">Deny</button>
+      <button class="btn-primary" id="approve-btn" type="button" style="margin-top:0">Approve</button>
+    </div>
+  </div>
+
+  <div class="error hidden" id="error" role="alert"></div>
+</div>
+
+<script>
+  var OAUTH = JSON.parse('${paramsJson}');
+  var REDIRECT_URI = '${safeRedirect}';
+
+  document.addEventListener('DOMContentLoaded', function () {
+    var signin = document.getElementById('signin');
+    var approve = document.getElementById('approve');
+    var whoEmail = document.getElementById('who-email');
+    var errorBox = document.getElementById('error');
+
+    function showError(msg) {
+      errorBox.textContent = msg;
+      errorBox.classList.remove('hidden');
+    }
+
+    firebase.auth().onAuthStateChanged(function (user) {
+      if (user) {
+        signin.classList.add('hidden');
+        approve.classList.remove('hidden');
+        whoEmail.textContent = user.email || user.uid;
+      } else {
+        approve.classList.add('hidden');
+        signin.classList.remove('hidden');
+      }
+    });
+
+    document.getElementById('login-form').addEventListener('submit', function (e) {
+      e.preventDefault();
+      errorBox.classList.add('hidden');
+      var email = document.getElementById('email').value.trim();
+      var password = document.getElementById('password').value;
+      document.getElementById('signin-btn').disabled = true;
+      firebase.auth().signInWithEmailAndPassword(email, password).catch(function (err) {
+        showError(err.message || 'Sign-in failed.');
+        document.getElementById('signin-btn').disabled = false;
+      });
+    });
+
+    document.getElementById('google-btn').addEventListener('click', function () {
+      errorBox.classList.add('hidden');
+      var provider = new firebase.auth.GoogleAuthProvider();
+      firebase.auth().signInWithPopup(provider).catch(function (err) {
+        showError(err.message || 'Google sign-in failed.');
+      });
+    });
+
+    document.getElementById('deny-btn').addEventListener('click', function () {
+      var url = new URL(REDIRECT_URI);
+      url.searchParams.set('error', 'access_denied');
+      if (OAUTH.state) url.searchParams.set('state', OAUTH.state);
+      window.location.href = url.toString();
+    });
+
+    document.getElementById('approve-btn').addEventListener('click', function () {
+      errorBox.classList.add('hidden');
+      var btn = document.getElementById('approve-btn');
+      btn.disabled = true;
+      var user = firebase.auth().currentUser;
+      if (!user) {
+        showError('Your session expired. Please sign in again.');
+        btn.disabled = false;
+        return;
+      }
+      user.getIdToken().then(function (idToken) {
+        var body = Object.assign({ idToken: idToken }, OAUTH);
+        return fetch(window.location.pathname, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        });
+      }).then(function (res) {
+        return res.json().then(function (data) { return { ok: res.ok, data: data }; });
+      }).then(function (r) {
+        if (r.ok && r.data.redirect) {
+          window.location.href = r.data.redirect;
+        } else {
+          showError((r.data && (r.data.error_description || r.data.error)) || 'Authorization failed.');
+          btn.disabled = false;
+        }
+      }).catch(function (err) {
+        showError(err.message || 'Authorization failed.');
+        btn.disabled = false;
+      });
+    });
+  });
+</script>
+</body>
+</html>`;
+}
+
+module.exports = { renderConsentPage };

--- a/functions/mcp/oauth/consent-page.js
+++ b/functions/mcp/oauth/consent-page.js
@@ -9,13 +9,33 @@ const { escapeHtml } = require('./respond');
 // original OAuth parameters back to /authorize; the server verifies the token,
 // confirms app entitlement, and issues the authorization code.
 //
-// `oauthParams` are echoed back on approval; every reflected value is
-// HTML-escaped and re-validated server-side on POST (the page is never trusted).
-function renderConsentPage({ appId, appName, clientName, redirectUri, oauthParams }) {
+// `oauthParams` are echoed back on approval and re-validated server-side on
+// POST (the page is never trusted). They carry attacker-controllable values
+// (state, resource), so they are emitted inside a <script type="application/
+// json"> block and read with JSON.parse — never interpolated into executable
+// JS. Only display strings (appName, clientName) go into HTML text, where
+// HTML-escaping is the correct transform.
+function jsonForScriptBlock(value) {
+  // Prevent the JSON text from terminating the <script> element or being
+  // reinterpreted as JS: escape '<', '>', '&', and the JS line separators
+  // U+2028/U+2029.
+  return JSON.stringify(value).replace(
+    /[<>&\u2028\u2029]/g,
+    (c) =>
+      ({
+        '<': '\\u003c',
+        '>': '\\u003e',
+        '&': '\\u0026',
+        '\u2028': '\\u2028',
+        '\u2029': '\\u2029',
+      })[c]
+  );
+}
+
+function renderConsentPage({ appId, appName, clientName, oauthParams }) {
   const safeAppName = escapeHtml(appName || appId);
   const safeClientName = escapeHtml(clientName || 'an MCP client');
-  const paramsJson = JSON.stringify(oauthParams).replace(/</g, '\\u003c');
-  const safeRedirect = escapeHtml(redirectUri);
+  const paramsJson = jsonForScriptBlock(oauthParams);
 
   return `<!doctype html>
 <html lang="en">
@@ -102,9 +122,10 @@ function renderConsentPage({ appId, appName, clientName, redirectUri, oauthParam
   <div class="error hidden" id="error" role="alert"></div>
 </div>
 
+<script type="application/json" id="oauth-params">${paramsJson}</script>
 <script>
-  var OAUTH = JSON.parse('${paramsJson}');
-  var REDIRECT_URI = '${safeRedirect}';
+  var OAUTH = JSON.parse(document.getElementById('oauth-params').textContent);
+  var REDIRECT_URI = OAUTH.redirect_uri;
 
   document.addEventListener('DOMContentLoaded', function () {
     var signin = document.getElementById('signin');

--- a/functions/mcp/oauth/pkce.js
+++ b/functions/mcp/oauth/pkce.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const crypto = require('crypto');
+
+// PKCE (RFC 7636) with S256 only — "plain" is rejected everywhere (design §10).
+
+const CODE_CHALLENGE_METHOD = 'S256';
+
+function base64UrlSha256(input) {
+  return crypto.createHash('sha256').update(input).digest('base64url');
+}
+
+// Constant-time comparison of the expected vs. derived challenge to avoid
+// leaking timing information about a code_verifier.
+function verifyPkce(codeVerifier, codeChallenge) {
+  if (typeof codeVerifier !== 'string' || typeof codeChallenge !== 'string') {
+    return false;
+  }
+  const derived = base64UrlSha256(codeVerifier);
+  const a = Buffer.from(derived);
+  const b = Buffer.from(codeChallenge);
+  if (a.length !== b.length) return false;
+  return crypto.timingSafeEqual(a, b);
+}
+
+// A syntactically valid S256 challenge is a base64url string of the right size
+// (SHA-256 → 32 bytes → 43 base64url chars, no padding).
+function isValidChallenge(codeChallenge) {
+  return typeof codeChallenge === 'string' && /^[A-Za-z0-9\-_]{43}$/.test(codeChallenge);
+}
+
+module.exports = { CODE_CHALLENGE_METHOD, base64UrlSha256, verifyPkce, isValidChallenge };

--- a/functions/mcp/oauth/respond.js
+++ b/functions/mcp/oauth/respond.js
@@ -1,0 +1,35 @@
+'use strict';
+
+// OAuth 2.0 response helpers (RFC 6749).
+
+// Token / registration endpoint errors: JSON body per RFC 6749 §5.2. Default
+// 400; 401 for invalid_client per spec.
+function oauthError(res, error, description, status) {
+  const code = status || (error === 'invalid_client' ? 401 : 400);
+  res.set('Cache-Control', 'no-store');
+  res.set('Pragma', 'no-cache');
+  res.status(code).json({ error, ...(description ? { error_description: description } : {}) });
+}
+
+// Authorization endpoint errors, once client_id + redirect_uri are validated:
+// redirect back to the client with error params (RFC 6749 §4.1.2.1),
+// preserving state.
+function redirectError(res, redirectUri, error, description, state) {
+  const url = new URL(redirectUri);
+  url.searchParams.set('error', error);
+  if (description) url.searchParams.set('error_description', description);
+  if (state) url.searchParams.set('state', state);
+  res.redirect(302, url.toString());
+}
+
+// HTML-escape reflected values before embedding them in the consent page.
+function escapeHtml(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+module.exports = { oauthError, redirectError, escapeHtml };

--- a/functions/mcp/oauth/store.js
+++ b/functions/mcp/oauth/store.js
@@ -1,6 +1,18 @@
 'use strict';
 
+const { Timestamp } = require('firebase-admin/firestore');
 const { COLLECTIONS } = require('./config');
+
+// Adds a Firestore Timestamp mirror of expiresAtMs so a Firestore TTL policy
+// (configured on the `expireAt` field of mcp_oauth_codes / mcp_oauth_tokens)
+// can auto-delete expired docs — abandoned auth codes and revoked/expired
+// refresh tokens otherwise accumulate unbounded. Revoked-but-unexpired tokens
+// are retained until natural expiry so reuse detection still works.
+function withExpireAt(record) {
+  return typeof record.expiresAtMs === 'number'
+    ? { ...record, expireAt: Timestamp.fromMillis(record.expiresAtMs) }
+    : record;
+}
 
 // Persistence for the OAuth authorization server. The endpoint logic depends
 // only on this interface, so it can be exercised with an in-memory store in
@@ -45,7 +57,7 @@ function createFirestoreStore(db) {
     },
 
     async putCode(record) {
-      await col(COLLECTIONS.codes).doc(record.code).set(record);
+      await col(COLLECTIONS.codes).doc(record.code).set(withExpireAt(record));
     },
 
     async consumeCode(code) {
@@ -59,7 +71,7 @@ function createFirestoreStore(db) {
     },
 
     async putRefreshToken(record) {
-      await col(COLLECTIONS.tokens).doc(record.tokenHash).set(record);
+      await col(COLLECTIONS.tokens).doc(record.tokenHash).set(withExpireAt(record));
     },
 
     async getRefreshToken(tokenHash) {
@@ -73,21 +85,24 @@ function createFirestoreStore(db) {
       return db.runTransaction(async (tx) => {
         const snap = await tx.get(oldRef);
         const decision = evaluateRotation(snap.exists ? snap.data() : null, nowMs);
-        if (!decision.ok) {
-          // Reuse of a rotated token signals possible theft — revoke it hard.
-          if (decision.reason === 'reuse') {
-            tx.update(oldRef, { revoked: true });
-          }
-          return decision;
-        }
+        if (!decision.ok) return decision; // caller handles reuse (family revocation)
         tx.update(oldRef, { revoked: true, rotatedTo: newRecord.tokenHash });
-        tx.set(newRef, newRecord);
+        tx.set(newRef, withExpireAt(newRecord));
         return decision;
       });
     },
 
     async revokeRefreshToken(tokenHash) {
       await col(COLLECTIONS.tokens).doc(tokenHash).set({ revoked: true }, { merge: true });
+    },
+
+    // Revokes every refresh token in a rotation family (theft response).
+    async revokeFamily(familyId) {
+      const snap = await col(COLLECTIONS.tokens).where('familyId', '==', familyId).get();
+      if (snap.empty) return;
+      const batch = db.batch();
+      snap.docs.forEach((doc) => batch.update(doc.ref, { revoked: true }));
+      await batch.commit();
     },
   };
 }
@@ -121,12 +136,7 @@ function createInMemoryStore() {
     },
     async rotateRefreshToken(oldHash, newRecord, nowMs = Date.now()) {
       const decision = evaluateRotation(tokens.get(oldHash) || null, nowMs);
-      if (!decision.ok) {
-        if (decision.reason === 'reuse') {
-          tokens.set(oldHash, { ...tokens.get(oldHash), revoked: true });
-        }
-        return decision;
-      }
+      if (!decision.ok) return decision; // caller handles reuse (family revocation)
       tokens.set(oldHash, { ...decision.old, revoked: true, rotatedTo: newRecord.tokenHash });
       tokens.set(newRecord.tokenHash, newRecord);
       return decision;
@@ -134,6 +144,11 @@ function createInMemoryStore() {
     async revokeRefreshToken(tokenHash) {
       const existing = tokens.get(tokenHash);
       if (existing) tokens.set(tokenHash, { ...existing, revoked: true });
+    },
+    async revokeFamily(familyId) {
+      for (const [hash, record] of tokens) {
+        if (record.familyId === familyId) tokens.set(hash, { ...record, revoked: true });
+      }
     },
     // test-only introspection
     _debug: { clients, codes, tokens },

--- a/functions/mcp/oauth/store.js
+++ b/functions/mcp/oauth/store.js
@@ -1,0 +1,143 @@
+'use strict';
+
+const { COLLECTIONS } = require('./config');
+
+// Persistence for the OAuth authorization server. The endpoint logic depends
+// only on this interface, so it can be exercised with an in-memory store in
+// tests (createInMemoryStore) and backed by Firestore in production
+// (createFirestoreStore). Both implementations MUST behave identically for the
+// atomic operations below.
+//
+// Interface:
+//   getClient(clientId)                  -> client record | null
+//   putClient(record)                    -> void            (DCR, phase 1d)
+//   putCode(record)                      -> void            (record.code is id)
+//   consumeCode(code)                    -> record | null   (atomic single-use)
+//   putRefreshToken(record)              -> void            (record.tokenHash is id)
+//   getRefreshToken(tokenHash)           -> record | null
+//   rotateRefreshToken(oldHash, newRec)  -> { ok, reason?, old? } (atomic)
+//   revokeRefreshToken(tokenHash)        -> void
+
+// Shared rotation decision so both stores enforce the exact same rules:
+// unknown token, replay of an already-rotated (revoked) token, or an expired
+// token are all rejected; a live token is rotated.
+function evaluateRotation(oldRecord, nowMs) {
+  if (!oldRecord) return { ok: false, reason: 'not_found' };
+  if (oldRecord.revoked) return { ok: false, reason: 'reuse', old: oldRecord };
+  if (typeof oldRecord.expiresAtMs === 'number' && oldRecord.expiresAtMs <= nowMs) {
+    return { ok: false, reason: 'expired', old: oldRecord };
+  }
+  return { ok: true, old: oldRecord };
+}
+
+// ── Firestore-backed store (production) ────────────────────────────────
+function createFirestoreStore(db) {
+  const col = (name) => db.collection(name);
+
+  return {
+    async getClient(clientId) {
+      const snap = await col(COLLECTIONS.clients).doc(clientId).get();
+      return snap.exists ? { clientId, ...snap.data() } : null;
+    },
+
+    async putClient(record) {
+      await col(COLLECTIONS.clients).doc(record.clientId).set(record);
+    },
+
+    async putCode(record) {
+      await col(COLLECTIONS.codes).doc(record.code).set(record);
+    },
+
+    async consumeCode(code) {
+      const ref = col(COLLECTIONS.codes).doc(code);
+      return db.runTransaction(async (tx) => {
+        const snap = await tx.get(ref);
+        if (!snap.exists) return null;
+        tx.delete(ref); // single-use: gone once read
+        return snap.data();
+      });
+    },
+
+    async putRefreshToken(record) {
+      await col(COLLECTIONS.tokens).doc(record.tokenHash).set(record);
+    },
+
+    async getRefreshToken(tokenHash) {
+      const snap = await col(COLLECTIONS.tokens).doc(tokenHash).get();
+      return snap.exists ? snap.data() : null;
+    },
+
+    async rotateRefreshToken(oldHash, newRecord, nowMs = Date.now()) {
+      const oldRef = col(COLLECTIONS.tokens).doc(oldHash);
+      const newRef = col(COLLECTIONS.tokens).doc(newRecord.tokenHash);
+      return db.runTransaction(async (tx) => {
+        const snap = await tx.get(oldRef);
+        const decision = evaluateRotation(snap.exists ? snap.data() : null, nowMs);
+        if (!decision.ok) {
+          // Reuse of a rotated token signals possible theft — revoke it hard.
+          if (decision.reason === 'reuse') {
+            tx.update(oldRef, { revoked: true });
+          }
+          return decision;
+        }
+        tx.update(oldRef, { revoked: true, rotatedTo: newRecord.tokenHash });
+        tx.set(newRef, newRecord);
+        return decision;
+      });
+    },
+
+    async revokeRefreshToken(tokenHash) {
+      await col(COLLECTIONS.tokens).doc(tokenHash).set({ revoked: true }, { merge: true });
+    },
+  };
+}
+
+// ── In-memory store (tests) ────────────────────────────────────────────
+function createInMemoryStore() {
+  const clients = new Map();
+  const codes = new Map();
+  const tokens = new Map();
+
+  return {
+    async getClient(clientId) {
+      return clients.get(clientId) || null;
+    },
+    async putClient(record) {
+      clients.set(record.clientId, record);
+    },
+    async putCode(record) {
+      codes.set(record.code, record);
+    },
+    async consumeCode(code) {
+      const record = codes.get(code) || null;
+      codes.delete(code); // single-use
+      return record;
+    },
+    async putRefreshToken(record) {
+      tokens.set(record.tokenHash, record);
+    },
+    async getRefreshToken(tokenHash) {
+      return tokens.get(tokenHash) || null;
+    },
+    async rotateRefreshToken(oldHash, newRecord, nowMs = Date.now()) {
+      const decision = evaluateRotation(tokens.get(oldHash) || null, nowMs);
+      if (!decision.ok) {
+        if (decision.reason === 'reuse') {
+          tokens.set(oldHash, { ...tokens.get(oldHash), revoked: true });
+        }
+        return decision;
+      }
+      tokens.set(oldHash, { ...decision.old, revoked: true, rotatedTo: newRecord.tokenHash });
+      tokens.set(newRecord.tokenHash, newRecord);
+      return decision;
+    },
+    async revokeRefreshToken(tokenHash) {
+      const existing = tokens.get(tokenHash);
+      if (existing) tokens.set(tokenHash, { ...existing, revoked: true });
+    },
+    // test-only introspection
+    _debug: { clients, codes, tokens },
+  };
+}
+
+module.exports = { createFirestoreStore, createInMemoryStore, evaluateRotation };

--- a/functions/mcp/oauth/token.js
+++ b/functions/mcp/oauth/token.js
@@ -1,0 +1,138 @@
+'use strict';
+
+const { oauthError } = require('./respond');
+const { verifyPkce } = require('./pkce');
+const { signAccessToken, generateRefreshToken, hashRefreshToken } = require('./tokens');
+const { ACCESS_TOKEN_TTL_SECONDS, REFRESH_TOKEN_TTL_SECONDS } = require('./config');
+
+function tokenResponse(res, { accessToken, refreshToken, scope }) {
+  res.set('Cache-Control', 'no-store');
+  res.set('Pragma', 'no-cache');
+  res.status(200).json({
+    access_token: accessToken,
+    token_type: 'Bearer',
+    expires_in: ACCESS_TOKEN_TTL_SECONDS,
+    refresh_token: refreshToken,
+    scope,
+  });
+}
+
+function createTokenHandler(deps) {
+  const { store, now = () => Date.now() } = deps;
+
+  // Issues a fresh access token + refresh token for a validated identity/app.
+  async function issueTokens(res, { uid, clientId, appId, scope, audience }, nowMs) {
+    const accessToken = signAccessToken({ uid, audience, scope });
+    const refreshToken = generateRefreshToken();
+    await store.putRefreshToken({
+      tokenHash: hashRefreshToken(refreshToken),
+      uid,
+      clientId,
+      appId,
+      scope,
+      audience,
+      revoked: false,
+      createdAtMs: nowMs,
+      expiresAtMs: nowMs + REFRESH_TOKEN_TTL_SECONDS * 1000,
+    });
+    return tokenResponse(res, { accessToken, refreshToken, scope });
+  }
+
+  // grant_type=authorization_code — exchange a PKCE-bound, single-use code.
+  async function authorizationCodeGrant(req, res, body) {
+    const {
+      code,
+      redirect_uri: redirectUri,
+      client_id: clientId,
+      code_verifier: codeVerifier,
+    } = body;
+
+    if (!code || !codeVerifier || !clientId || !redirectUri) {
+      return oauthError(res, 'invalid_request', 'Missing required parameters.');
+    }
+
+    // Single-use: consuming the code removes it, so a replay finds nothing.
+    const record = await store.consumeCode(code);
+    if (!record) return oauthError(res, 'invalid_grant', 'Invalid or expired authorization code.');
+    if (typeof record.expiresAtMs === 'number' && record.expiresAtMs <= now()) {
+      return oauthError(res, 'invalid_grant', 'Authorization code expired.');
+    }
+    if (record.clientId !== clientId) {
+      return oauthError(res, 'invalid_grant', 'client_id mismatch.');
+    }
+    if (record.redirectUri !== redirectUri) {
+      return oauthError(res, 'invalid_grant', 'redirect_uri mismatch.');
+    }
+    if (!verifyPkce(codeVerifier, record.codeChallenge)) {
+      return oauthError(res, 'invalid_grant', 'PKCE verification failed.');
+    }
+
+    return issueTokens(
+      res,
+      {
+        uid: record.uid,
+        clientId: record.clientId,
+        appId: record.appId,
+        scope: record.scope,
+        audience: record.audience,
+      },
+      now()
+    );
+  }
+
+  // grant_type=refresh_token — rotate the refresh token and mint a new access
+  // token. Rotation is atomic; presenting an already-rotated token is treated
+  // as reuse and rejected (design §6, §10).
+  async function refreshTokenGrant(req, res, body) {
+    const { refresh_token: refreshToken, client_id: clientId } = body;
+    if (!refreshToken || !clientId) {
+      return oauthError(res, 'invalid_request', 'Missing required parameters.');
+    }
+
+    const oldHash = hashRefreshToken(refreshToken);
+    const old = await store.getRefreshToken(oldHash);
+    if (!old || old.clientId !== clientId) {
+      return oauthError(res, 'invalid_grant', 'Invalid refresh token.');
+    }
+
+    const nowMs = now();
+    const newRefreshToken = generateRefreshToken();
+    const newRecord = {
+      tokenHash: hashRefreshToken(newRefreshToken),
+      uid: old.uid,
+      clientId: old.clientId,
+      appId: old.appId,
+      scope: old.scope,
+      audience: old.audience,
+      revoked: false,
+      createdAtMs: nowMs,
+      expiresAtMs: nowMs + REFRESH_TOKEN_TTL_SECONDS * 1000,
+      rotatedFrom: oldHash,
+    };
+
+    const result = await store.rotateRefreshToken(oldHash, newRecord, nowMs);
+    if (!result.ok) {
+      return oauthError(res, 'invalid_grant', 'Refresh token is no longer valid.');
+    }
+
+    const accessToken = signAccessToken({ uid: old.uid, audience: old.audience, scope: old.scope });
+    return tokenResponse(res, { accessToken, refreshToken: newRefreshToken, scope: old.scope });
+  }
+
+  return async function handleToken(req, res) {
+    if (req.method !== 'POST') {
+      return oauthError(res, 'invalid_request', 'The token endpoint requires POST.', 405);
+    }
+    const body = req.body || {};
+    switch (body.grant_type) {
+      case 'authorization_code':
+        return authorizationCodeGrant(req, res, body);
+      case 'refresh_token':
+        return refreshTokenGrant(req, res, body);
+      default:
+        return oauthError(res, 'unsupported_grant_type', 'Unsupported grant_type.');
+    }
+  };
+}
+
+module.exports = { createTokenHandler };

--- a/functions/mcp/oauth/token.js
+++ b/functions/mcp/oauth/token.js
@@ -2,7 +2,12 @@
 
 const { oauthError } = require('./respond');
 const { verifyPkce } = require('./pkce');
-const { signAccessToken, generateRefreshToken, hashRefreshToken } = require('./tokens');
+const {
+  signAccessToken,
+  generateRefreshToken,
+  hashRefreshToken,
+  generateFamilyId,
+} = require('./tokens');
 const { ACCESS_TOKEN_TTL_SECONDS, REFRESH_TOKEN_TTL_SECONDS } = require('./config');
 
 function tokenResponse(res, { accessToken, refreshToken, scope }) {
@@ -18,11 +23,20 @@ function tokenResponse(res, { accessToken, refreshToken, scope }) {
 }
 
 function createTokenHandler(deps) {
-  const { store, now = () => Date.now() } = deps;
+  // getEntitlements(uid) -> current apps[] claim, used to re-check access on
+  // refresh so a revoked app claim stops working within the access-token TTL
+  // rather than lingering for the full refresh lifetime.
+  const { store, getEntitlements, now = () => Date.now() } = deps;
 
   // Issues a fresh access token + refresh token for a validated identity/app.
-  async function issueTokens(res, { uid, clientId, appId, scope, audience }, nowMs) {
-    const accessToken = signAccessToken({ uid, audience, scope });
+  // `familyId` groups a refresh token with its rotation successors for
+  // reuse-based family revocation.
+  async function issueTokens(
+    res,
+    { uid, clientId, appId, scope, audience, issuer, familyId },
+    nowMs
+  ) {
+    const accessToken = signAccessToken({ uid, audience, scope, issuer });
     const refreshToken = generateRefreshToken();
     await store.putRefreshToken({
       tokenHash: hashRefreshToken(refreshToken),
@@ -31,6 +45,8 @@ function createTokenHandler(deps) {
       appId,
       scope,
       audience,
+      issuer,
+      familyId,
       revoked: false,
       createdAtMs: nowMs,
       expiresAtMs: nowMs + REFRESH_TOKEN_TTL_SECONDS * 1000,
@@ -75,6 +91,8 @@ function createTokenHandler(deps) {
         appId: record.appId,
         scope: record.scope,
         audience: record.audience,
+        issuer: record.issuer,
+        familyId: generateFamilyId(), // new family for this authorization
       },
       now()
     );
@@ -95,6 +113,22 @@ function createTokenHandler(deps) {
       return oauthError(res, 'invalid_grant', 'Invalid refresh token.');
     }
 
+    // Re-check entitlement against the user's *current* claims. If the app was
+    // revoked since consent, stop issuing tokens (and revoke the family so the
+    // refresh chain is dead), rather than honoring it for the refresh lifetime.
+    if (getEntitlements) {
+      let apps;
+      try {
+        apps = await getEntitlements(old.uid);
+      } catch {
+        return oauthError(res, 'invalid_grant', 'Unable to verify access.');
+      }
+      if (!Array.isArray(apps) || !apps.includes(old.appId)) {
+        if (old.familyId) await store.revokeFamily(old.familyId);
+        return oauthError(res, 'invalid_grant', 'Access to this app has been revoked.');
+      }
+    }
+
     const nowMs = now();
     const newRefreshToken = generateRefreshToken();
     const newRecord = {
@@ -104,6 +138,8 @@ function createTokenHandler(deps) {
       appId: old.appId,
       scope: old.scope,
       audience: old.audience,
+      issuer: old.issuer,
+      familyId: old.familyId,
       revoked: false,
       createdAtMs: nowMs,
       expiresAtMs: nowMs + REFRESH_TOKEN_TTL_SECONDS * 1000,
@@ -112,10 +148,20 @@ function createTokenHandler(deps) {
 
     const result = await store.rotateRefreshToken(oldHash, newRecord, nowMs);
     if (!result.ok) {
+      // Reuse of an already-rotated token signals theft — kill the whole family
+      // so the attacker's live successor token is revoked too.
+      if (result.reason === 'reuse' && old.familyId) {
+        await store.revokeFamily(old.familyId);
+      }
       return oauthError(res, 'invalid_grant', 'Refresh token is no longer valid.');
     }
 
-    const accessToken = signAccessToken({ uid: old.uid, audience: old.audience, scope: old.scope });
+    const accessToken = signAccessToken({
+      uid: old.uid,
+      audience: old.audience,
+      scope: old.scope,
+      issuer: old.issuer,
+    });
     return tokenResponse(res, { accessToken, refreshToken: newRefreshToken, scope: old.scope });
   }
 

--- a/functions/mcp/oauth/tokens.js
+++ b/functions/mcp/oauth/tokens.js
@@ -2,32 +2,44 @@
 
 const crypto = require('crypto');
 const jwt = require('jsonwebtoken');
-const { getSigningSecret, TOKEN_ISSUER, ACCESS_TOKEN_TTL_SECONDS } = require('./config');
+const { PRIMARY_ORIGIN } = require('../config');
+const { getSigningSecret, ACCESS_TOKEN_TTL_SECONDS } = require('./config');
 
 // ── Access tokens (self-validating JWT, HS256) ─────────────────────────
 //
 // The resource server (phase 1e) verifies these locally with the shared secret
 // and the expected audience — no datastore read on the hot path (design §6).
+//
+// Both `audience` and `issuer` are required on sign, and `audience` is required
+// on verify: audience binding (RFC 8707) is what stops a token minted for app A
+// being replayed at app B, so the check must never be silently skippable by
+// omitting the argument.
 
-function signAccessToken({ uid, audience, scope, secret = getSigningSecret() }) {
+function signAccessToken({ uid, audience, scope, issuer, secret = getSigningSecret() }) {
+  if (!audience) throw new Error('signAccessToken requires an audience.');
+  if (!issuer) throw new Error('signAccessToken requires an issuer.');
   return jwt.sign({ scope }, secret, {
     algorithm: 'HS256',
-    issuer: TOKEN_ISSUER,
+    issuer,
     subject: uid,
     audience,
     expiresIn: ACCESS_TOKEN_TTL_SECONDS,
   });
 }
 
-// Verifies signature, issuer, expiry, and — when provided — the audience. Audience
-// binding (RFC 8707) is what stops a token minted for app A being replayed at
-// app B (enforced by the resource server in phase 1e). Returns the decoded
-// payload or throws.
-function verifyAccessToken(token, { audience, secret = getSigningSecret() } = {}) {
+// Verifies signature, issuer, expiry, and audience. Throws if `audience` is
+// absent so a resource-server handler cannot accept cross-app tokens by
+// forgetting to pass its own audience. `issuer` defaults to the canonical
+// origin; the resource server passes its resolved origin explicitly.
+function verifyAccessToken(
+  token,
+  { audience, issuer = PRIMARY_ORIGIN, secret = getSigningSecret() } = {}
+) {
+  if (!audience) throw new Error('verifyAccessToken requires an audience.');
   return jwt.verify(token, secret, {
     algorithms: ['HS256'],
-    issuer: TOKEN_ISSUER,
-    ...(audience ? { audience } : {}),
+    issuer,
+    audience,
   });
 }
 
@@ -49,10 +61,17 @@ function generateAuthCode() {
   return crypto.randomBytes(32).toString('base64url');
 }
 
+// Groups a refresh token and all its rotation successors into one "family".
+// On detected reuse the whole family is revoked (OAuth 2.1 / RFC 6819).
+function generateFamilyId() {
+  return crypto.randomBytes(16).toString('hex');
+}
+
 module.exports = {
   signAccessToken,
   verifyAccessToken,
   generateRefreshToken,
   hashRefreshToken,
   generateAuthCode,
+  generateFamilyId,
 };

--- a/functions/mcp/oauth/tokens.js
+++ b/functions/mcp/oauth/tokens.js
@@ -1,0 +1,58 @@
+'use strict';
+
+const crypto = require('crypto');
+const jwt = require('jsonwebtoken');
+const { getSigningSecret, TOKEN_ISSUER, ACCESS_TOKEN_TTL_SECONDS } = require('./config');
+
+// ── Access tokens (self-validating JWT, HS256) ─────────────────────────
+//
+// The resource server (phase 1e) verifies these locally with the shared secret
+// and the expected audience — no datastore read on the hot path (design §6).
+
+function signAccessToken({ uid, audience, scope, secret = getSigningSecret() }) {
+  return jwt.sign({ scope }, secret, {
+    algorithm: 'HS256',
+    issuer: TOKEN_ISSUER,
+    subject: uid,
+    audience,
+    expiresIn: ACCESS_TOKEN_TTL_SECONDS,
+  });
+}
+
+// Verifies signature, issuer, expiry, and — when provided — the audience. Audience
+// binding (RFC 8707) is what stops a token minted for app A being replayed at
+// app B (enforced by the resource server in phase 1e). Returns the decoded
+// payload or throws.
+function verifyAccessToken(token, { audience, secret = getSigningSecret() } = {}) {
+  return jwt.verify(token, secret, {
+    algorithms: ['HS256'],
+    issuer: TOKEN_ISSUER,
+    ...(audience ? { audience } : {}),
+  });
+}
+
+// ── Refresh tokens (opaque, hashed at rest, rotated on use) ────────────
+
+function generateRefreshToken() {
+  return crypto.randomBytes(32).toString('base64url');
+}
+
+// Refresh tokens are stored only as SHA-256 hashes so a datastore leak does not
+// expose usable tokens (design §10). The hash also serves as the document id.
+function hashRefreshToken(token) {
+  return crypto.createHash('sha256').update(token).digest('hex');
+}
+
+// ── Authorization codes (opaque, single-use, short TTL) ────────────────
+
+function generateAuthCode() {
+  return crypto.randomBytes(32).toString('base64url');
+}
+
+module.exports = {
+  signAccessToken,
+  verifyAccessToken,
+  generateRefreshToken,
+  hashRefreshToken,
+  generateAuthCode,
+};

--- a/functions/mcp/sdk.js
+++ b/functions/mcp/sdk.js
@@ -1,0 +1,17 @@
+'use strict';
+
+// The `@modelcontextprotocol/sdk` package is ESM-only, but these Cloud
+// Functions run as CommonJS. Bridge the gap with dynamic import() and cache the
+// resulting module namespace per subpath so the resolution cost is paid once
+// per warm instance. This is the ESM/CJS friction the 1a transport spike exists
+// to de-risk (design §7).
+const cache = new Map();
+
+function loadSdk(subpath) {
+  if (!cache.has(subpath)) {
+    cache.set(subpath, import(`@modelcontextprotocol/sdk/${subpath}`));
+  }
+  return cache.get(subpath);
+}
+
+module.exports = { loadSdk };

--- a/functions/mcp/transport.js
+++ b/functions/mcp/transport.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const { loadSdk } = require('./sdk');
+
+// Runs one MCP request in stateless Streamable HTTP mode: a fresh server +
+// transport per request, no session state retained between requests. This is
+// the correct pattern on serverless — Cloud Functions instances are ephemeral
+// and fan out horizontally, so in-memory session continuity cannot be relied
+// on (design §4, §7). `enableJsonResponse` returns a single JSON body instead
+// of holding open an SSE stream, which suits short request/response tool calls.
+async function handleMcpRequest(req, res, buildServer) {
+  const { StreamableHTTPServerTransport } = await loadSdk('server/streamableHttp.js');
+
+  const server = await buildServer();
+  const transport = new StreamableHTTPServerTransport({
+    sessionIdGenerator: undefined, // stateless: no session tracking
+    enableJsonResponse: true,
+  });
+
+  // Ensure per-request resources are released once the response is done.
+  res.on('close', () => {
+    transport.close();
+    server.close();
+  });
+
+  await server.connect(transport);
+  await transport.handleRequest(req, res, req.body);
+}
+
+module.exports = { handleMcpRequest };

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@google/genai": "^1.0.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "firebase-admin": "^13.0.0",
         "firebase-functions": "^6.0.0",
         "google-auth-library": "^9.0.0"
@@ -359,6 +360,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -464,6 +477,401 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/js-sdsl"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/@opentelemetry/api": {
@@ -764,6 +1172,39 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/ansi-regex": {
@@ -1249,6 +1690,27 @@
         "node": ">=6"
       }
     },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/express": {
       "version": "4.22.1",
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
@@ -1295,6 +1757,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -1315,6 +1795,22 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-builder": {
       "version": "1.1.0",
@@ -1846,6 +2342,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hono": {
+      "version": "4.12.27",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
+      "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/html-entities": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
@@ -1996,6 +2501,15 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -2013,6 +2527,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
@@ -2064,6 +2584,18 @@
       "dependencies": {
         "bignumber.js": "^9.0.0"
       }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/jsonwebtoken": {
       "version": "9.0.3",
@@ -2447,7 +2979,6 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -2548,6 +3079,15 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "license": "MIT"
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
     },
     "node_modules/proto3-json-serializer": {
       "version": "2.0.2",
@@ -2663,6 +3203,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/retry": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
@@ -2700,6 +3249,55 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/router/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/router/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/router/node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/safe-buffer": {
@@ -2825,14 +3423,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -2844,13 +3442,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3291,8 +3889,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/ws": {
       "version": "8.20.0",
@@ -3371,6 +3968,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -12,7 +12,8 @@
         "@modelcontextprotocol/sdk": "^1.29.0",
         "firebase-admin": "^13.0.0",
         "firebase-functions": "^6.0.0",
-        "google-auth-library": "^9.0.0"
+        "google-auth-library": "^9.0.0",
+        "jsonwebtoken": "^9.0.3"
       },
       "engines": {
         "node": "22"

--- a/functions/package.json
+++ b/functions/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@google/genai": "^1.0.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "firebase-admin": "^13.0.0",
     "firebase-functions": "^6.0.0",
     "google-auth-library": "^9.0.0"

--- a/functions/package.json
+++ b/functions/package.json
@@ -12,6 +12,7 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "firebase-admin": "^13.0.0",
     "firebase-functions": "^6.0.0",
-    "google-auth-library": "^9.0.0"
+    "google-auth-library": "^9.0.0",
+    "jsonwebtoken": "^9.0.3"
   }
 }

--- a/planning/initiative-1-mcp-foundation.md
+++ b/planning/initiative-1-mcp-foundation.md
@@ -27,7 +27,7 @@ The Loom as it exists today is left untouched. Initiatives 2 and 3 are separate 
 MCP can be integrated in two directions. **This initiative builds only one of them, end to end.**
 
 - **Inbound (this initiative):** Olympus _is_ an MCP server. A human talks to _their own_ Claude client — including the **iOS Claude app** — and Claude reaches into Olympus to read and write via MCP tools and resources. The thinking happens in the user's Claude; **Olympus runs no LLM in this path and incurs no model cost.**
-- **Outbound (explicitly out of scope):** Olympus calling the Anthropic API with tools to drive its own features. That is Initiative 3's concern (swapping Gemini for Claude in the game loop) and is deliberately deferred. The tool definitions built here are designed so an outbound consumer _could_ reuse them later, but no outbound code is written now.
+- **Outbound (out of scope for the whole program):** Olympus calling a hosted LLM API to drive its own features. There is no current use case, so no outbound code is written anywhere in this three-initiative program. **All three initiatives are inbound-only** — Initiative 3 is Claude-as-narrator inside the Claude app, with Olympus as host and game engine (see §13), not Olympus calling out. If an internal LLM need ever arises, it would use **Gemini** (already proven in Olympus), never an outbound Anthropic call.
 
 **Consequence:** because iOS is a required target from day one, and the iOS/claude.ai custom-connector path only speaks **OAuth 2.1**, the OAuth authorization server is core to Initiative 1 — not a later "walk" step. There is no personal-access-token product path; a static bearer token exists only as a local dev/testing shim for MCP Inspector.
 
@@ -45,7 +45,7 @@ MCP can be integrated in two directions. **This initiative builds only one of th
 
 **Non-Goals (for now)**
 
-- Any outbound Anthropic API usage (Initiative 3).
+- Any outbound LLM API usage (not in this program; a future internal LLM need would use Gemini).
 - Any LLM running inside an Olympus app (the whole point is the external client).
 - Cartographer / Loom domain tools (later initiatives; only their _pattern_ is proven here).
 - MCP resources/prompts beyond the minimum needed to prove the model (rich resource catalogs come with real apps).
@@ -254,11 +254,11 @@ If that holds, the seam is proven and Cartographer (Initiative 2) and the game s
 
 ### Still open
 
-- **Intra-app scopes (read vs. write):** seam now, design later — do any Initiative 2/3 needs pull this forward?
+- **Intra-app scopes (read vs. write):** one scope per app for the MVP (connector = app); a `requiredScope` field per tool is a purely additive change behind the §8 seam. Recommendation is to defer. The likely early pull is **Cartographer** (Initiative 2): read canon freely, gate canon writes behind explicit consent. Decide when we design Cartographer, not now.
 
 ---
 
 ## 13. Handoff to Later Initiatives
 
 - **Initiative 2 (Cartographer):** a new app module registered through §8, mounted at `/mcp/cartographer`; its tools author canon. No new plumbing.
-- **Initiative 3 (game system):** reuses the _same tool definitions_ as an **outbound** consumer — a Cloud Function calling the Anthropic API with those tools — to run the game loop with Claude instead of Gemini. Initiative 1's registry is written so a tool module can be consumed either inbound (here) or outbound (there).
+- **Initiative 3 (game system):** also **inbound**. Claude, inside the user's Claude app, is the **narrator and intent layer**; Olympus is the **host and game engine** — rules, server dice, authoritative world/character state, and canon — exposed through the Initiative 1 MCP layer as tools (submit action, query state), MCP prompts (start/continue an adventure), and resources (current scene, character sheet). Olympus adjudicates and disposes; Claude narrates the fixed result. This carries the Loom's "the model proposes, the server disposes" pipeline into MCP without Olympus running any LLM. No new plumbing beyond richer tools/prompts/resources registered through §8.

--- a/planning/initiative-1-mcp-foundation.md
+++ b/planning/initiative-1-mcp-foundation.md
@@ -227,7 +227,8 @@ Crawl → walk → run _inside_ the initiative. Explicit exit criteria.
 | **1f — POC app**                     | Scriptorium claim, collection, 4 tools + 1 resource                                                 | Tools CRUD `scriptorium_notes` under the caller's identity                                             |
 | **1g — iOS acceptance**              | Add the Scriptorium connector on the **iOS Claude app** by URL                                      | **From iOS: authorize with Olympus login, then create/read/update/delete Scriptorium data via Claude** |
 | **1h — Hardening**                   | Revocation, rate limiting, audit log, cold-start/latency stance, error semantics                    | Revoked token denied; abusive calls throttled; events audited                                          |
-| **1i — Second connector (stretch)**  | One Symposium read tool as a second app module                                                      | Two connectors coexist on the client, each sees only its own tools; cross-app token replay fails       |
+| **1i — Grand Hall connections**      | "Manage connections" view in the Grand Hall profile: list authorized connectors, revoke each        | A user sees their active connectors and can revoke one; the revoked token is denied on next call       |
+| **1j — Second connector (stretch)**  | One Symposium read tool as a second app module                                                      | Two connectors coexist on the client, each sees only its own tools; cross-app token replay fails       |
 
 **Initiative exit criterion (the whole point):**
 
@@ -247,13 +248,13 @@ If that holds, the seam is proven and Cartographer (Initiative 2) and the game s
 - **Per-app connectors** — one shared AS + one host framework + N per-app resource servers; each app is a separate connector with an audience-bound token. This is the isolation model, replacing a single mega-connector with intra-connector scopes.
 - **Throwaway POC app ("Scriptorium")** — no LLM, no real domain; exists solely to prove the plumbing.
 - **Clean origin via Hosting rewrites** — `/mcp/**` and `/.well-known/**` on the primary origin.
+- **Access-token signing** — symmetric Functions secret for MVP; asymmetric/KMS is a later hardening option, not now.
+- **Consent management** — per-connect consent **plus** a "manage connections" list in the Grand Hall profile where a user can review and revoke authorized connectors (phase 1i).
+- **Cold-start latency** — accepted; no min-instances spend on `mcpServer` for the MVP. Revisit only if measured latency breaks client timeouts.
 
 ### Still open
 
-- **Access-token signing:** symmetric Functions secret (MVP) vs. asymmetric/KMS — defaulting to symmetric, revisit in hardening.
-- **Consent granularity:** per-connect consent only, or a manageable connections list in the Grand Hall profile?
 - **Intra-app scopes (read vs. write):** seam now, design later — do any Initiative 2/3 needs pull this forward?
-- **Cold-start latency:** accept it vs. min instances on `mcpServer` — decide in 1h against measured numbers.
 
 ---
 

--- a/planning/initiative-1-mcp-foundation.md
+++ b/planning/initiative-1-mcp-foundation.md
@@ -1,0 +1,263 @@
+# Initiative 1 — MCP Foundation
+
+**Status:** Draft for review
+**Project:** Olympus (`olympus-dfa00`)
+**Program:** Crawl / Walk / Run — three initiatives that build on each other
+**This initiative:** Crawl — prove inbound MCP works end to end, as a reusable per-app substrate
+**Related:** The Loom (frozen as-is), The Cartographer (Initiative 2), Loom-as-game-system (Initiative 3)
+
+---
+
+## 1. Program Context
+
+This is the first of three initiatives that bring Claude and Olympus together incrementally:
+
+| #     | Initiative                    | Role                                                                                                                                    |
+| ----- | ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| **1** | **MCP Foundation** (this doc) | Make MCP a first-class, reusable capability of the Olympus platform, proven by a throwaway POC app. Core plumbing for everything after. |
+| 2     | The Cartographer              | A world/lore-building app that uses the Initiative 1 MCP layer so Claude can help author canon.                                         |
+| 3     | Game system                   | Brings it together, meeting the Loom's goals — using MCP + Claude (external) for AI flavor instead of Gemini.                           |
+
+The Loom as it exists today is left untouched. Initiatives 2 and 3 are separate planning docs/milestones; this doc is scoped strictly to Initiative 1.
+
+---
+
+## 2. The One Direction: Inbound Only
+
+MCP can be integrated in two directions. **This initiative builds only one of them, end to end.**
+
+- **Inbound (this initiative):** Olympus _is_ an MCP server. A human talks to _their own_ Claude client — including the **iOS Claude app** — and Claude reaches into Olympus to read and write via MCP tools and resources. The thinking happens in the user's Claude; **Olympus runs no LLM in this path and incurs no model cost.**
+- **Outbound (explicitly out of scope):** Olympus calling the Anthropic API with tools to drive its own features. That is Initiative 3's concern (swapping Gemini for Claude in the game loop) and is deliberately deferred. The tool definitions built here are designed so an outbound consumer _could_ reuse them later, but no outbound code is written now.
+
+**Consequence:** because iOS is a required target from day one, and the iOS/claude.ai custom-connector path only speaks **OAuth 2.1**, the OAuth authorization server is core to Initiative 1 — not a later "walk" step. There is no personal-access-token product path; a static bearer token exists only as a local dev/testing shim for MCP Inspector.
+
+---
+
+## 3. Goals and Non-Goals
+
+**Goals**
+
+- A reusable MCP capability any Olympus app can plug into by registering tools/resources — mirroring how apps already register in `apps.yaml` and own a `hasApp()` claim.
+- **Per-app connectors:** each app (POC, later Symposium, Loom, Cartographer) is a _separate connector_ the user sets up on the client, with its own URL, its own audience-bound token, and its own tool list.
+- Full inbound OAuth 2.1 handshake with **Dynamic Client Registration**, so a connector can be added on iOS by pasting a URL.
+- A throwaway POC app that proves create/read/update/delete from an external Claude client with real Olympus auth.
+- Identity and authorization that reuse the existing Firebase Auth + custom-claims model exactly.
+
+**Non-Goals (for now)**
+
+- Any outbound Anthropic API usage (Initiative 3).
+- Any LLM running inside an Olympus app (the whole point is the external client).
+- Cartographer / Loom domain tools (later initiatives; only their _pattern_ is proven here).
+- MCP resources/prompts beyond the minimum needed to prove the model (rich resource catalogs come with real apps).
+- Fine-grained intra-app scopes (read vs. write). The connector boundary = app boundary for the MVP; intra-app scopes stay behind a seam.
+
+---
+
+## 4. Design Principles
+
+Inherits Olympus conventions, adds MCP-specific ones:
+
+- **The connector boundary is the app boundary.** One app = one MCP resource server = one connector. Isolation is enforced at three layers: separate connector URL, audience-bound token, and `hasApp(appId)` claim check.
+- **Build shared plumbing once, mount per app.** One OAuth AS, one host framework; apps contribute only a tool module. No app re-implements auth or transport.
+- **Reuse the existing identity model.** Login is Firebase Auth. Authorization is the existing custom claims. The MCP server never invents a parallel user system.
+- **Stateless on serverless.** MCP Streamable HTTP runs in stateless mode; access tokens are self-validating (signed JWT) so no per-request datastore read on the hot path.
+- **Tokens can't cross apps.** Resource indicators (RFC 8707) bind every token to exactly one app's audience.
+- **The server disposes.** Mutating tools validate exactly like the app's own writes would; the external model proposes, Olympus validates and commits.
+- **Design doc first, MVP discipline, explicit phase exit criteria.**
+
+---
+
+## 5. Architecture
+
+### 5.1 Topology
+
+```
+                       ┌─────────────────────────────────────────┐
+   iOS / desktop /     │            Olympus (olympus-dfa00)        │
+   claude.ai Claude    │                                           │
+        │              │   Shared OAuth 2.1 Authorization Server   │
+        │  OAuth 2.1   │   - /.well-known/oauth-authorization-server
+        ├─────────────▶│   - /authorize  (consent, Firebase login) │
+        │  (DCR, PKCE) │   - /token, /register, /revoke            │
+        │              │              │ issues audience-bound tokens│
+        │              │              ▼                             │
+        │  MCP over     │   Per-app MCP resource servers (mounted): │
+        │  Streamable   │   /mcp/scriptorium   (aud: .../scriptorium)
+        ├─────────────▶│   /mcp/symposium     (aud: .../symposium)  ← later
+        │              │   /mcp/loom          (aud: .../loom)       ← later
+        │              │        each: /.well-known/oauth-protected-resource/<path>
+        │              │              │                             │
+        │              │              ▼                             │
+        │              │   Shared MCP host framework                │
+        │              │   (transport · token validation · registry)│
+        │              │              │                             │
+        │              │              ▼                             │
+        │              │   Firestore (per-app collections, claims)  │
+        └──────────────┴─────────────────────────────────────────┘
+```
+
+### 5.2 Clean origin via Hosting rewrites
+
+`/mcp/**` and `/.well-known/**` are served on the **primary Olympus origin** via Firebase Hosting rewrites to the MCP Cloud Function:
+
+```json
+// firebase.json (sketch)
+"rewrites": [
+  { "source": "/mcp/**", "function": "mcpServer" },
+  { "source": "/.well-known/oauth-authorization-server", "function": "mcpServer" },
+  { "source": "/.well-known/oauth-protected-resource/**", "function": "mcpServer" }
+]
+```
+
+This gives stable, pretty connector URLs (`https://olympus-dfa00.web.app/mcp/scriptorium`) and keeps OAuth resource-metadata origins matching the MCP endpoint origins, which the spec requires.
+
+### 5.3 Per-app resource servers
+
+Each app is a distinct **OAuth resource** identified by its endpoint URL:
+
+- Discovery: `/.well-known/oauth-protected-resource/mcp/<appId>` (RFC 9728, path-based) describes that resource and points to the single shared AS.
+- Audience: tokens for that connector carry `aud = https://.../mcp/<appId>` (RFC 8707 resource indicators). The resource server rejects any other audience.
+- Access: every tool in the app checks `hasApp(appId)` against the token's mapped claims.
+
+Adding a new app later is: implement a tool module, register it under an `appId`, and it auto-mounts at `/mcp/<appId>` with its own discovery doc and audience. No OAuth or transport work repeated.
+
+---
+
+## 6. OAuth 2.1 Flow
+
+The AS is a small authorization server implemented in Cloud Functions. Firebase Auth performs the human login; the AS mints Olympus-issued tokens.
+
+**Handshake (add-by-URL on iOS):**
+
+1. Client fetches `/.well-known/oauth-protected-resource/mcp/<appId>` → learns the AS.
+2. Client fetches `/.well-known/oauth-authorization-server` → learns endpoints, PKCE support (S256 required), registration endpoint.
+3. **Dynamic Client Registration** (RFC 7591) at `/register` → client gets a `client_id` (public client, PKCE).
+4. `/authorize` renders consent; the user signs in with **Firebase Auth** (same login as the web apps). Consent names the app being connected.
+5. Authorization code (PKCE) → `/token` → **access token (short-lived, signed JWT, audience-bound) + refresh token (rotated, hashed at rest)**.
+6. Client calls `/mcp/<appId>` with the bearer token; the resource server validates signature + `aud` locally, maps `sub` → uid → claims, exposes only that app's tools gated by `hasApp(appId)`.
+
+**Token strategy**
+
+- **Access token:** signed JWT (`sub=uid`, `aud=<app resource>`, `exp` short, minimal claims snapshot). Self-validating → no datastore read on the hot path (matters on serverless).
+- **Refresh token:** opaque, stored hashed in Firestore, rotated on use, revocable.
+- **Signing key:** Functions secret for MVP (symmetric); asymmetric/KMS noted as a hardening follow-up.
+
+**Scopes ↔ claims:** MVP uses one scope per app (`mcp:<appId>`) that maps to the `hasApp(appId)` requirement. Intra-app read/write scopes stay behind a seam for later.
+
+---
+
+## 7. Olympus Integration
+
+| Concern   | Implementation                                                                                                                   |
+| --------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| Endpoints | Firebase Hosting rewrites → `mcpServer` Cloud Function (v2 `onRequest`, Node 22)                                                 |
+| Transport | MCP Streamable HTTP, **stateless mode**                                                                                          |
+| SDK       | `@modelcontextprotocol/sdk` (ESM) consumed from CommonJS functions via dynamic `import()` — resolved in the foundation spike     |
+| AS        | Same function (or a sibling) hosting `/authorize`, `/token`, `/register`, `/revoke`, discovery docs                              |
+| Identity  | Firebase Auth for login; custom claims (`apps[]`, `admin`) for authorization — unchanged                                         |
+| Rules     | New `mcp_*` and `scriptorium_*` collections default-deny; server writes via Admin SDK act as the mapped user's authority in code |
+| Deploy    | Existing GitHub Actions; new function + rewrites ride the standard merge deploy                                                  |
+
+**New Firestore collections (Initiative 1):**
+
+```
+mcp_oauth_clients     // DCR-registered clients (client_id, redirect_uris, metadata)
+mcp_oauth_codes       // short-lived authorization codes (PKCE), TTL
+mcp_oauth_tokens      // refresh tokens (hashed), rotation + revocation state
+mcp_audit             // tool-call + auth audit log (hardening)
+scriptorium_notes     // the POC app's trivial CRUD data
+```
+
+---
+
+## 8. The Tool Registry Pattern
+
+The reusable seam every app plugs into. An app contributes a module:
+
+```
+registerApp('scriptorium', {
+  resource: 'https://.../mcp/scriptorium',
+  tools: [
+    { name: 'list_notes',   schema, handler(ctx, args) { /* ctx.uid, ctx.claims */ } },
+    { name: 'create_note',  schema, handler(ctx, args) { /* validates, writes */ } },
+    { name: 'update_note',  schema, handler },
+    { name: 'delete_note',  schema, handler },
+  ],
+  resources: [ { uri, name, read(ctx) } ],
+});
+```
+
+The host composes registered apps, mounts each at `/mcp/<appId>`, generates its discovery doc, and injects an authenticated `ctx` (uid + claims) into every handler after validating the audience-bound token and `hasApp(appId)`. Apps never touch OAuth or transport.
+
+---
+
+## 9. The POC App — "Scriptorium"
+
+Deliberately dumb; its only purpose is to exercise the plumbing.
+
+- **No UI logic, no LLM.** A tiny Firestore-backed notes/facts list (`scriptorium_notes`), owner-scoped.
+- **Tools:** `list_notes`, `create_note`, `update_note`, `delete_note` (+ one read-only `resource`).
+- **Claim:** a `scriptorium` app claim, granted via The Pantheon like any other app.
+- **Why separate from Symposium:** isolates MCP plumbing from real-app complexity for the crawl. Symposium becomes the _second connector_ that proves reuse and per-app isolation (stretch).
+
+---
+
+## 10. Security Model
+
+- **Three-layer app isolation:** separate connector URL · audience-bound token (RFC 8707) · `hasApp(appId)` check.
+- **PKCE S256 mandatory**, public clients only, exact redirect-URI matching per DCR registration.
+- **Short-lived access tokens**, rotating refresh tokens, revocation endpoint + `mcp_oauth_tokens` state.
+- **Least privilege in tools:** every handler authorizes against the mapped claims and validates inputs before any write; no raw passthrough to Firestore.
+- **Audit log** of auth events and tool calls (`mcp_audit`).
+- **Default-deny Firestore rules** for all new collections; the server writes via Admin SDK only after in-code authorization.
+
+---
+
+## 11. Roadmap (within Initiative 1)
+
+Crawl → walk → run _inside_ the initiative. Explicit exit criteria.
+
+| Phase                                | Scope                                                                                               | Exit criterion                                                                                         |
+| ------------------------------------ | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| **1a — Transport spike**             | `mcpServer` function, Streamable HTTP stateless, ESM/CJS resolved, one `ping` tool, dev bearer shim | MCP Inspector lists and calls `ping` locally                                                           |
+| **1b — Origin & discovery**          | Hosting rewrites; RFC 9728 (path-based) + RFC 8414 metadata                                         | Discovery docs resolve on the primary origin                                                           |
+| **1c — OAuth AS core**               | `/authorize` + consent via Firebase Auth, `/token`, PKCE, JWT access + refresh                      | Auth-code + PKCE flow yields a working token by hand                                                   |
+| **1d — DCR**                         | `/register` (RFC 7591)                                                                              | A client self-registers and completes the flow with no pre-config                                      |
+| **1e — Resource binding + registry** | Per-app mount, audience validation (RFC 8707), `ctx` injection, `hasApp` gate                       | A token for app A is rejected by app B's endpoint                                                      |
+| **1f — POC app**                     | Scriptorium claim, collection, 4 tools + 1 resource                                                 | Tools CRUD `scriptorium_notes` under the caller's identity                                             |
+| **1g — iOS acceptance**              | Add the Scriptorium connector on the **iOS Claude app** by URL                                      | **From iOS: authorize with Olympus login, then create/read/update/delete Scriptorium data via Claude** |
+| **1h — Hardening**                   | Revocation, rate limiting, audit log, cold-start/latency stance, error semantics                    | Revoked token denied; abusive calls throttled; events audited                                          |
+| **1i — Second connector (stretch)**  | One Symposium read tool as a second app module                                                      | Two connectors coexist on the client, each sees only its own tools; cross-app token replay fails       |
+
+**Initiative exit criterion (the whole point):**
+
+> From the **iOS Claude app**, add Olympus as a connector by URL, authorize with your Olympus login, and have Claude **read and write the POC app's data** — with a second app's connector proving clean per-app division.
+
+If that holds, the seam is proven and Cartographer (Initiative 2) and the game system (Initiative 3) inherit it.
+
+---
+
+## 12. Open Questions & Decisions
+
+### Decided (2026-07-03)
+
+- **Inbound only, end to end** — no outbound Anthropic API in this initiative.
+- **iOS is a day-one target** — therefore OAuth 2.1 is core, not deferred; personal-access tokens are a dev shim only.
+- **DCR is in scope** — required for frictionless add-by-URL on mobile.
+- **Per-app connectors** — one shared AS + one host framework + N per-app resource servers; each app is a separate connector with an audience-bound token. This is the isolation model, replacing a single mega-connector with intra-connector scopes.
+- **Throwaway POC app ("Scriptorium")** — no LLM, no real domain; exists solely to prove the plumbing.
+- **Clean origin via Hosting rewrites** — `/mcp/**` and `/.well-known/**` on the primary origin.
+
+### Still open
+
+- **Access-token signing:** symmetric Functions secret (MVP) vs. asymmetric/KMS — defaulting to symmetric, revisit in hardening.
+- **Consent granularity:** per-connect consent only, or a manageable connections list in the Grand Hall profile?
+- **Intra-app scopes (read vs. write):** seam now, design later — do any Initiative 2/3 needs pull this forward?
+- **Cold-start latency:** accept it vs. min instances on `mcpServer` — decide in 1h against measured numbers.
+
+---
+
+## 13. Handoff to Later Initiatives
+
+- **Initiative 2 (Cartographer):** a new app module registered through §8, mounted at `/mcp/cartographer`; its tools author canon. No new plumbing.
+- **Initiative 3 (game system):** reuses the _same tool definitions_ as an **outbound** consumer — a Cloud Function calling the Anthropic API with those tools — to run the game loop with Claude instead of Gemini. Initiative 1's registry is written so a tool module can be consumed either inbound (here) or outbound (there).

--- a/tests/mcp-oauth.test.js
+++ b/tests/mcp-oauth.test.js
@@ -26,7 +26,7 @@ const { verifyAccessToken } = require('../functions/mcp/oauth/tokens');
 const { base64UrlSha256 } = require('../functions/mcp/oauth/pkce');
 const { renderConsentPage } = require('../functions/mcp/oauth/consent-page');
 
-const CANONICAL = 'https://olympus-dfa00.web.app';
+const CANONICAL = 'https://bcoletech.com';
 const APP = 'scriptorium';
 const AUD = `${CANONICAL}/mcp/${APP}`;
 const REDIRECT = 'https://claude.ai/api/mcp/auth_callback';

--- a/tests/mcp-oauth.test.js
+++ b/tests/mcp-oauth.test.js
@@ -1,0 +1,347 @@
+'use strict';
+
+/**
+ * Unit tests for the inbound MCP OAuth 2.1 authorization server
+ * (functions/mcp/oauth). Drives the /authorize and /token handlers with the
+ * in-memory store — no Firestore emulator required.
+ *
+ * Covers the phase-1c flow and the hardening from the PR #358 security review:
+ * XSS-safe consent rendering, required audience, Host-header pinning,
+ * refresh-token family revocation on reuse, and entitlement re-check on refresh.
+ *
+ * Run: cd tests && npx jest mcp-oauth --verbose
+ */
+
+// Signing secret must be resolvable before requiring the token modules.
+process.env.MCP_JWT_SECRET = 'test-signing-secret-mcp-oauth';
+// Ensure prod "pinned origin" mode (Host header ignored), not emulator mode.
+delete process.env.FUNCTIONS_EMULATOR;
+delete process.env.OLYMPUS_ORIGIN;
+
+const crypto = require('crypto');
+const { createInMemoryStore } = require('../functions/mcp/oauth/store');
+const { createAuthorizeHandler } = require('../functions/mcp/oauth/authorize');
+const { createTokenHandler } = require('../functions/mcp/oauth/token');
+const { verifyAccessToken } = require('../functions/mcp/oauth/tokens');
+const { base64UrlSha256 } = require('../functions/mcp/oauth/pkce');
+const { renderConsentPage } = require('../functions/mcp/oauth/consent-page');
+
+const CANONICAL = 'https://olympus-dfa00.web.app';
+const APP = 'scriptorium';
+const AUD = `${CANONICAL}/mcp/${APP}`;
+const REDIRECT = 'https://claude.ai/api/mcp/auth_callback';
+
+const codeVerifier = crypto.randomBytes(40).toString('base64url');
+const codeChallenge = base64UrlSha256(codeVerifier);
+
+function mockRes() {
+  const r = { statusCode: 200, headers: {}, body: undefined, html: undefined };
+  r.set = (k, v) => ((r.headers[k.toLowerCase()] = v), r);
+  r.status = (c) => ((r.statusCode = c), r);
+  r.json = (o) => ((r.body = o), r);
+  r.send = (s) => ((r.html = s), r);
+  r.redirect = (code, url) => ((r.statusCode = code), (r.redirectedTo = url), r);
+  r.get = (k) => r.headers[k.toLowerCase()];
+  return r;
+}
+
+const baseParams = () => ({
+  response_type: 'code',
+  client_id: 'client-123',
+  redirect_uri: REDIRECT,
+  scope: 'mcp:scriptorium',
+  state: 'xyz-state',
+  code_challenge: codeChallenge,
+  code_challenge_method: 'S256',
+});
+
+const HEADERS = { host: 'olympus-dfa00.web.app', 'x-forwarded-proto': 'https' };
+
+function setup() {
+  const store = createInMemoryStore();
+  store.putClient({ clientId: 'client-123', clientName: 'Claude', redirectUris: [REDIRECT] });
+
+  // Mutable entitlements so the refresh re-check can be exercised.
+  const entitlements = new Map([['uid-abc', ['scriptorium', 'symposium']]]);
+
+  const verifyIdToken = async (idToken) => {
+    if (idToken === 'user-with-app') return { uid: 'uid-abc', apps: entitlements.get('uid-abc') };
+    if (idToken === 'user-without-app') return { uid: 'uid-none', apps: ['symposium'] };
+    throw new Error('invalid token');
+  };
+  const getEntitlements = async (uid) => entitlements.get(uid) || [];
+
+  let clock = Date.now();
+  const now = () => clock;
+
+  const authorize = createAuthorizeHandler({ store, verifyIdToken, now });
+  const token = createTokenHandler({ store, getEntitlements, now });
+
+  return {
+    store,
+    entitlements,
+    authorize,
+    token,
+    advance: (ms) => (clock += ms),
+  };
+}
+
+async function approve(authorize, overrides = {}, headers = HEADERS) {
+  const res = mockRes();
+  await authorize(
+    { method: 'POST', headers, body: { ...baseParams(), idToken: 'user-with-app', ...overrides } },
+    res
+  );
+  return res;
+}
+
+async function getCode(authorize, headers = HEADERS) {
+  const res = await approve(authorize, {}, headers);
+  return new URL(res.body.redirect).searchParams.get('code');
+}
+
+async function exchange(token, code, overrides = {}) {
+  const res = mockRes();
+  await token(
+    {
+      method: 'POST',
+      headers: HEADERS,
+      body: {
+        grant_type: 'authorization_code',
+        code,
+        redirect_uri: REDIRECT,
+        client_id: 'client-123',
+        code_verifier: codeVerifier,
+        ...overrides,
+      },
+    },
+    res
+  );
+  return res;
+}
+
+async function refresh(token, refreshToken) {
+  const res = mockRes();
+  await token(
+    {
+      method: 'POST',
+      headers: HEADERS,
+      body: { grant_type: 'refresh_token', refresh_token: refreshToken, client_id: 'client-123' },
+    },
+    res
+  );
+  return res;
+}
+
+describe('authorize consent', () => {
+  test('renders consent naming the app, without leaking a code', async () => {
+    const { authorize } = setup();
+    const res = mockRes();
+    await authorize({ method: 'GET', headers: HEADERS, query: baseParams() }, res);
+    expect(res.statusCode).toBe(200);
+    expect(res.html).toMatch(/Scriptorium/);
+    expect(res.html).not.toMatch(/code=/);
+  });
+
+  test('sets anti-clickjacking headers', async () => {
+    const { authorize } = setup();
+    const res = mockRes();
+    await authorize({ method: 'GET', headers: HEADERS, query: baseParams() }, res);
+    expect(res.get('X-Frame-Options')).toBe('DENY');
+    expect(res.get('Content-Security-Policy')).toMatch(/frame-ancestors 'none'/);
+  });
+
+  test('unknown client → 400 page, no redirect', async () => {
+    const { authorize } = setup();
+    const res = mockRes();
+    await authorize(
+      { method: 'GET', headers: HEADERS, query: { ...baseParams(), client_id: 'nope' } },
+      res
+    );
+    expect(res.statusCode).toBe(400);
+    expect(res.redirectedTo).toBeUndefined();
+  });
+
+  test('plain PKCE → redirect invalid_request', async () => {
+    const { authorize } = setup();
+    const res = mockRes();
+    await authorize(
+      {
+        method: 'GET',
+        headers: HEADERS,
+        query: { ...baseParams(), code_challenge_method: 'plain' },
+      },
+      res
+    );
+    expect(res.statusCode).toBe(302);
+    expect(res.redirectedTo).toMatch(/error=invalid_request/);
+  });
+
+  test('POST without app entitlement → 403 access_denied', async () => {
+    const { authorize } = setup();
+    const res = await approve(authorize, { idToken: 'user-without-app' });
+    expect(res.statusCode).toBe(403);
+    expect(res.body.error).toBe('access_denied');
+  });
+
+  test('POST with bad idToken → 401', async () => {
+    const { authorize } = setup();
+    const res = await approve(authorize, { idToken: 'bad' });
+    expect(res.statusCode).toBe(401);
+  });
+
+  test('POST redirect_uri mismatch → invalid_request', async () => {
+    const { authorize } = setup();
+    const res = await approve(authorize, { redirect_uri: 'https://evil.example/cb' });
+    expect(res.body.error).toBe('invalid_request');
+  });
+
+  test('approve returns a redirect with code and preserved state', async () => {
+    const { authorize } = setup();
+    const res = await approve(authorize);
+    const url = new URL(res.body.redirect);
+    expect(url.searchParams.get('code')).toBeTruthy();
+    expect(url.searchParams.get('state')).toBe('xyz-state');
+  });
+});
+
+describe('consent page is XSS-safe', () => {
+  test('malicious state/resource cannot break out of the params block', () => {
+    const malicious = "');alert(document.domain)//";
+    const html = renderConsentPage({
+      appId: APP,
+      appName: 'Scriptorium',
+      clientName: 'Claude',
+      oauthParams: { redirect_uri: REDIRECT, state: malicious, resource: '</script><img>' },
+    });
+    // Params are embedded in a JSON script block, not an executable JS literal.
+    expect(html).toMatch(/<script type="application\/json" id="oauth-params">/);
+    const block = html.match(
+      /<script type="application\/json" id="oauth-params">([\s\S]*?)<\/script>/
+    )[1];
+    // The only breakout risk in a <script type="application/json"> block is the
+    // literal markup chars that could close the element or start a new one — all
+    // '<'/'>' are escaped, so no raw angle brackets survive (quotes are harmless
+    // data in this context, not a breakout vector).
+    expect(block).not.toContain('<');
+    expect(block).not.toContain('>');
+    // And the data still round-trips intact (< etc. are valid JSON escapes).
+    const parsed = JSON.parse(block);
+    expect(parsed.state).toBe(malicious);
+    expect(parsed.resource).toBe('</script><img>');
+  });
+});
+
+describe('token — authorization_code grant', () => {
+  test('wrong PKCE verifier → invalid_grant', async () => {
+    const { authorize, token } = setup();
+    const code = await getCode(authorize);
+    const res = await exchange(token, code, { code_verifier: 'wrong' });
+    expect(res.body.error).toBe('invalid_grant');
+  });
+
+  test('single-use: replay of consumed code → invalid_grant', async () => {
+    const { authorize, token } = setup();
+    const code = await getCode(authorize);
+    await exchange(token, code); // first use
+    const res = await exchange(token, code); // replay
+    expect(res.body.error).toBe('invalid_grant');
+  });
+
+  test('expired code → invalid_grant', async () => {
+    const { authorize, token, advance } = setup();
+    const code = await getCode(authorize);
+    advance(10 * 60 * 1000);
+    const res = await exchange(token, code);
+    expect(res.body.error).toBe('invalid_grant');
+  });
+
+  test('valid exchange returns access + refresh with canonical audience', async () => {
+    const { authorize, token } = setup();
+    const res = await exchange(token, await getCode(authorize));
+    expect(res.body.token_type).toBe('Bearer');
+    expect(res.body.access_token).toBeTruthy();
+    expect(res.body.refresh_token).toBeTruthy();
+    expect(res.get('Cache-Control')).toBe('no-store');
+    const payload = verifyAccessToken(res.body.access_token, { audience: AUD });
+    expect(payload.sub).toBe('uid-abc');
+    expect([].concat(payload.aud)[0]).toBe(AUD);
+    expect(payload.scope).toBe('mcp:scriptorium');
+  });
+});
+
+describe('audience binding (RFC 8707)', () => {
+  test('token is rejected for a different app audience', async () => {
+    const { authorize, token } = setup();
+    const res = await exchange(token, await getCode(authorize));
+    expect(() =>
+      verifyAccessToken(res.body.access_token, { audience: `${CANONICAL}/mcp/symposium` })
+    ).toThrow();
+  });
+
+  test('verifyAccessToken throws when audience is omitted', async () => {
+    const { authorize, token } = setup();
+    const res = await exchange(token, await getCode(authorize));
+    expect(() => verifyAccessToken(res.body.access_token)).toThrow(/audience/);
+  });
+});
+
+describe('Host header cannot influence issued audience (#3)', () => {
+  test('attacker Host does not change the token audience', async () => {
+    const { authorize, token } = setup();
+    const code = await getCode(authorize, {
+      host: 'attacker.example',
+      'x-forwarded-proto': 'https',
+    });
+    const res = await exchange(token, code);
+    // Audience stays pinned to the canonical origin, not attacker.example.
+    const payload = verifyAccessToken(res.body.access_token, { audience: AUD });
+    expect([].concat(payload.aud)[0]).toBe(AUD);
+  });
+});
+
+describe('token — refresh_token grant', () => {
+  test('rotates the refresh token', async () => {
+    const { authorize, token } = setup();
+    const first = await exchange(token, await getCode(authorize));
+    const res = await refresh(token, first.body.refresh_token);
+    expect(res.body.access_token).toBeTruthy();
+    expect(res.body.refresh_token).toBeTruthy();
+    expect(res.body.refresh_token).not.toBe(first.body.refresh_token);
+  });
+
+  test('reuse of a rotated token revokes the whole family (#4)', async () => {
+    const { authorize, token } = setup();
+    const first = await exchange(token, await getCode(authorize));
+    const rt1 = first.body.refresh_token;
+    const second = await refresh(token, rt1); // rotate → rt2 (live)
+    const rt2 = second.body.refresh_token;
+
+    const reuse = await refresh(token, rt1); // reuse rt1 → detected
+    expect(reuse.body.error).toBe('invalid_grant');
+
+    // The live successor rt2 must now also be dead.
+    const afterReuse = await refresh(token, rt2);
+    expect(afterReuse.body.error).toBe('invalid_grant');
+  });
+
+  test('re-checks entitlement and rejects after the app claim is revoked (#5)', async () => {
+    const { authorize, token, entitlements } = setup();
+    const first = await exchange(token, await getCode(authorize));
+
+    // Admin removes the app from the user's claims.
+    entitlements.set('uid-abc', ['symposium']);
+
+    const res = await refresh(token, first.body.refresh_token);
+    expect(res.body.error).toBe('invalid_grant');
+  });
+});
+
+describe('token — misc', () => {
+  test('unsupported grant_type rejected', async () => {
+    const { token } = setup();
+    const res = mockRes();
+    await token({ method: 'POST', headers: HEADERS, body: { grant_type: 'password' } }, res);
+    expect(res.body.error).toBe('unsupported_grant_type');
+  });
+});


### PR DESCRIPTION
Implements the first three phases of [Initiative 1 — MCP Foundation](https://github.com/bcolemutech/olympus-web/blob/main/planning/initiative-1-mcp-foundation.md), tracked in #347. Adds a new `mcpServer` Cloud Function that serves the inbound MCP layer and its OAuth 2.1 authorization server on the primary Olympus origin. No LLM runs in Olympus on this path — external Claude clients do the thinking.

Closes #348, #349, #350.

## Phase 1a — Transport spike (#348)
- New `mcpServer` Cloud Function (v2 `onRequest`, Node 22).
- MCP **Streamable HTTP transport, stateless mode** — a fresh server + transport per request, suited to ephemeral, fan-out serverless.
- Resolves the ESM-only `@modelcontextprotocol/sdk` from CommonJS via a cached dynamic `import()` (`functions/mcp/sdk.js`) — the key friction this spike existed to de-risk.
- One hardcoded `ping` diagnostic tool.
- Dev-only bearer shim: reachable under the emulator (open, or gated by `MCP_DEV_TOKEN`); deployed environments deny with an RFC 9728 pointer until OAuth lands.

## Phase 1b — Origin & discovery docs (#349)
- Firebase Hosting rewrites route `/mcp/**` and `/.well-known/**` to `mcpServer`.
- **RFC 8414** authorization-server metadata (advertises `/authorize`, `/token`, `/register`, `/revoke`; mandatory PKCE S256).
- **RFC 9728** path-based protected-resource metadata, served only for known resources so no phantom connector is advertised; origin-matching URLs.

## Phase 1c — OAuth 2.1 AS core (#350)
Firebase Auth performs the human login; the AS mints Olympus-issued, audience-bound tokens.
- `GET /authorize` — consent screen reusing Firebase Auth exactly as the Grand Hall does (compat SDK from `/__/firebase/`). Validates `client_id` + `redirect_uri` before any redirect; enforces PKCE S256 and a single `mcp:<appId>` scope.
- `POST /authorize` — verifies the Firebase ID token, checks `hasApp(appId)` entitlement, issues a single-use, PKCE-bound authorization code.
- `POST /token` — `authorization_code` grant (single-use code + PKCE verify) and `refresh_token` grant (atomic rotation with reuse detection). RFC 6749 error responses.

**Token strategy:** access token is a self-validating HS256 JWT (`sub`=uid, `aud`=app resource, `scope`, short exp) — no datastore read on the hot path; audience binding (RFC 8707) blocks cross-app replay. Refresh tokens are opaque, SHA-256 hashed at rest, rotated on use. Auth codes are opaque, single-use, 5-minute TTL.

## Architecture notes
- **Per-app isolation** is three-layered: separate connector URL, audience-bound token, and `hasApp(appId)` check. Adding an app later is a tool module + registration — no OAuth/transport work repeated (registry seam lands in 1e).
- OAuth persistence is behind a **store interface** (Firestore in prod, in-memory in tests). New collections `mcp_oauth_clients` / `mcp_oauth_codes` / `mcp_oauth_tokens` are server-only (Admin SDK) and already covered by the existing default-deny Firestore rules — no rules change needed.
- Adds `@modelcontextprotocol/sdk` and `jsonwebtoken`; declares `Buffer`/`URL` globals for the functions ESLint zone.

## Verification
Driven locally against the real MCP SDK client (Inspector-equivalent) and the OAuth handlers:
- **Transport/discovery:** `initialize` + `tools/list` + `tools/call ping`; both discovery docs resolve with origin-matching URLs; deployed-env deny; CORS preflight.
- **OAuth (27 checks):** consent render, entitlement gate, approve→code, code→access+refresh, refresh rotation, and rejection of reused codes, reused refresh tokens, wrong PKCE verifier, wrong audience, expired codes, and unsupported grants.

## Reviewer notes / action items
1. **`MCP_JWT_SECRET` must be created before this deploys to production** — the function binds it via `secrets`, so `firebase deploy --only functions` will fail until you run `firebase functions:secrets:set MCP_JWT_SECRET`. The emulator uses a dev-only fallback.
2. **Interactive consent + Firebase login was not driven end-to-end here** (needs the hosting emulator for `/__/firebase/` + a real user) — it's a manual gate like the iOS acceptance test. The security-critical token machinery is fully covered by automated checks.
3. This is **hand-rolled auth** — `authorize.js` / `token.js` warrant a focused security review before fronting real data. `/register` (DCR, 1d) and `/revoke` (1h) are advertised in metadata but not yet implemented; DCR is the next phase and also unlocks end-to-end interactive testing of 1c.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K4EwUoqrBo2NLZs5w7iXy2

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4EwUoqrBo2NLZs5w7iXy2)_